### PR TITLE
Add placeOfPublication.folded to SEARCH_SCOPES

### DIFF
--- a/lib/elasticsearch/config.js
+++ b/lib/elasticsearch/config.js
@@ -29,7 +29,7 @@ const SEARCH_SCOPES = {
       'parallelUniformTitle',
       'formerTitle',
       'addedAuthorTitle',
-      'placeOfPublication',
+      'placeOfPublication.folded',
       { field: 'items.idBarcode', on: (q) => /\d{6,}/.test(q) },
       // Try to detect shelfmark searches (e.g. JFD 16-5143)
       { field: 'items.shelfMark', on: (q) => /^[A-Z]{1,3} \d{2,}/.test(q) }

--- a/test/fixtures/query-0eb0fa8da3e80f2e721d5af2bf174965.json
+++ b/test/fixtures/query-0eb0fa8da3e80f2e721d5af2bf174965.json
@@ -1,0 +1,18 @@
+{
+  "took": 18,
+  "timed_out": false,
+  "_shards": {
+    "total": 2,
+    "successful": 2,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 0,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": []
+  }
+}

--- a/test/fixtures/query-2bbb714026908228cee2e387f9d601ea.json
+++ b/test/fixtures/query-2bbb714026908228cee2e387f9d601ea.json
@@ -1,0 +1,17005 @@
+{
+  "took": 70,
+  "timed_out": false,
+  "_shards": {
+    "total": 2,
+    "successful": 2,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 98,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b11294632",
+        "_score": 473.47043,
+        "_source": {
+          "extent": [
+            "xxi, 273 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Originally published ... by Charles Scribner's Sons ... in 1940\"--T.p. verso.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Vintage Books"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1990
+          ],
+          "dateEndString": [
+            "1940"
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "Angels on toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 90-6303"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1990"
+          ],
+          "creatorLiteral": [
+            "Powell, Dawn"
+          ],
+          "idLccn": [
+            "89040281"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1990
+          ],
+          "idOclc": [
+            "70304237",
+            "NYPG90-B53168"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 90-6303"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11294632"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0679726861"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "70304237"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG90-B53168"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "89040281"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1302350"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)70304237"
+            }
+          ],
+          "dateEndYear": [
+            1940
+          ],
+          "updatedAt": 1711585322970,
+          "publicationStatement": [
+            "New York : Vintage Books, 1990, c1940."
+          ],
+          "idIsbn": [
+            "0679726861"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 90-6303",
+            "urn:bnum:11294632",
+            "urn:isbn:0679726861",
+            "urn:oclc:70304237",
+            "urn:oclc:NYPG90-B53168",
+            "urn:lccn:89040281",
+            "urn:identifier:(WaOLN)nyp1302350",
+            "urn:identifier:(OCoLC)70304237"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1990"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Angels on toast / Dawn Powell ; with an introduction by Gore Vidal."
+          ],
+          "uri": "b11294632",
+          "lccClassification": [
+            "PS3531.O936 A83 1989"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "0679726861"
+          ]
+        },
+        "sort": [
+          473.47043,
+          "b11294632"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b11294632",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 90-6303",
+                      "urn:barcode:33433040606604"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "JFD 90-6303"
+                    ],
+                    "shelfMark_sort": "aJFD 90-006303",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFD 90-6303"
+                    ],
+                    "uri": "i13160245",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFD 90-6303"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433040606604"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433040606604"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b10981311",
+        "_score": 472.47043,
+        "_source": {
+          "extent": [
+            "1 miniature score (12 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: H.P.S. 976.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Fondly dedicated to the memory of André Kostelanetz.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 2:30.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Jalni Publications : Boosey & Hawkes, sole selling agent"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "dateEndString": [
+            "1980"
+          ],
+          "title": [
+            "A musical toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "JNF 87-27"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [
+            "Bernstein, Leonard, 1918-1990"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Kostelanetz, Andre, 1901-1980"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "idOclc": [
+            "11578466",
+            "NYPG85-C1260"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNF 87-27"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10981311"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11578466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG85-C1260"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "HPS 976. Boosey & Hawkes"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0988546"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)11578466"
+            }
+          ],
+          "popularity": 2,
+          "dateEndYear": [
+            1980
+          ],
+          "updatedAt": 1752422485670,
+          "publicationStatement": [
+            "[United States] : Jalni Publications : Boosey & Hawkes, sole selling agent, 1984, c1980."
+          ],
+          "identifier": [
+            "urn:shelfmark:JNF 87-27",
+            "urn:bnum:10981311",
+            "urn:oclc:11578466",
+            "urn:oclc:NYPG85-C1260",
+            "urn:identifier:HPS 976. Boosey & Hawkes",
+            "urn:identifier:(WaOLN)nyp0988546",
+            "urn:identifier:(OCoLC)11578466"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "titleDisplay": [
+            "A musical toast / Leonard Bernstein."
+          ],
+          "uri": "b10981311",
+          "formatId": "c",
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "[United States]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          472.47043,
+          "b10981311"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b10981311",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:57",
+                        "label": "printed music limited circ MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:57||printed music limited circ MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433047232982"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JNF 87-27",
+                      "urn:barcode:33433047232982"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JNF 87-27",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433047232982",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "physicalLocation": [
+                      "JNF 87-27"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JNF 87-27"
+                    ],
+                    "shelfMark_sort": "aJNF 87-000027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i13956002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "cb1808514",
+        "_score": 464.68634,
+        "_source": {
+          "extent": [
+            "1 score (3 unnumbered pages, 12 pages) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes by Jack Gottlieb.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 2:30.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Recorded by the Israel Philharmonic, the composer conducting, on Deutsche Grammophon 2532 052.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Also available in a version for symphonic band.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "publisherLiteral": [
+            "Jalni Publications ; Boosey & Hawkes, sole selling agent"
+          ],
+          "dateEndString": [
+            "1980"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A musical toast"
+          ],
+          "creatorLiteral": [
+            "Bernstein, Leonard, 1918-1990"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "Hawkes pocket scores"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "1808514"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm11578466"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "H.P.S. 976 Boosey & Hawkes"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm11578466"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)1808514"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "1808514"
+            }
+          ],
+          "idOclc": [
+            "ocm11578466"
+          ],
+          "uniformTitle": [
+            "Musical toast",
+            "Hawkes pocket scores."
+          ],
+          "dateEndYear": [
+            1980
+          ],
+          "holdings": [],
+          "updatedAt": 1664590433971,
+          "publicationStatement": [
+            "[Place of publication not identified] : Jalni Publications ; New York, N.Y. : Boosey & Hawkes, sole selling agent, 1984, ©1980."
+          ],
+          "identifier": [
+            "urn:bnum:1808514",
+            "urn:oclc:ocm11578466",
+            "urn:undefined:H.P.S. 976 Boosey & Hawkes",
+            "urn:undefined:(OCoLC)ocm11578466",
+            "urn:undefined:(NNC)1808514",
+            "urn:undefined:1808514"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "titleDisplay": [
+            "A musical toast / Leonard Bernstein."
+          ],
+          "uri": "cb1808514",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "formatId": "c",
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "[Place of publication not identified] : New York, N.Y."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Musical toast"
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          464.68634,
+          "cb1808514"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "cb1808514",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:MR61509485"
+                    ],
+                    "physicalLocation": [
+                      "61 B458 M9"
+                    ],
+                    "shelfMark_sort": "a61 B458 M000009",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "ci2278358",
+                    "shelfMark": [
+                      "61 B458 M9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "61 B458 M9"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "MR61509485"
+                      }
+                    ],
+                    "idBarcode": [
+                      "MR61509485"
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "MR"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b13111567",
+        "_score": 425.3195,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "The Nation Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1909
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "title": [
+            "Verse and toast. Series 1-"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "NBI (Rowe, W. H. Verse and toast)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1909"
+          ],
+          "creatorLiteral": [
+            "Rowe, William H., Jr"
+          ],
+          "idLccn": [
+            "09014147"
+          ],
+          "numElectronicResources": [
+            2
+          ],
+          "dateStartYear": [
+            1909
+          ],
+          "idOclc": [
+            "12310878"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NBI (Rowe, W. H. Verse and toast)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13111567"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "12310878"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "09014147"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3090092"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1711009811615,
+          "publicationStatement": [
+            "New York, The Nation Press, 1909-"
+          ],
+          "identifier": [
+            "urn:shelfmark:NBI (Rowe, W. H. Verse and toast)",
+            "urn:bnum:13111567",
+            "urn:oclc:12310878",
+            "urn:lccn:09014147",
+            "urn:identifier:(WaOLN)nyp3090092"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1909"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Verse and toast. Series 1- By Col. William H. Rowe, Jr."
+          ],
+          "uri": "b13111567",
+          "electronicResources": [
+            {
+              "label": "Full text available via HathiTrust--ser. 1",
+              "url": "http://babel.hathitrust.org/cgi/pt?id=nyp.33433066644091"
+            },
+            {
+              "label": "Full text available via HathiTrust--ser. 2",
+              "url": "http://babel.hathitrust.org/cgi/pt?id=nyp.33433066644109"
+            }
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          425.3195,
+          "b13111567"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b13111567",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NBI (Rowe, W. H. Verse and toast) ser. 2",
+                      "urn:barcode:33433066644109"
+                    ],
+                    "physicalLocation": [
+                      "NBI (Rowe, W. H. Verse and toast)"
+                    ],
+                    "shelfMark_sort": "aNBI (Rowe, W. H. Verse and toast) ser. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "NBI (Rowe, W. H. Verse and toast) ser. 2"
+                    ],
+                    "uri": "i16815166",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "NBI (Rowe, W. H. Verse and toast) ser. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433066644109"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "ser. 2"
+                    ],
+                    "idBarcode": [
+                      "33433066644109"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b13111567",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2 ser. 1",
+                      "urn:barcode:33433066644091"
+                    ],
+                    "physicalLocation": [
+                      "NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2"
+                    ],
+                    "shelfMark_sort": "aNBI (Rowe, W. H. Verse and toast) Library has: Series 1-2 ser. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2 ser. 1"
+                    ],
+                    "uri": "i16257903",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2 ser. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433066644091"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "ser. 1"
+                    ],
+                    "idBarcode": [
+                      "33433066644091"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b10861042",
+        "_score": 355.8368,
+        "_source": {
+          "extent": [
+            "24 p. : ill., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"A publication commemorating the bicentennial of the evacuation of the British from New York City on November 25, 1783, at the end of the Revolutionary War.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 24.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Evacuation Day, New York, N.Y., 1783",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- History",
+            "New York (N.Y.) -- History -- Revolution, 1775-1783"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Fraunces Tavern Museum"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "title": [
+            "A toast to freedom New York celebrates Evacuation Day."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            2
+          ],
+          "shelfMark": [
+            "*ZI-437 no. 20"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Fraunces Tavern Museum",
+            "Sons of the American Revolution. Empire State Society"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "idOclc": [
+            "NYPG84-B40685"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZI-437 no. 20"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10861042"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG84-B40685"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0868084"
+            }
+          ],
+          "popularity": 3,
+          "updatedAt": 1752442232065,
+          "publicationStatement": [
+            "New York : Fraunces Tavern Museum, 1984."
+          ],
+          "identifier": [
+            "urn:shelfmark:*ZI-437 no. 20",
+            "urn:bnum:10861042",
+            "urn:oclc:NYPG84-B40685",
+            "urn:identifier:(WaOLN)nyp0868084"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Evacuation Day, New York, N.Y., 1783.",
+            "New York (N.Y.) -- History -- Revolution, 1775-1783."
+          ],
+          "titleDisplay": [
+            "A toast to freedom [microform] :  New York celebrates Evacuation Day."
+          ],
+          "uri": "b10861042",
+          "formatId": "h",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          355.8368,
+          "b10861042"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b10861042",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "enumerationChronology": [
+                      "r. 2"
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-"
+                    ],
+                    "formatLiteral": [
+                      "Microform"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag82",
+                        "label": "Schwarzman Building - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag82||Schwarzman Building - Milstein Division Room 121"
+                    ],
+                    "idBarcode": [
+                      "33433110534520"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*ZI-437",
+                      "urn:barcode:33433110534520"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZI-437",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433110534520",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "physicalLocation": [
+                      "*ZI-437"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "*ZI-437"
+                    ],
+                    "shelfMark_sort": "a*ZI-000437",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i31168756",
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 2
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b10861042",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "enumerationChronology": [
+                      "r. 1"
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "formatLiteral": [
+                      "Microform"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag82",
+                        "label": "Schwarzman Building - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag82||Schwarzman Building - Milstein Division Room 121"
+                    ],
+                    "idBarcode": [
+                      "33433110534512"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*ZI-437",
+                      "urn:barcode:33433110534512"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZI-437",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433110534512",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "physicalLocation": [
+                      "*ZI-437"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "*ZI-437"
+                    ],
+                    "shelfMark_sort": "a*ZI-000437",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i24076491",
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b18106748",
+        "_score": 355.0848,
+        "_source": {
+          "extent": [
+            "24 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"A publication commemorating the bicentennial of the evacuation of the British from New York City on November 25, 1783, ...\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "The research and implementation of this project ... with the assistance of the Sons of the Revolution in the State of New York.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "\"Selected bibliography\": p. 24.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "New York Genealogical and Biographical Society;",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Evacuation Day, New York, N.Y., 1783",
+            "Evacuation Day, New York, N.Y., 1783 -- Anniversaries, etc",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- History",
+            "New York (N.Y.) -- History -- Revolution, 1775-1783"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Fraunces Tavern Museum"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1984
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "A Toast to freedom : New York celebrates Evacuation Day."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "NYGB N.Y. L M314.43 F73"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Fraunces Tavern Museum",
+            "Sons of the American Revolution. New York State Society",
+            "New York Genealogical and Biographical Society Collection"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "donor": [
+            "Gift of the New York Genealogical and Biographical Society."
+          ],
+          "idOclc": [
+            "15527116"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NYGB N.Y. L M314.43 F73"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "18106748"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "15527116"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)15527116"
+            }
+          ],
+          "updatedAt": 1711602363339,
+          "publicationStatement": [
+            "New York : Fraunces Tavern Museum, 1984."
+          ],
+          "identifier": [
+            "urn:shelfmark:NYGB N.Y. L M314.43 F73",
+            "urn:bnum:18106748",
+            "urn:oclc:15527116",
+            "urn:identifier:(OCoLC)15527116"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Evacuation Day, New York, N.Y., 1783 -- Anniversaries, etc.",
+            "New York (N.Y.) -- History -- Revolution, 1775-1783."
+          ],
+          "titleDisplay": [
+            "A Toast to freedom : New York celebrates Evacuation Day."
+          ],
+          "uri": "b18106748",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          355.0848,
+          "b18106748"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b18106748",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NYGB N.Y. L M314.43 F73",
+                      "urn:barcode:33433086370503"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "NYGB N.Y. L M314.43 F73"
+                    ],
+                    "shelfMark_sort": "aNYGB N.Y. L M314.43 F000073",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "NYGB N.Y. L M314.43 F73"
+                    ],
+                    "uri": "i24199542",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "NYGB N.Y. L M314.43 F73"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433086370503"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "idBarcode": [
+                      "33433086370503"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b15774363",
+        "_score": 258.81384,
+        "_source": {
+          "extent": [
+            "37.8 (75 boxes)"
+          ],
+          "note": [
+            {
+              "noteType": "Access",
+              "label": "Collection is open to the public. Library policy on photography and photocopying will apply. Advance notice may be required.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Bradley, Keith",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Beatrice Lillie, comedienne, actress, singer and author, was born May 29, 1894 in Toronto, Ontario. She left school for the stage at age 15 to tour Canada in The Lillie Trio with her mother Lucy and sister Muriel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "After coming to London in 1914, Lillie joined Andre Charlot's Revue, where she later made her Broadway debut in 1924. With a career spanning more than 50 years, she performed in revues, plays, film, on radio and television and also enjoyed a successful recording career. Lillie frequently performed both in London and the United States, earning her fame as \"The Toast of Two Continents.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "In 1920 Beatrice married Sir Robert Peel, gaining the title Lady Peel. The couple had one son, Robert Peel Jr., in 1934. She was widowed in 1934 and lost her son to the war in 1942.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Lillie traveled to the Middle East, Africa, France and Germany to perform for the troops during WWII, an effort for which she received a decoration from General Charles de Gaulle. She developed close friendships with other famous figures, including Noel Coward, Winston Churchill, George Bernard Shaw and Charlie Chaplin. During the war Beatrice Lillie met John Phillip Huck who would become her manager and life-long companion.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Ms. Lillie starred in shows by Noel Coward, George Bernard Shaw, Rogers & Hart, Schwartz & Dietz and Cole Porter. Lillie became best known for starring in This year of grace (1928), written for her by Noel Coward, and received equal recognition for her version of Coward's song, \"Mad dogs and Englishmen.\" Other notable Broadway performances include The Seven lively arts (1947), Inside USA (1948), Ziegfeld follies of 1957 and High spirits (1964). She toured the world with her one-woman show An evening with Beatrice Lillie from 1952-1956, winning a Tony Award in 1953. Lady Peel made a handful of films, which met with varying degrees of success. Beginning with an early silent film Exit smiling (1926) and ending on a high note with her role as a Mrs. Meers in Thoroughly modern Millie (1967). Beatrice Lillie published her autobiography, Every other inch a lady, in 1973.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Beatrice Lillie retired to England to recover from a stroke in 1977. She died January 20, 1989 at her home, Henley-on-Thames, England. She was 94 years old.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processed",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Lillie, Beatrice, 1894-1989",
+            "Performing arts",
+            "Women comedians",
+            "Actresses",
+            "Entertainers"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "description": [
+            "The Beatrice Lillie papers consist of 37.8 linear feet spanning the 1910s to the 1990s. The collection has been divided into ten series: Correspondence, Personal Papers, Legal and Financial Papers, Professional Work Files, Clippings, Photographs, Ephemera, Artwork, and Oversize Materials. The first three series: Correspondence, Personal Papers and Legal and Financial Papers also include items belonging to Beatrice Lillie's long-time companion John Phillip Huck and his sister Georgina M. Huck. The collection is strong in biographical works, including two unpublished works. It effectively reveals the performer's humor and colorful persona through lyrics and skits. A large collection of photographs illuminates a professional and personal Beatrice Lillie."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            75
+          ],
+          "buildingLocationIds": [
+            "pa",
+            "rc"
+          ],
+          "createdYear": [
+            1911
+          ],
+          "dateEndString": [
+            "1995"
+          ],
+          "title": [
+            "Beatrice Lillie papers"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "*T-Mss 2000-012"
+          ],
+          "createdString": [
+            "1911"
+          ],
+          "creatorLiteral": [
+            "Lillie, Beatrice, 1894-1989"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Bricusse, Leslie",
+            "Charlot, André, 1882-1956",
+            "Churchill, Winston, 1874-1965",
+            "Coward, Noël, 1899-1973",
+            "Dietz, Howard, 1896-1983",
+            "Hamilton, Nancy, 1908-1985",
+            "Hart, Lorenz, 1895-1943",
+            "Hope, Bob, 1903-2003",
+            "Novello, Ivor, 1893-1951",
+            "Peel, Robert, 1909-1992",
+            "Porter, Cole, 1891-1964",
+            "Rodgers, Richard, 1902-1979",
+            "Schwartz, Arthur, 1900-1984"
+          ],
+          "dateStartYear": [
+            1911
+          ],
+          "idOclc": [
+            "NYPT03-A1"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*T-Mss 2000-012"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15774363"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPT03-A1"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)T170000001"
+            }
+          ],
+          "popularity": 24,
+          "dateEndYear": [
+            1995
+          ],
+          "updatedAt": 1751953379091,
+          "genreForm": [
+            "Biographies.",
+            "Clippings.",
+            "Correspondence.",
+            "Financial records.",
+            "Legal documents.",
+            "Personal papers.",
+            "Photographs.",
+            "Scrapbooks.",
+            "Sheet music."
+          ],
+          "identifier": [
+            "urn:shelfmark:*T-Mss 2000-012",
+            "urn:bnum:15774363",
+            "urn:oclc:NYPT03-A1",
+            "urn:identifier:(WaOLN)T170000001"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mix",
+              "label": "Mixed material"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1911"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Lillie, Beatrice, 1894-1989.",
+            "Performing arts.",
+            "Women comedians.",
+            "Actresses.",
+            "Entertainers."
+          ],
+          "titleDisplay": [
+            "Beatrice Lillie papers, 1911-1995"
+          ],
+          "uri": "b15774363",
+          "formatId": "p",
+          "recordTypeId": "p",
+          "issuance": [
+            {
+              "id": "urn:biblevel:c",
+              "label": "collection"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Finding Aid",
+              "url": "http://www.nypl.org/archives/4489"
+            }
+          ]
+        },
+        "sort": [
+          258.81384,
+          "b15774363"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 75,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15774363",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Lillie%2C+Beatrice%2C+1894-1989&CallNumber=*T-Mss+2000-012&Date=1911&Form=30&Genre=archival+material&ItemInfo1=Supervised+use&ItemInfo2=Collection+is+open+to+the+public.+Library+policy+on+photography+and+photocopying+will+apply.+Advance+notice+may+be+required.&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15774363&ItemISxN=i153520644&ItemNumber=33433036090011&ItemVolume=Box+1&Location=Performing+Arts+Theatre+Division&ReferenceNumber=b157743639&Site=LPATH&Title=Beatrice+Lillie+papers%2C+1911-1995"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:21",
+                        "label": "archival material"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:21||archival material"
+                    ],
+                    "enumerationChronology": [
+                      "Box 1"
+                    ],
+                    "formatLiteral": [
+                      "Archival Mix"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pat38",
+                        "label": "Performing Arts Research Collections - Theatre"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pat38||Performing Arts Research Collections - Theatre"
+                    ],
+                    "idBarcode": [
+                      "33433036090011"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*T-Mss 2000-012",
+                      "urn:barcode:33433036090011"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*T-Mss 2000-012",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433036090011",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*T-Mss 2000-012"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*T-Mss 2000-012"
+                    ],
+                    "shelfMark_sort": "a*T-Mss 2000-000012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15352064"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15774363",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Lillie%2C+Beatrice%2C+1894-1989&CallNumber=*T-Mss+2000-012&Date=1911&Form=30&Genre=archival+material&ItemInfo1=Supervised+use&ItemInfo2=Collection+is+open+to+the+public.+Library+policy+on+photography+and+photocopying+will+apply.+Advance+notice+may+be+required.&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15774363&ItemISxN=i153521387&ItemNumber=33433036090755&ItemVolume=Box+75&Location=Performing+Arts+Theatre+Division&ReferenceNumber=b157743639&Site=LPATH&Title=Beatrice+Lillie+papers%2C+1911-1995"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:21",
+                        "label": "archival material"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:21||archival material"
+                    ],
+                    "enumerationChronology": [
+                      "Box 75"
+                    ],
+                    "formatLiteral": [
+                      "Archival Mix"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pat38",
+                        "label": "Performing Arts Research Collections - Theatre"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pat38||Performing Arts Research Collections - Theatre"
+                    ],
+                    "idBarcode": [
+                      "33433036090755"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*T-Mss 2000-012",
+                      "urn:barcode:33433036090755"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*T-Mss 2000-012",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433036090755",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*T-Mss 2000-012"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*T-Mss 2000-012"
+                    ],
+                    "shelfMark_sort": "a*T-Mss 2000-000012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15352138"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15774363",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Lillie%2C+Beatrice%2C+1894-1989&CallNumber=*T-Mss+2000-012&Date=1911&Form=30&Genre=archival+material&ItemInfo1=Supervised+use&ItemInfo2=Collection+is+open+to+the+public.+Library+policy+on+photography+and+photocopying+will+apply.+Advance+notice+may+be+required.&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15774363&ItemISxN=i153521363&ItemNumber=33433036090730&ItemVolume=Box+73&Location=Performing+Arts+Theatre+Division&ReferenceNumber=b157743639&Site=LPATH&Title=Beatrice+Lillie+papers%2C+1911-1995"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:21",
+                        "label": "archival material"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:21||archival material"
+                    ],
+                    "enumerationChronology": [
+                      "Box 73"
+                    ],
+                    "formatLiteral": [
+                      "Archival Mix"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pat38",
+                        "label": "Performing Arts Research Collections - Theatre"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pat38||Performing Arts Research Collections - Theatre"
+                    ],
+                    "idBarcode": [
+                      "33433036090730"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*T-Mss 2000-012",
+                      "urn:barcode:33433036090730"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*T-Mss 2000-012",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433036090730",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*T-Mss 2000-012"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*T-Mss 2000-012"
+                    ],
+                    "shelfMark_sort": "a*T-Mss 2000-000012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15352136"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b10685709",
+        "_score": 258.6608,
+        "_source": {
+          "extent": [
+            "volumes <1-12> : illustrations ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "University of Tennessee Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "IAW (Jackson) 80-3099"
+          ],
+          "idLccn": [
+            "79015078"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "IAW (Jackson) 80-3099"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10685709"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0870492195"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780870492198"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0870494414"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780870494413"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0870496506"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780870496509"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0870497782"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780870497780"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0870498975"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780870498978"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1572331747"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781572331747"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781572335936"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1572335939"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781572337152"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "157233715X"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781621900047"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1621900045"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781621902676"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1621902676"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781621905387"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1621905381"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781621907558"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1621907554"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "5029597"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79015078"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)5029597"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)609560879 (OCoLC)769265853 (OCoLC)769850561 (OCoLC)770876143 (OCoLC)777774362 (OCoLC)807573070 (OCoLC)876110400 (OCoLC)890078391 (OCoLC)890280620 (OCoLC)894132413 (OCoLC)913850526 (OCoLC)914132651 (OCoLC)922670928 (OCoLC)958221171 (OCoLC)1101360978 (OCoLC)1114108948 (OCoLC)1131934218 (OCoLC)1164180119 (OCoLC)1222878957 (OCoLC)1225660295"
+            }
+          ],
+          "updatedAt": 1754342280041,
+          "publicationStatement": [
+            "Knoxville : University of Tennessee Press, [1980-]",
+            "©1980"
+          ],
+          "identifier": [
+            "urn:shelfmark:IAW (Jackson) 80-3099",
+            "urn:bnum:10685709",
+            "urn:isbn:0870492195",
+            "urn:isbn:9780870492198",
+            "urn:isbn:0870494414",
+            "urn:isbn:9780870494413",
+            "urn:isbn:0870496506",
+            "urn:isbn:9780870496509",
+            "urn:isbn:0870497782",
+            "urn:isbn:9780870497780",
+            "urn:isbn:0870498975",
+            "urn:isbn:9780870498978",
+            "urn:isbn:1572331747",
+            "urn:isbn:9781572331747",
+            "urn:isbn:9781572335936",
+            "urn:isbn:1572335939",
+            "urn:isbn:9781572337152",
+            "urn:isbn:157233715X",
+            "urn:isbn:9781621900047",
+            "urn:isbn:1621900045",
+            "urn:isbn:9781621902676",
+            "urn:isbn:1621902676",
+            "urn:isbn:9781621905387",
+            "urn:isbn:1621905381",
+            "urn:isbn:9781621907558",
+            "urn:isbn:1621907554",
+            "urn:oclc:5029597",
+            "urn:lccn:79015078",
+            "urn:identifier:(OCoLC)5029597",
+            "urn:identifier:(OCoLC)609560879 (OCoLC)769265853 (OCoLC)769850561 (OCoLC)770876143 (OCoLC)777774362 (OCoLC)807573070 (OCoLC)876110400 (OCoLC)890078391 (OCoLC)890280620 (OCoLC)894132413 (OCoLC)913850526 (OCoLC)914132651 (OCoLC)922670928 (OCoLC)958221171 (OCoLC)1101360978 (OCoLC)1114108948 (OCoLC)1131934218 (OCoLC)1164180119 (OCoLC)1222878957 (OCoLC)1225660295"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jackson, Andrew, 1767-1845.",
+            "Jackson, Andrew, 1767-1845.",
+            "1829-1837",
+            "Presidents -- United States -- Correspondence.",
+            "Politics and government.",
+            "Presidents.",
+            "United States -- Politics and government -- 1829-1837 -- Sources.",
+            "United States."
+          ],
+          "lccClassification": [
+            "E302 .J35 1980"
+          ],
+          "formatId": "a",
+          "titleAlt": [
+            "Works"
+          ],
+          "tableOfContents": [
+            "Volume I: 1770-1803 -- Volume II: 1804-1813 -- Volume III: 1814-1815 -- Volume IV: 1816-1820 -- Volume V: 1825-1828 -- Volume VI: 1825-1828 -- Volume VII: 1829 -- Volume VIII: 1830 -- Volume IX: 1831 -- Volume X: 1832 -- Volume XI: 1833 -- Volume XII: 1834"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Volume 2 edited by Harold D. Moser and Sharon Macpherson.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Volume 5 edited by Harold D. Moser, David H. Roth, and George H. Hoemann.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Volume 6 edited by Harold D. Moser, J. Clint Clifft and assistant editor Wyatt C. Wells.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Volume 7 edited by Daniel Feller, Harold D. Moser, Laura-Eve Moss, and Thomas Coens.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Volume 8 edited by Daniel Feller, Thomas Coens, and Laura-Eve Moss.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Volume 9 edited by Daniel Feller, Laura-Eve Moss, Thomas Coens, and Erik B. Alexander.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Volumes 10-11 edited by Daniel Feller, Thomas Coens, and Laura-Eve Moss.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Volume 12 edited by Daniel Feller, Thomas Coens, Laura-Eve Moss, and Aaron Crawford.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Jackson, Andrew, 1767-1845",
+            "1829-1837",
+            "Presidents",
+            "Presidents -- United States",
+            "Presidents -- United States -- Correspondence",
+            "Politics and government",
+            "United States",
+            "United States -- Politics and government",
+            "United States -- Politics and government -- 1829-1837",
+            "United States -- Politics and government -- 1829-1837 -- Sources"
+          ],
+          "numItemDatesParsed": [
+            2
+          ],
+          "description": [
+            "\"Andrew Jackson is one of the most critical and controversial figures in American history.  A dominant actor on the American scene in the period between the Revolution and Civil War, he stamped his name first on a mass political movement and then an era.  At the same time Jackson's ascendancy accelerated the dispossession and death of Native Americans and spurred the expansion of slavery. 'The Papers of Andrew Jackson' is a project to collect and publish Jackson's entire extant literary record. The project is now producing a series of seventeen volumes that will bring Jackson's most important papers to the public in easily readable form.\"--",
+            "V. 6. This sixth volume of The Papers of Andrew Jackson documents the election on Andrew Jackson, the first westerner and the last veteran of the American Revolution, to the presidency. The four years of this volume chronicle the presidential campaign of 1828. Jackson, winner of the popular vote in 1824 but loser of the election, was once again the reluctant candidate, called into service by the voice of the voters. The campaign, one of the longest in American history, pitted Jackson against the incumbent John Quincy Adams; it was also one of the dirtiest campaigns in American history. The brunt of the mudslinging was aimed at Jackson, and it is covered in detail in this volume. Every aspect of the public and private life of the fifty-eight-year-old former major general in the United States Army came under scrutiny, and in both his opponents found him deficient. According to his detractors, he lacked the moral principles, the temperament, the education, and the family background requisite for a president of the United States. In sum, Jackson resembled the devil incarnate, to use his own words. The mudslinging left Jackson livid, anxious for retribution but constrained by the cause in which he was engaged. The presidential campaign of 1828, in the minds of Jackson and his supporters, was for the cause of truth and democracy against corrupt, self-seeking politicians, an aristocracy of power built upon bargains and dubious political alliances dedicated to its perpetuation in office. The four years covered in this volume were some of the most trying in Jackson s life, but the one event that hurt Jackson the most was the death of his wife. Until his dying day, Jackson contended that her death had been hastened by the slanders of his opponents in the campaign. As great as the loss was for him personally, Jackson nonetheless rejoiced in the results of the election for, in his eyes, the voice of the people had finally been heard. Liberty, not power, had triumphed. Reform was at hand, and retribution would surely follow.",
+            "V. 7. With this seventh volume, The Papers of Andrew Jackson enters the heart of Jackson's career: his tumultuous two terms as president of the United States. The year 1829 began with Jackson fresh from a triumphant victory over incumbent John Quincy Adams in the 1828 campaign, yet mourning the sudden death of his beloved wife, Rachel. In January, having hired an overseer for his Hermitage plantation and arranged for Rachel's tomb, he left Tennessee for Washington. Jackson assumed the presidency with two objectives already fixed in mind: purging the federal bureaucracy of recreant officeholders and removing the southern Indian tribes westward beyond state authority. By year's end he had added two more: purchasing Texas and destroying the Bank of the United States. But meanwhile he found himself diverted, and nearly consumed, by the notorious Peggy Eaton affair--a burgeoning scandal which pitted the president, his Secretary of War John Eaton, and the latter's vivacious wife against the Washington guardians of feminine propriety. This first presidential volume reveals all these stories, and many more, in a depth never seen before. It presents full texts of more than four hundred documents, most printed for the first time. Gathered from a vast array of libraries, archives, and individual owners, they include Jackson's intimate exchanges with family and friends, private notes and musings, and formative drafts of public addresses. Administrative papers range from presidential pardons to military promotions to plans for discharging the public debt. They exhibit Jackson's daily conduct of the executive office in close and sometimes startling detail, and cast new light on such controversial matters as Indian removal and political patronage. Included also are letters to the president from people in every corner of the country and every walk of life: Indian delegations presenting grievances, distraught mothers pleading help for wayward sons, aged veterans begging pensions, politicians offering advice and seeking jobs. Embracing a broad spectrum of actors and events, this volume offers an incomparable window not only into Jackson and his presidency, but into America itself in 1829.",
+            "V. 8. This eighth volume of Andrew Jackson s papers presents more than five hundred documents, many appearing here for the first time, from a core year in Jackson s tumultuous presidency. They include Jackson s handwritten drafts of his presidential messages, private notes and memoranda, and correspondence with government officials, Army and Navy officers, friends and family, Indian leaders, foreign diplomats, and ordinary citizens throughout the country. In 1830 Jackson pursued his controversial Indian removal policy, concluding treaties to compel the Choctaws and Chickasaws west of the Mississippi and refusing protection for the Cherokees against encroachments by Georgia. Jackson nurtured his opposition to the Bank of the United States and entered into an escalating confrontation with the Senate over presidential appointments to office. In April, Jackson pronounced his ban on nullification with the famous toast to Our Federal Union, and in May he began an explosive quarrel with Vice-President John C. Calhoun over the latter s conduct as secretary of war during Jackson s Seminole campaign of 1818. Also in May, Jackson delivered his first presidential veto, stopping federal funding for the Maysville Road and declaring opposition to Henry Clay s American System. In July, Jackson s refusal to use his pardoning power to save an Irish-born mail robber from the gallows provoked a near-riot in Philadelphia. By the end of the year, Jackson was preparing for his reelection campaign in 1832. Meanwhile the sex scandal surrounding Peggy Eaton, wife of the secretary of war, lurked throughout, dividing Jackson s cabinet, sundering his own family and household, and threatening to wreck the administration. Embracing all these stories and many more, this volume offers an incomparable window not only into Andrew Jackson and his presidency but into 1830s America itself.",
+            "V. 9. This volume presents more than five hundred original documents, many newly discovered, from Andrew Jackson s third presidential year. They include Jackson s private memoranda, intimate family letters, and correspondence with government and military officers, diplomats, Indians, political friends and foes, and ordinary citizens throughout the country. In 1831 Jackson finally cleared his contentious Cabinet, reluctantly accepting the resignations of Martin Van Buren and John Eaton and demanding that the other members follow. But in the aftermath, animosities among them boiled over, as Eaton sought duels with outgoing secretaries Samuel Ingham and John Berrien. The affair ended with gangs of armed high-government officers stalking each other in the Washington streets, and with Ingham publicly accusing Jackson of countenancing a plot to assassinate him. Meanwhile, Jackson pursued his feud with Vice-President John C. Calhoun, whom he had come to view as the diabolical manipulator of all his enemies. Enlisting a favorite Supreme Court justice to gather evidence, Jackson crafted an exposition, intended for publication, that leveled nearly fantastic charges against Calhoun and others. Through all this, the business of government ploughed on. Jackson pursued his drive to remove the Cherokees and other Indians west of the Mississippi and to undercut tribal leaders who dared resist. To squelch sectional controversy, Jackson moved to retire the national debt and reduce the tariff, while reiterating his ban on nullification and his opposition to the Bank of the United States. Nat Turner's Virginia slave revolt in August drew a quick administration response. By year s end, the dust over the Cabinet implosion was settling, as Jackson prepared to stand for reelection against his old nemesis Henry Clay. Embracing all these stories and many more, this volume offers an incomparable window not only into Andrew Jackson and his presidency but into America itself in 1831.",
+            "V. 10. This volume presents more than four hundred documents from Andrew Jackson s fourth presidential year. It includes private memoranda, intimate family letters, drafts of official messages, and correspondence with government and military officers, diplomats, Indians, political friends and foes, and ordinary citizens throughout the country. The year 1832 began with Jackson still pursuing his feud with Vice President John C. Calhoun, whom Jackson accused of secretly siding against him in the 1818 controversy over Jackson s Seminole campaign in Florida. The episode ended embarrassingly for Jackson when a key witness, called on to prove his charges, instead directly contradicted them. Indian removal remained a preoccupation for Jackson. The Choctaws began emigrating westward, the Creeks and Chickasaws signed but then immediately protested removal treaties, and the Cherokees won what proved to be an empty victory against removal in the Supreme Court. Illinois Indians mounted armed resistance in the Black Hawk War. In midsummer, a cholera epidemic swept the country, and Jackson was urged to proclaim a day of fasting and prayer. He refused, saying it would intermingle church and state. A bill to recharter the Bank of the United States passed Congress in July, and Jackson vetoed it with a ringing message that became the signature document of his presidency. In November, Jackson, with new running mate Martin Van Buren, won triumphant reelection over Henry Clay. But only days later, South Carolina nullified the federal tariff law and began preparing for armed resistance. Jackson answered with an official proclamation that disunion by armed force is treason. The year closed with Jackson immersed in plans to suppress nullification and destroy the Bank of the United States. Embracing all these stories and many more, this volume offers an incomparable window into Andrew Jackson, his presidency, and America itself in 1832.",
+            "V. 11. This volume presents full annotated text of five hundred documents from Andrew Jackson's fifth presidential year. They include his private memoranda, intimate family letters, presidential message drafts, and correspondence with government and military officers, diplomats, Indian leaders, political friends and foes, and citizens throughout the country.The year 1833 began with a crisis in South Carolina, where a state convention had declared the federal tariff law null and void and pledged resistance by armed force if necessary. Jackson countered by rallying public opinion against the nullifiers, quietly positioning troops and warships, and procuring a \"force bill\" from Congress to compel collection of customs duties. The episode ended peaceably after South Carolina accepted a compromise tariff devised by Jackson's arch-rival Henry Clay. But Clay's surprise cooperation with South Carolina's John C. Calhoun foretold a new opposition coalition against Jackson.With nullification checked, Jackson embarked in June on a triumphal tour to cement his newfound popularity in the North. Ecstatic crowds greeted him in Philadelphia, New York, and Boston, and Harvard awarded him a degree. But Jackson's fragile health broke under the strain, forcing him to cut the tour short. Meanwhile Jackson pursued his campaign against the Bank of the United States, whose recharter he had vetoed in 1832. Charging the Bank with political meddling and corruption, Jackson determined to cripple it by removing federal deposits to state banks. But Treasury secretary William John Duane refused either to give the necessary order or resign. In September Jackson dismissed him and installed Roger Taney to implement the removal. Jackson's bold assumption of authority energized supporters but outraged opponents, prompting Clay to introduce a Senate resolution of censure.The year closed with Jackson girding for further battle over the Bank, pursuing schemes to pry the province of Texas loose from Mexico, and trying to stem rampant land frauds that his own Indian removal policy had unleashed against Creek Indians in Alabama. Unfolding these stories and many more, this volume offers an incomparable window into Andrew Jackson, his presidency, and America itself in 1833.",
+            "V. 12. This volume presents more than five hundred annotated original documents from Andrew Jackson's sixth presidential year. They include his private memoranda, intimate family letters, official messages, and correspondence with government and military officers, diplomats, Indian leaders, political friends and foes, and plain citizens throughout the country.  The year 1834 began with Jackson battling the United States Senate. Pursuing his campaign against the federally chartered Bank of the United States, Jackson in 1833 had installed Roger Taney as interim Treasury secretary to transfer the government's deposits to selected state-chartered \"pet\" banks. The Bank retaliated by curtailing its business, setting off a commercial crisis and a political frenzy. In 1834 the Senate, controlled by the new opposition Whig Party led by Jackson's old nemeses Henry Clay and John C. Calhoun, rejected a slew of Jackson's nominees for office, including Taney, and adopted an unprecedented (and still unparalleled) resolution of censure against Jackson himself. Jackson returned a scathing protest, which the Senate rejected. Meanwhile the administration struggled to implement its \"experiment\" of conducting government finances through state banks.  Throughout the year Jackson pursued his aim of compelling eastern Indians to remove west of the Mississippi. In May the Chickasaws signed a removal treaty. But brazen frauds complicated the administration's scheme to induce individual Creeks to emigrate from Alabama, while the Cherokees, led by Principal Chief John Ross, stood fast in resistance. In June some unauthorized dissident Cherokees signed a removal treaty, but it died in the Senate.  In 1834 Jackson continued his longstanding effort to pry the province of Texas loose from Mexico, while the U.S. hurtled toward confrontation with France over French failure to pay an indemnity due under an 1831 treaty. Other matters engaging Jackson included corruption scandals in the Post Office Department and at Mississippi land offices, fractious disputes over rank and seniority among Army and Navy officers, and a fire that gutted Jackson's Hermitage home in Tennessee. Unfolding these stories and many more, this volume offers a revelatory window into Andrew Jackson, his presidency, and America itself in 1834."
+          ],
+          "numItemsTotal": [
+            11
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "title": [
+            "The papers of Andrew Jackson"
+          ],
+          "numItemVolumesParsed": [
+            11
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "creatorLiteral": [
+            "Jackson, Andrew, 1767-1845"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Smith, Sam B., 1929-2003",
+            "Owsley, Harriet Chappell, 1901-1999",
+            "Macpherson, Sharon C.",
+            "Remini, Robert V. (Robert Vincent), 1921-2013",
+            "Moser, Harold D.",
+            "Feller, Daniel, 1950-",
+            "Roth, David H.",
+            "Hoemann, George H., 1952-",
+            "Coens, Thomas, 1974-",
+            "Moss, Laura-Eve",
+            "Alexander, Erik B.",
+            "Crawford, Aaron"
+          ],
+          "idOclc": [
+            "5029597"
+          ],
+          "popularity": 50,
+          "uniformTitle": [
+            "Works"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "checkInBoxes": [
+                {
+                  "coverage": "No. 5 (1821 - 1824)",
+                  "position": 1,
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "IAW (Jackson) 80-3099"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "No. 6 (1825 - 1828)",
+                  "position": 2,
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "IAW (Jackson) 80-3099"
+                  ],
+                  "status": "Bound"
+                }
+              ],
+              "holdingStatement": [
+                "1-7,10,12"
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "IAW (Jackson) 80-3099"
+                }
+              ],
+              "physicalLocation": [
+                "IAW (Jackson) 80-3099"
+              ],
+              "location": [
+                {
+                  "code": "loc:mag92",
+                  "label": "Schwarzman Building - Milstein Division Room 121"
+                }
+              ],
+              "shelfMark": [
+                "IAW (Jackson) 80-3099"
+              ],
+              "uri": "h1030920"
+            }
+          ],
+          "genreForm": [
+            "Personal correspondence.",
+            "Sources.",
+            "Correspondence."
+          ],
+          "idIsbn": [
+            "0870492195",
+            "9780870492198",
+            "0870494414",
+            "9780870494413",
+            "0870496506",
+            "9780870496509",
+            "0870497782",
+            "9780870497780",
+            "0870498975",
+            "9780870498978",
+            "1572331747",
+            "9781572331747",
+            "9781572335936",
+            "1572335939",
+            "9781572337152",
+            "157233715X",
+            "9781621900047",
+            "1621900045",
+            "9781621902676",
+            "1621902676",
+            "9781621905387",
+            "1621905381",
+            "9781621907558",
+            "1621907554"
+          ],
+          "numCheckinCardItems": [
+            2
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "titleDisplay": [
+            "The papers of Andrew Jackson / Sam B. Smith and Harriet Chappell Owsley, editors ; Robert V. Remini, consulting editor ; Sharon C. Macpherson, associate editor ; Linda D. Keeton, staff assistant."
+          ],
+          "uri": "b10685709",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Knoxville"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Book review (H-Net)",
+              "url": "http://www.h-net.org/review/hrev-a0c8q7-aa"
+            },
+            {
+              "label": "Book review (H-Net)",
+              "url": "http://www.h-net.org/reviews/showrev.php?id=25345"
+            },
+            {
+              "label": "Book review (H-Net)",
+              "url": "http://www.h-net.org/reviews/showrev.php?id=7356"
+            }
+          ],
+          "dimensions": [
+            "25 cm"
+          ],
+          "idIsbn_clean": [
+            "0870492195",
+            "9780870492198",
+            "0870494414",
+            "9780870494413",
+            "0870496506",
+            "9780870496509",
+            "0870497782",
+            "9780870497780",
+            "0870498975",
+            "9780870498978",
+            "1572331747",
+            "9781572331747",
+            "9781572335936",
+            "1572335939",
+            "9781572337152",
+            "157233715X",
+            "9781621900047",
+            "1621900045",
+            "9781621902676",
+            "1621902676",
+            "9781621905387",
+            "1621905381",
+            "9781621907558",
+            "1621907554"
+          ]
+        },
+        "sort": [
+          258.6608,
+          "b10685709"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 11,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b10685709",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "enumerationChronology": [
+                      "v. 12"
+                    ],
+                    "enumerationChronology_sort": [
+                      "        12-"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building - Milstein Division Room 121"
+                    ],
+                    "idBarcode": [
+                      "33433137385237"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:IAW (Jackson) 80-3099",
+                      "urn:barcode:33433137385237"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "IAW (Jackson) 80-3099",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433137385237",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "IAW (Jackson) 80-3099"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "IAW (Jackson) 80-3099"
+                    ],
+                    "shelfMark_sort": "aIAW (Jackson) 80-003099",
+                    "status": [
+                      {
+                        "id": "status:oh",
+                        "label": "On Holdshelf"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:oh||On Holdshelf"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i40826956",
+                    "volumeRange": [
+                      {
+                        "gte": 12,
+                        "lte": 12
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "        12-"
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b10685709",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "enumerationChronology": [
+                      "v. 10"
+                    ],
+                    "enumerationChronology_sort": [
+                      "        10-"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building - Milstein Division Room 121"
+                    ],
+                    "idBarcode": [
+                      "33433119383762"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:IAW (Jackson) 80-3099",
+                      "urn:barcode:33433119383762"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "IAW (Jackson) 80-3099",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433119383762",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "IAW (Jackson) 80-3099"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "IAW (Jackson) 80-3099"
+                    ],
+                    "shelfMark_sort": "aIAW (Jackson) 80-003099",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i34456277",
+                    "volumeRange": [
+                      {
+                        "gte": 10,
+                        "lte": 10
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "        10-"
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b10685709",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "enumerationChronology": [
+                      "v. 7"
+                    ],
+                    "enumerationChronology_sort": [
+                      "         7-"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building - Milstein Division Room 121"
+                    ],
+                    "idBarcode": [
+                      "33433079269134"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:IAW (Jackson) 80-3099",
+                      "urn:barcode:33433079269134"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "IAW (Jackson) 80-3099",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433079269134",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "IAW (Jackson) 80-3099"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "IAW (Jackson) 80-3099"
+                    ],
+                    "shelfMark_sort": "aIAW (Jackson) 80-003099",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17468525",
+                    "volumeRange": [
+                      {
+                        "gte": 7,
+                        "lte": 7
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         7-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "cb1677200",
+        "_score": 257.99185,
+        "_source": {
+          "extent": [
+            "193, vi pages ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Originally published: Chicago : Nakł. i drukiem Władysława Dyniewicza, 1896.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "subjectLiteral_exploded": [
+            "Toasts",
+            "Toasts -- Poland"
+          ],
+          "publisherLiteral": [
+            "Oficyna Wydawn. Kalliope"
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "dateEndString": [
+            "1896"
+          ],
+          "createdYear": [
+            1994
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Toast polski wierszem i prozą, czyli, Zbiór mów przy uroczystościach wszelkiego rodzaju : jako to, przy weselach, ważniejszych zebraniach, przy obchodach zebraniach, przy obchodach jubileuszowych itd."
+          ],
+          "createdString": [
+            "1994"
+          ],
+          "idLccn": [
+            "   95124368 "
+          ],
+          "dateStartYear": [
+            1994
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "1677200"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "8385549323 (pbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "8385549331(hardcover)"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "   95124368 "
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm34576390"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm34576390"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "1677200"
+            }
+          ],
+          "idOclc": [
+            "ocm34576390"
+          ],
+          "dateEndYear": [
+            1896
+          ],
+          "holdings": [],
+          "updatedAt": 1654826078096,
+          "publicationStatement": [
+            "Warszawa : Oficyna Wydawn. Kalliope, 1994."
+          ],
+          "identifier": [
+            "urn:bnum:1677200",
+            "urn:isbn:8385549323 (pbk.)",
+            "urn:isbn:8385549331(hardcover)",
+            "urn:lccn:   95124368 ",
+            "urn:oclc:ocm34576390",
+            "urn:undefined:(OCoLC)ocm34576390",
+            "urn:undefined:1677200"
+          ],
+          "idIsbn": [
+            "8385549323 (pbk.)",
+            "8385549331(hardcover)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1994"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Toasts -- Poland."
+          ],
+          "titleDisplay": [
+            "Toast polski wierszem i prozą, czyli, Zbiór mów przy uroczystościach wszelkiego rodzaju : jako to, przy weselach, ważniejszych zebraniach, przy obchodach zebraniach, przy obchodach jubileuszowych itd."
+          ],
+          "uri": "cb1677200",
+          "lccClassification": [
+            "PN6347.P6 T63 1994"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Warszawa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Zbiór mów przy uroczystościach wszelkiego rodzaju"
+          ],
+          "idIsbn_clean": [
+            "8385549323",
+            "8385549331"
+          ],
+          "dimensions": [
+            "17 cm"
+          ]
+        },
+        "sort": [
+          257.99185,
+          "cb1677200"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "cb1677200",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:CU63297698"
+                    ],
+                    "physicalLocation": [
+                      "PN6347.P6 T63 1994"
+                    ],
+                    "shelfMark_sort": "aPN6347.P6 T63 001994",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "ci2131706",
+                    "shelfMark": [
+                      "PN6347.P6 T63 1994"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PN6347.P6 T63 1994"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "CU63297698"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU63297698"
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "hb990002994230203941",
+        "_score": 202.45773,
+        "_source": {
+          "extent": [
+            "xi, 105 p., [1] folded leaf of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 103-105.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "subjectLiteral_exploded": [
+            "Fur trade",
+            "Fur trade -- Northwestern States",
+            "Fur trade -- Northwest, Canadian",
+            "Material culture",
+            "Material culture -- Northwestern States",
+            "Material culture -- Northwest, Canadian",
+            "Northwestern States",
+            "Northwestern States -- Antiquities",
+            "Northwest, Canadian",
+            "Northwest, Canadian -- Antiquities"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wheeler Productions"
+          ],
+          "description": [
+            "Includes an introduction to the fur trade, many illustrations of artifacts, sections on fur trade accidents, food and drink, and a listing of fur trade sites in Canada and the United States."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1985
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A toast to the fur trade : a picture essay on its material culture / by Robert C. Wheeler ; illustrations by David Christofferson ; edited by Ardis Hillman Wheeler."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Wheeler, Robert C., 1913-1986"
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "^^^84091414^"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Wheeler, Ardis Hillman"
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990002994230203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0961436212 (pbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0961436204 (hard)"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "^^^84091414^"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "12314723"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-10060378"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)12314723"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)12272687 (OCoLC)12282112 (OCoLC)12282122 (OCoLC)12321773 (OCoLC)28021603 (OCoLC)1298901854"
+            }
+          ],
+          "idOclc": [
+            "12314723",
+            "SCSB-10060378"
+          ],
+          "holdings": [],
+          "updatedAt": 1677462999158,
+          "publicationStatement": [
+            "St. Paul, MN : Wheeler Productions, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:990002994230203941",
+            "urn:isbn:0961436212 (pbk.)",
+            "urn:isbn:0961436204 (hard)",
+            "urn:lccn:^^^84091414^",
+            "urn:oclc:12314723",
+            "urn:oclc:SCSB-10060378",
+            "urn:undefined:(OCoLC)12314723",
+            "urn:undefined:(OCoLC)12272687 (OCoLC)12282112 (OCoLC)12282122 (OCoLC)12321773 (OCoLC)28021603 (OCoLC)1298901854"
+          ],
+          "idIsbn": [
+            "0961436212 (pbk.)",
+            "0961436204 (hard)"
+          ],
+          "genreForm": [
+            "History"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Fur trade -- Northwestern States.",
+            "Fur trade -- Northwest, Canadian",
+            "Material culture -- Northwestern States.",
+            "Material culture -- Northwest, Canadian.",
+            "Northwestern States -- Antiquities.",
+            "Northwest, Canadian -- Antiquities."
+          ],
+          "titleDisplay": [
+            "A toast to the fur trade : a picture essay on its material culture / by Robert C. Wheeler ; illustrations by David Christofferson ; edited by Ardis Hillman Wheeler."
+          ],
+          "uri": "hb990002994230203941",
+          "lccClassification": [
+            "F597 .W57 1985"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "St. Paul, MN"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "0961436212",
+            "0961436204"
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          202.45773,
+          "hb990002994230203941"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "hb990002994230203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:32044042656827"
+                    ],
+                    "physicalLocation": [
+                      "N.A.ARC. W 565 t"
+                    ],
+                    "shelfMark_sort": "aN.A.ARC. W 565 t",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "hi231754796330003941",
+                    "shelfMark": [
+                      "N.A.ARC. W 565 t"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "N.A.ARC. W 565 t"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32044042656827"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32044042656827"
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "TZ"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b19426830",
+        "_score": 18.766731,
+        "_source": {
+          "extent": [
+            "1 videodisc (43 min.) : sd., col. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "George Dorris introduced each speaker.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Poor image quality; commercial interruption for 10 seconds at approx. 8:30.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Related to the Selma Jeanne Cohen papers (*MGZMD 258): Series VII: Performance and lecture videos, 1977-1998.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Videography, Nina Bennahum.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Videotaped during party in the Reading Room at the Dance Collection at the New York Public Library for the Performing Arts, New York, N.Y., on Sept. 27, 1995.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "DVD.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Estate of Selma Jeanne Cohen;",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cohen, Selma Jeanne, 1920-2005"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "description": [
+            "Birthday party celebrating the 75th birthday of Selma Jeanne Cohen (dance historian, editor, teacher)."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1995
+          ],
+          "dateEndString": [
+            "0927"
+          ],
+          "title": [
+            "Selma Jeanne Cohen's 75th birthday party at the Dance Collection"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "*MGZIDVD 5-6474"
+          ],
+          "createdString": [
+            "1995"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "seriesStatement": [
+            "Selma Jeanne Cohen Archive"
+          ],
+          "contributorLiteral": [
+            "Cohen, Selma Jeanne, 1920-2005",
+            "Nichols, Madeleine M.",
+            "Dorris, George E.",
+            "Oswald, Genevieve",
+            "Anderson, Jack, 1935-2023",
+            "Reynolds, Nancy, 1938-",
+            "Green, William, 1926-",
+            "Garafola, Lynn",
+            "Bennahum, Ninotchka",
+            "New York Public Library for the Performing Arts. Dance Collection",
+            "Estate of Selma Jeanne Cohen. dnr"
+          ],
+          "dateStartYear": [
+            1995
+          ],
+          "idOclc": [
+            "764650414"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*MGZIDVD 5-6474"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "19426830"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "764650414"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)764650414"
+            }
+          ],
+          "popularity": 0,
+          "dateEndYear": [
+            927
+          ],
+          "updatedAt": 1751556471667,
+          "publicationStatement": [
+            "1995."
+          ],
+          "genreForm": [
+            "Dance.",
+            "Video.",
+            "Interviews.",
+            "Nonfiction films."
+          ],
+          "identifier": [
+            "urn:shelfmark:*MGZIDVD 5-6474",
+            "urn:bnum:19426830",
+            "urn:oclc:764650414",
+            "urn:identifier:(OCoLC)764650414"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mov",
+              "label": "Moving image"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1995"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cohen, Selma Jeanne, 1920-2005."
+          ],
+          "titleDisplay": [
+            "Selma Jeanne Cohen's 75th birthday party at the Dance Collection [videorecording] / master of ceremonies, George Dorris."
+          ],
+          "uri": "b19426830",
+          "formatId": "v",
+          "recordTypeId": "g",
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Introduction / by Madeleine Nichols and George Dorris -- Gigi Oswald -- Jack Anderson -- Nancy Reynolds -- William Green -- Selma Jeanne Cohen -- Toast / by Lynn Garafola."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          18.766731,
+          "b19426830"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b19426830",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=*MGZIDVD+5-6474&Date=1995&Form=30&Genre=archival+video+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db19426830&ItemISxN=i278701735&ItemNumber=33433070901354&ItemPublisher=1995.&Location=Performing+Arts+Dance+Division&ReferenceNumber=b194268305&Site=LPADNAMI&Title=Selma+Jeanne+Cohen%27s+75th+birthday+party+at+the+Dance+Collection&Transaction.CustomFields.MapsLocationNote=%5BDVD%5D"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:24",
+                        "label": "archival video recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:24||archival video recording"
+                    ],
+                    "formatLiteral": [
+                      "DVD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pad22",
+                        "label": "Performing Arts Research Collections - Dance"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pad22||Performing Arts Research Collections - Dance"
+                    ],
+                    "idBarcode": [
+                      "33433070901354"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*MGZIDVD 5-6474",
+                      "urn:barcode:33433070901354"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*MGZIDVD 5-6474",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433070901354",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*MGZIDVD 5-6474"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*MGZIDVD 5-6474"
+                    ],
+                    "shelfMark_sort": "a*MGZIDVD 5-006474",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i27870173"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b15994132",
+        "_score": 17.990082,
+        "_source": {
+          "extent": [
+            "1 videocassette (VHS, NTSC) (58 min.) : sd., col. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title from original container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Camera: Caro Thompson.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Videotaped at Jacob's Pillow, Becket, Mass., June 23, Aug. 3 and other dates in summer 1984.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Morris dance",
+            "Break dancing"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "description": [
+            "This tape is a compilation of footage from special events during the 1984 season at Jacob's Pillow. The first segment includes footage from opening night festivities, including performances by the Pokingbrook Morris dancers and female garland dancers. The second segment records a brief presentation by Jacob's Pillow director Liz Thompson and dance patron Irene Hunter. Thompson speaks about the first appearance by the Martha Graham company at Jacob's Pillow and her own experience as a Graham dancer, and announces the naming of a building at Jacob's Pillow for Irene Hunter. Thompson proposes an audience toast to Hunter and Graham, and Hunter proposes a toast to Thompson. The third segment on the tape includes footage from outdoor daytime Gala festivities, including performances by two clowns making balloon sculptures, stilt-walkers, and breakdancers from the Rockwell Association. The fourth segment records a raffle held after a performance by the Hubbard Street Dance Company. The segment starts with the curtain calls following the performance; Marge Champion draws seat numbers and announces prizes for members of the audience. The last segment of the tape records breakdancing by a group of children and teenagers from Pittsfield."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1984
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "title": [
+            "Jacob's Pillow. special events."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*MGZIA 4-4451"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Champion, Marge",
+            "Thompson, Caro",
+            "Jacob's Pillow Dance Festival"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "donor": [
+            "Gift of Jacob's Pillow Dance Festival."
+          ],
+          "idOclc": [
+            "NYPT04-F167"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*MGZIA 4-4451"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15994132"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPT04-F167"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)t280000016"
+            }
+          ],
+          "updatedAt": 1712867515154,
+          "publicationStatement": [
+            "1984."
+          ],
+          "genreForm": [
+            "Dance.",
+            "Video."
+          ],
+          "identifier": [
+            "urn:shelfmark:*MGZIA 4-4451",
+            "urn:bnum:15994132",
+            "urn:oclc:NYPT04-F167",
+            "urn:identifier:(WaOLN)t280000016"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mov",
+              "label": "Moving image"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Morris dance.",
+            "Break dancing."
+          ],
+          "titleDisplay": [
+            "Jacob's Pillow. 1984 [videorecording] : special events."
+          ],
+          "uri": "b15994132",
+          "formatId": "s",
+          "recordTypeId": "g",
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "June, 1984. Opening night: Morris dancers (11 min.) -- Audience toast (4 min.)",
+            "June 23, 1984. Gala festivities (19 min.)",
+            "Aug. 3, 1984. Hubbard Street raffle (8 min.)",
+            "[n.d.] Breakdancers from Pittsfield (16 min.)"
+          ],
+          "dimensions": [
+            "1/2 in."
+          ]
+        },
+        "sort": [
+          17.990082,
+          "b15994132"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15994132",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*MGZIA 4-4451",
+                      "urn:barcode:33433064016748"
+                    ],
+                    "physicalLocation": [
+                      "*MGZIA 4-4451"
+                    ],
+                    "shelfMark_sort": "a*MGZIA 4-004451",
+                    "catalogItemType_packed": [
+                      "catalogItemType:24||archival video recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=*MGZIA+4-4451&Date=1984&Form=30&Genre=archival+video+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15994132&ItemISxN=i154045846&ItemNumber=33433064016748&ItemPublisher=1984.&Location=Performing+Arts+Dance+Division&ReferenceNumber=b159941325&Site=LPADNAMI&Title=Jacob%27s+Pillow.+special+events."
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*MGZIA 4-4451"
+                    ],
+                    "uri": "i15404584",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*MGZIA 4-4451"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064016748"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pad22||Performing Arts Research Collections - Dance"
+                    ],
+                    "idBarcode": [
+                      "33433064016748"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:24",
+                        "label": "archival video recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Moving image"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pad22",
+                        "label": "Performing Arts Research Collections - Dance"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b17948355",
+        "_score": 17.798214,
+        "_source": {
+          "extent": [
+            "1 videodisc (130 min.) : sound, color ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Adaptation of the play by David Storey.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Videodisc release of the 1975 British motion picture by American Film Theatre.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Special features: interview with Alan Bates; interview with David Storey; \"David Storey and In celebration\" an essay by Michael Feingold; AFT Cinebill; stills gallery; AFT scrapbook.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Executive producer, Otto Plaschkes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Alan Bates, James Bolam, Brian Cox, Constance Chapman, Gabrielle Daye, Bill Owen.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "MPAA rating: PG.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "DVD, NTSC, Region 1; letterboxed (1.85:1); monaural.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Forms part of the Theatre on Film and Tape Archive, Billy Rose Theatre Division.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Storey, David, 1933-2017",
+            "Storey, David, 1933-2017 -- Film adaptations",
+            "1900-1999",
+            "Working class families",
+            "Working class families -- England",
+            "Working class families -- England -- Yorkshire",
+            "Working class families -- England -- Yorkshire -- Drama",
+            "Families",
+            "Families -- England",
+            "Families -- England -- Yorkshire",
+            "Families -- England -- Yorkshire -- Drama",
+            "Brothers",
+            "Brothers -- England",
+            "Brothers -- England -- Yorkshire",
+            "Brothers -- England -- Yorkshire -- Drama",
+            "Manners and customs",
+            "Yorkshire (England)",
+            "Yorkshire (England) -- Social life and customs",
+            "Yorkshire (England) -- Social life and customs -- 20th century",
+            "Yorkshire (England) -- Social life and customs -- 20th century -- Drama",
+            "England",
+            "England -- Social life and customs",
+            "England -- Social life and customs -- 20th century",
+            "England -- Social life and customs -- 20th century -- Drama",
+            "England -- Yorkshire"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kino on Video"
+          ],
+          "description": [
+            "Three sons return to the primitive Yorkshire mining town of their birth to celebrate their parents' fortieth wedding anniversary. During the celebration, their submerged hatreds and fears emerge from behind their model blue collar family facade."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            2003
+          ],
+          "dateEndString": [
+            "1975"
+          ],
+          "title": [
+            "In celebration"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "NCOX 2003"
+          ],
+          "createdString": [
+            "2003"
+          ],
+          "idLccn": [
+            "738329029029"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "seriesStatement": [
+            "American film theatre collection ; 2"
+          ],
+          "contributorLiteral": [
+            "Landau, Ely",
+            "Storey, David, 1933-2017",
+            "Bates, Alan, 1934-2003",
+            "Cox, Brian, 1946-",
+            "Anderson, Lindsay, 1923-1994",
+            "Bolam, James, 1935-",
+            "Chapman, Constance, 1912-2003",
+            "Daye, Gabrielle, 1911-2005",
+            "Owen, Bill, 1914-1999",
+            "Ely Landau Organization",
+            "Cinevision (Firm)",
+            "American Film Theatre",
+            "Kino International Corporation"
+          ],
+          "dateStartYear": [
+            2003
+          ],
+          "idOclc": [
+            "52778462"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NCOX 2003"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "17948355"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "52778462"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "738329029029"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "K290 DVD Kino on Video"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)52778462"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)178797157 (OCoLC)671677241 (OCoLC)964418821 (OCoLC)980803395 (OCoLC)1006448934 (OCoLC)1020435485 (OCoLC)1037244606 (OCoLC)1043512195 (OCoLC)1050157347 (OCoLC)1059484844 (OCoLC)1066125835 (OCoLC)1104896887"
+            }
+          ],
+          "popularity": 0,
+          "uniformTitle": [
+            "American film theatre. Collection 2."
+          ],
+          "dateEndYear": [
+            1975
+          ],
+          "updatedAt": 1748641800781,
+          "publicationStatement": [
+            "New York, NY : Kino on Video, [2003]"
+          ],
+          "genreForm": [
+            "Feature films.",
+            "Biographical films.",
+            "Drama.",
+            "Film adaptations."
+          ],
+          "identifier": [
+            "urn:shelfmark:NCOX 2003",
+            "urn:bnum:17948355",
+            "urn:oclc:52778462",
+            "urn:lccn:738329029029",
+            "urn:identifier:K290 DVD Kino on Video",
+            "urn:identifier:(OCoLC)52778462",
+            "urn:identifier:(OCoLC)178797157 (OCoLC)671677241 (OCoLC)964418821 (OCoLC)980803395 (OCoLC)1006448934 (OCoLC)1020435485 (OCoLC)1037244606 (OCoLC)1043512195 (OCoLC)1050157347 (OCoLC)1059484844 (OCoLC)1066125835 (OCoLC)1104896887"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mov",
+              "label": "Moving image"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2003"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Storey, David, 1933-2017 -- Film adaptations.",
+            "Storey, David, 1933-2017",
+            "1900-1999",
+            "Working class families -- England -- Yorkshire -- Drama.",
+            "Families -- England -- Yorkshire -- Drama.",
+            "Brothers -- England -- Yorkshire -- Drama.",
+            "Brothers.",
+            "Families.",
+            "Manners and customs.",
+            "Working class families.",
+            "Yorkshire (England) -- Social life and customs -- 20th century -- Drama.",
+            "England -- Social life and customs -- 20th century -- Drama.",
+            "England.",
+            "England -- Yorkshire."
+          ],
+          "titleDisplay": [
+            "In celebration / the Ely Landau Organization, Inc. and Cinevision Ltée present The American Film Theatre ; produced by Ely Landau ; directed by Lindsay Anderson ; written by David Storey."
+          ],
+          "uri": "b17948355",
+          "lccClassification": [
+            "PN1997 .I475 2003"
+          ],
+          "electronicResources": [
+            {
+              "label": "Connect to IMDb information for this film",
+              "url": "http://www.imdb.com/title/tt0073158/"
+            }
+          ],
+          "formatId": "v",
+          "recordTypeId": "g",
+          "placeOfPublication": [
+            "New York, NY"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "David Storey's In celebration"
+          ],
+          "tableOfContents": [
+            "\"Hello Dad!\" \"Hello Mom!\" \"How does it feel to be home?\" Human hygiene \"Not my cup of tea\" Memories The truth A toast \"Family analysis\" \"What's going on?\" Andrew's vengeance \"We all have our problems\" Choices."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          17.798214,
+          "b17948355"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b17948355",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=NCOX+2003&Date=2003&Form=30&Genre=archival+video+recording&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db17948355&ItemISxN=i315887023&ItemNumber=33433063602100&ItemPlace=New+York%2C+NY&ItemPublisher=Kino+on+Video%2C+%5B2003%5D&Location=Performing+Arts+Theatre+on+Film+and+Tape+Archive&ReferenceNumber=b179483559&Site=LPATF&Title=In+celebration&Transaction.CustomFields.Custom651=England+Yorkshire.+fast+%28OCoLC%29fst01213252"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:24",
+                        "label": "archival video recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:24||archival video recording"
+                    ],
+                    "formatLiteral": [
+                      "DVD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:paf28",
+                        "label": "Performing Arts Research Collections - TOFT"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:paf28||Performing Arts Research Collections - TOFT"
+                    ],
+                    "idBarcode": [
+                      "33433063602100"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NCOX 2003",
+                      "urn:barcode:33433063602100"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "NCOX 2003",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433063602100",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "NCOX 2003"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "NCOX 2003"
+                    ],
+                    "shelfMark_sort": "aNCOX 002003",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i31588702"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b22159817",
+        "_score": 17.611923,
+        "_source": {
+          "extent": [
+            "1 videodisc (28 min.) : sound, color and black and white ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "This disc is a recorded DVD and may not play on all DVD players or drives.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "At head of title: A profile.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Documentary originally made in the late '90s.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Summary from videodisc container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Source used: videodisc container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Producer, Claudia Schadeberg ; cinematographer, Jurgen Schadeberg ; editor, Jurgen Schadeberg ; the Schadeberg Movie Company ; commissioned by NNTV.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "DVD-R, NTSC.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Narrated in English; musical numbers sung in English or Zulu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Rathebe, Dolly",
+            "African Inkspots (Musical group)",
+            "Singers",
+            "Singers -- South Africa",
+            "Singers -- South Africa -- 20th century",
+            "Singers -- South Africa -- 20th century -- Biography",
+            "Popular music",
+            "Popular music -- South Africa",
+            "Popular music -- South Africa -- 20th century",
+            "Jazz",
+            "Jazz -- South Africa",
+            "Jazz -- South Africa -- 20th century",
+            "Doo-wop (Music)",
+            "Doo-wop (Music) -- South Africa",
+            "Doo-wop (Music) -- South Africa -- 20th century",
+            "Music",
+            "Music -- Social aspects",
+            "Music -- Social aspects -- South Africa",
+            "Music -- Social aspects -- South Africa -- 20th century",
+            "Apartheid",
+            "Apartheid -- South Africa"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Villon Films"
+          ],
+          "description": [
+            "One of the most dynamic singing combinations to emerge in the early fifties was Dolly Rathebe and the African Inkspots. They were the toast of Sof'town, getting star billing in musical shows round the country and appearing in feature films such as 'Jim Comes to Jo'burg', 'The Magic Garden' and 'Song of Africa'. Our documentary pays tribute to the talents of these jazz greats who have made such a valuable contribution to the musical heritage of South Africa."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2006
+          ],
+          "buildingLocationIds": [
+            "sc"
+          ],
+          "dateEndString": [
+            "199u"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dolly and the Inkspots"
+          ],
+          "shelfMark": [
+            "Sc Visual DVD-230 "
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2006"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Schadeberg, Jurgen, 1931-2020",
+            "Schadeberg, Claudia",
+            "Rathebe, Dolly",
+            "African Inkspots (Musical group)",
+            "Schadeberg Movie Company, production company",
+            "NNTV (Television station : Johannesburg, South Africa)",
+            "Villon Films"
+          ],
+          "dateStartYear": [
+            2006
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Visual DVD-230 "
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22159817"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "85443392"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)85443392"
+            }
+          ],
+          "idOclc": [
+            "85443392"
+          ],
+          "dateEndYear": [
+            199
+          ],
+          "updatedAt": 1712871275453,
+          "publicationStatement": [
+            "Vancouver, B.C. : Villon Films, [2006?]"
+          ],
+          "identifier": [
+            "urn:shelfmark:Sc Visual DVD-230 ",
+            "urn:bnum:22159817",
+            "urn:oclc:85443392",
+            "urn:identifier:(OCoLC)85443392"
+          ],
+          "genreForm": [
+            "Documentary television programs.",
+            "Nonfiction television programs."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mov",
+              "label": "Moving image"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2006"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Rathebe, Dolly.",
+            "African Inkspots (Musical group)",
+            "Singers -- South Africa -- 20th century -- Biography.",
+            "Popular music -- South Africa -- 20th century.",
+            "Jazz -- South Africa -- 20th century.",
+            "Doo-wop (Music) -- South Africa -- 20th century.",
+            "Music -- Social aspects -- South Africa -- 20th century.",
+            "Apartheid -- South Africa."
+          ],
+          "titleDisplay": [
+            "Dolly and the Inkspots/ directed by Jurgen Schadeberg."
+          ],
+          "uri": "b22159817",
+          "lccClassification": [
+            "ML410.R227 P76 2006"
+          ],
+          "formatId": "v",
+          "recordTypeId": "g",
+          "placeOfPublication": [
+            "Vancouver, B.C."
+          ],
+          "titleAlt": [
+            "Dolly & the Inkspots",
+            "A profile, Dolly and the Inkspots"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          17.611923,
+          "b22159817"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b22159817",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1117",
+                        "label": "Schomburg Center for Research in Black Culture, Moving Image and Recorded Sound Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc Visual DVD-230",
+                      "urn:barcode:33433124442363"
+                    ],
+                    "physicalLocation": [
+                      "Sc Visual DVD-230"
+                    ],
+                    "shelfMark_sort": "aSc Visual DVD-000230",
+                    "catalogItemType_packed": [
+                      "catalogItemType:11||videorecording, non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=Sc+Visual+DVD-230&Date=2006&Form=30&Genre=videorecording%2C+non-circ&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db22159817&ItemISxN=i378752017&ItemNumber=33433124442363&ItemPlace=Vancouver%2C+B.C.&ItemPublisher=Villon+Films%2C+%5B2006%3F%5D&Location=Schomburg+Moving+Image+and+Recorded+Sound&ReferenceNumber=b221598170&Site=SCHMIRS&Title=Dolly+and+the+Inkspots"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "Sc Visual DVD-230"
+                    ],
+                    "uri": "i37875201",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Sc Visual DVD-230"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124442363"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scbb2||Schomburg Center - Moving Image & Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433124442363"
+                    ],
+                    "owner_packed": [
+                      "orgs:1117||Schomburg Center for Research in Black Culture, Moving Image and Recorded Sound Division"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:11",
+                        "label": "videorecording, non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Moving image"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scbb2",
+                        "label": "Schomburg Center - Moving Image & Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b15316446",
+        "_score": 17.262974,
+        "_source": {
+          "extent": [
+            "v. ; 24 cm."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Conservatism",
+            "Conservatism -- United States"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Conservative Book Club"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1964
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Omnibus."
+          ],
+          "shelfMark": [
+            "L-11 536"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Taylor, Henry J. (Henry Junior), 1902-1984",
+            "Shadegg, Stephen C",
+            "Lewis, C. S. (Clive Staples), 1898-1963",
+            "Wills, Garry, 1934-"
+          ],
+          "addedAuthorTitle": [
+            "Big man.",
+            "How to win an election.",
+            "Screwtape proposes a toast.",
+            "Convenient state."
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "L-11 536"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15316446"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "2868147"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)R130000021"
+            }
+          ],
+          "idOclc": [
+            "2868147"
+          ],
+          "popularity": 1,
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1729004254378,
+          "publicationStatement": [
+            "New Rochelle, N.Y. : Conservative Book Club, c1964-"
+          ],
+          "identifier": [
+            "urn:shelfmark:L-11 536",
+            "urn:bnum:15316446",
+            "urn:oclc:2868147",
+            "urn:identifier:(WaOLN)R130000021"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Conservatism -- United States."
+          ],
+          "titleDisplay": [
+            "Omnibus."
+          ],
+          "uri": "b15316446",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New Rochelle, N.Y."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "v. 1 The big man, by H.J. Taylor. - How to win an election, by S.C. Shadegg. - Screwtape proposes a toast, by C.S. Lewis. - The convenient state,   by G. Wills."
+          ]
+        },
+        "sort": [
+          17.262974,
+          "b15316446"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15316446",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:L-11 536 v. 5",
+                      "urn:barcode:33433002566952"
+                    ],
+                    "physicalLocation": [
+                      "L-11 536"
+                    ],
+                    "shelfMark_sort": "aL-11 536 v. 000005",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "enumerationChronology_sort": [
+                      "         5-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "L-11 536 v. 5"
+                    ],
+                    "uri": "i12377117",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "L-11 536 v. 5"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002566952"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "idBarcode": [
+                      "33433002566952"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 5,
+                        "lte": 5
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         5-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b14565371",
+        "_score": 17.212198,
+        "_source": {
+          "extent": [
+            "3 v. : music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Music for piano, with directions for the dances.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Folk dance music",
+            "Folk dance music -- Scandinavia",
+            "Folk dancing",
+            "Folk dancing -- Scandinavia",
+            "Piano music, Arranged"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ling Physical Education Association"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            198
+          ],
+          "dateEndString": [
+            "1989"
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "title": [
+            "Scandinavian dance music."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*MGS (Scandinavian) 00-3559"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "198"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            198
+          ],
+          "idOclc": [
+            "8946872",
+            "NYPY00-C7"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*MGS (Scandinavian) 00-3559"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "14565371"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "8946872"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPY00-C7"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)Y210000097"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)8946872"
+            }
+          ],
+          "dateEndYear": [
+            1989
+          ],
+          "updatedAt": 1711179616873,
+          "publicationStatement": [
+            "London : Ling Physical Education Association, [19--]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*MGS (Scandinavian) 00-3559",
+            "urn:bnum:14565371",
+            "urn:oclc:8946872",
+            "urn:oclc:NYPY00-C7",
+            "urn:identifier:(WaOLN)Y210000097",
+            "urn:identifier:(OCoLC)8946872"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "198"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Folk dance music -- Scandinavia.",
+            "Folk dancing -- Scandinavia.",
+            "Piano music, Arranged."
+          ],
+          "titleDisplay": [
+            "Scandinavian dance music."
+          ],
+          "uri": "b14565371",
+          "formatId": "c",
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "First series: Shoemaker ; Cochin China ; Ace of diamonds ; Mountain march ; Clap dance ; Little man in a fix ; French reel ; Swedish schottische ; Rospiggspolska ; Varsovienne ; Toast to King Gustav ; Oxdansen.",
+            "Second series: Mangling ; The bow ; Matrosdans ; Girls' joy ; Kontramarsch ; Napoleon ; Tantoli ; Gallopink ; Kontrasejre ; Finger polka ; Hornfiffen ; Swedish masquerade."
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          17.212198,
+          "b14565371"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b14565371",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*MGS (Scandinavian) 00-3559 Library has: 1st-2nd series",
+                      "urn:barcode:33433093051658"
+                    ],
+                    "physicalLocation": [
+                      "*MGS (Scandinavian) 00-3559 Library has: 1st-2nd series"
+                    ],
+                    "shelfMark_sort": "a*MGS (Scandinavian) 00-3559 Library has: 1st-2nd series",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*MGS (Scandinavian) 00-3559 Library has: 1st-2nd series"
+                    ],
+                    "uri": "i17050295",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*MGS (Scandinavian) 00-3559 Library has: 1st-2nd series"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093051658"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pad32||Performing Arts Research Collections - Dance"
+                    ],
+                    "idBarcode": [
+                      "33433093051658"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pad32",
+                        "label": "Performing Arts Research Collections - Dance"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b21867386",
+        "_score": 16.866467,
+        "_source": {
+          "extent": [
+            "1 online resource (1 sound file)."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Synopsis in English ([3] p.) inserted.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded in France in 1969.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Description based on hard copy version record.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Angel"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            2000
+          ],
+          "buildingLocationIds": [],
+          "dateEndString": [
+            "1969"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Carmen highlights"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2000"
+          ],
+          "creatorLiteral": [
+            "Bizet, Georges, 1838-1875"
+          ],
+          "idLccn": [
+            "GBAYC9902571",
+            "GBAYC9902572",
+            "GBAYC9902573",
+            "GBAYC9902574",
+            "GBAYC9902575",
+            "GBAYC9902576",
+            "GBAYC9902561",
+            "GBAYC9902562",
+            "GBAYC9902563",
+            "GBAYC9902565",
+            "GBAYC9902566",
+            "GBAYC9902567",
+            "GBAYC9902568",
+            "GBAYC9902569",
+            "GBAYC9902564",
+            "GBAYC9902570"
+          ],
+          "seriesStatement": [
+            "Seraphim classics. Opera"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "contributorLiteral": [
+            "Meilhac, Henri, 1831-1897",
+            "Halévy, Ludovic, 1834-1908",
+            "Bumbry, Grace, 1937-2023",
+            "Vickers, Jon",
+            "Freni, Mirella, 1935-2020",
+            "Frühbeck de Burgos, Rafael",
+            "Opéra de Paris"
+          ],
+          "dateStartYear": [
+            2000
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "21867386"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "840331538"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902571"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902572"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902573"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902574"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902575"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902576"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902561"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902562"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902563"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902565"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902566"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902567"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902568"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902569"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902564"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9902570"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "0724357412759 EMI Classics"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)840331538"
+            }
+          ],
+          "idOclc": [
+            "840331538"
+          ],
+          "uniformTitle": [
+            "Carmen. Selections",
+            "Seraphim classics. Opera."
+          ],
+          "dateEndYear": [
+            1969
+          ],
+          "updatedAt": 1711268707082,
+          "publicationStatement": [
+            "Hollywood, Calif. : Angel, [2000], p1970."
+          ],
+          "identifier": [
+            "urn:bnum:21867386",
+            "urn:oclc:840331538",
+            "urn:lccn:GBAYC9902571",
+            "urn:lccn:GBAYC9902572",
+            "urn:lccn:GBAYC9902573",
+            "urn:lccn:GBAYC9902574",
+            "urn:lccn:GBAYC9902575",
+            "urn:lccn:GBAYC9902576",
+            "urn:lccn:GBAYC9902561",
+            "urn:lccn:GBAYC9902562",
+            "urn:lccn:GBAYC9902563",
+            "urn:lccn:GBAYC9902565",
+            "urn:lccn:GBAYC9902566",
+            "urn:lccn:GBAYC9902567",
+            "urn:lccn:GBAYC9902568",
+            "urn:lccn:GBAYC9902569",
+            "urn:lccn:GBAYC9902564",
+            "urn:lccn:GBAYC9902570",
+            "urn:identifier:0724357412759 EMI Classics",
+            "urn:identifier:(OCoLC)840331538"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2000"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Carmen [electronic resource] : highlights / Bizet ; [libretto by Henri Meilhac & Ludovic Halévy]."
+          ],
+          "uri": "b21867386",
+          "lccClassification": [
+            "M1505.B594 C375 2000"
+          ],
+          "electronicResources": [
+            {
+              "label": "Access Naxos Music Library",
+              "url": "https://nypl.naxosmusiclibrary.com/catalogue/item.asp?cid=0724357412759"
+            }
+          ],
+          "formatId": "w",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Hollywood, Calif."
+          ],
+          "titleAlt": [
+            "Carmen."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Prélude -- Quand je vous amerais? L'amour est un oiseau rebelle : habanera -- Entr'acte -- Votre toast, je peux vous le rendre : song of the Toréador -- Le fleur que tu m'avais jetée : flower song -- Entr'acte -- Mêlons! coupons! -- Entr'acte."
+          ]
+        },
+        "sort": [
+          16.866467,
+          "b21867386"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b23461378",
+        "_score": 16.787134,
+        "_source": {
+          "extent": [
+            "1 audio disc : digital ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Program notes and synopsis by Paul Myers on container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded in 1961",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Musicals",
+            "Musicals -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Master Classics Records"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            2011
+          ],
+          "dateEndString": [
+            "1961"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Donnybrook! : Original Broadway cast"
+          ],
+          "shelfMark": [
+            "*LDC 29457"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2011"
+          ],
+          "creatorLiteral": [
+            "Burke, Johnny, 1908-1964"
+          ],
+          "idLccn": [
+            "885686538319"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Foy, Eddie, 1905-1983",
+            "Lund, Art",
+            "Warnick, Clay, 1915-1995"
+          ],
+          "dateStartYear": [
+            2011
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 29457"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "23461378"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "851182950"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "885686538319"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)851182950"
+            }
+          ],
+          "idOclc": [
+            "851182950"
+          ],
+          "popularity": 0,
+          "uniformTitle": [
+            "Donnybrook! Selections"
+          ],
+          "dateEndYear": [
+            1961
+          ],
+          "updatedAt": 1731595883943,
+          "publicationStatement": [
+            "[Place of publication not identified] : Master Classics Records, [2011]",
+            "©1961"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 29457",
+            "urn:bnum:23461378",
+            "urn:oclc:851182950",
+            "urn:lccn:885686538319",
+            "urn:identifier:(OCoLC)851182950"
+          ],
+          "genreForm": [
+            "Musicals."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2011"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Musicals -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Donnybrook! : Original Broadway cast / music and lyrics by Johnny Burke."
+          ],
+          "uri": "b23461378",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[Place of publication not identified]"
+          ],
+          "titleAlt": [
+            "Donnybrook!"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Overture -- Sez I -- The day the snow is meltin' -- Sad was the day -- Donnybrook -- Ellen Roe -- The loveable Irish -- I wouldn't bet one penny -- He makes me feel I'm lovely -- I have my own way -- A toast to the bride -- Wishawurra -- A quiet life -- Mr. Flynn -- Dee-lightful is the word -- For my own -- Finale."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          16.787134,
+          "b23461378"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b23461378",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 29457",
+                      "urn:barcode:33433016013462"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 29457"
+                    ],
+                    "shelfMark_sort": "a*LDC 029457",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Burke%2C+Johnny%2C+1908-1964&CallNumber=*LDC+29457&Date=2011&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db23461378&ItemISxN=i413511352&ItemNumber=33433016013462&ItemPlace=%5BPlace+of+publication+not+identified%5D&ItemPublisher=%C2%A91961&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b234613786&Site=LPAMRAMI&Title=Donnybrook%21+%3A+Original+Broadway+cast"
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 29457"
+                    ],
+                    "uri": "i41351135",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 29457"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433016013462"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433016013462"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Audio"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16745415",
+        "_score": 16.782803,
+        "_source": {
+          "extent": [
+            "1 sound disc : analog, 33 1/3 rpm, stereo. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Popular songs.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Loaned for promotion only - not for sale\"--Container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program and biographical notes by Lee Hildebrand on container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded live at the Whisky-a-Go-Go, Oct. 12, 1973, and at the Summit, Aug. 23, 1972, in Los Angeles.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Soul music",
+            "Popular music",
+            "Popular music -- 1981-1990"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Stax"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1988
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1972"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The Dramatics live"
+          ],
+          "shelfMark": [
+            "*LZR 1681 (C)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1988"
+          ],
+          "creatorLiteral": [
+            "Dramatics (Musical group) prf"
+          ],
+          "idLccn": [
+            "95785347"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1988
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LZR 1681 (C)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16745415"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "19036373"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "95785347"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "MPS 8545 Stax"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A240000050"
+            }
+          ],
+          "idOclc": [
+            "19036373"
+          ],
+          "dateEndYear": [
+            1972
+          ],
+          "updatedAt": 1712869232376,
+          "publicationStatement": [
+            "Berkeley, Calif. : Stax, p1988."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LZR 1681 (C)",
+            "urn:bnum:16745415",
+            "urn:oclc:19036373",
+            "urn:lccn:95785347",
+            "urn:identifier:MPS 8545 Stax",
+            "urn:identifier:(WaOLN)A240000050"
+          ],
+          "genreForm": [
+            "Live sound recordings."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1988"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Soul music.",
+            "Popular music -- 1981-1990."
+          ],
+          "titleDisplay": [
+            "The Dramatics live [sound recording] / the Dramatics."
+          ],
+          "uri": "b16745415",
+          "formatId": "j",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Berkeley, Calif."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Intro (:32) -- Get up and get down (3:02) -- Thankful for your love (5:10) -- This guy's in love with you (4:37) -- Respect yourself (3:41) -- That's the way I feel about cha (5:32) -- Toast to the pool (5:50) -- In the rain (5:53) -- Whatcha see is whatcha get (6:35)."
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          16.782803,
+          "b16745415"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16745415",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LZR 1681 (C) [Disc]",
+                      "urn:barcode:33433068003650"
+                    ],
+                    "physicalLocation": [
+                      "*LZR 1681 (C) [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LZR 1681 (C) [Disc]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Dramatics+%28Musical+group%29+prf&CallNumber=*LZR+1681+%28C%29+%5BDisc%5D&Date=1988&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16745415&ItemISxN=i174264379&ItemNumber=33433068003650&ItemPlace=Berkeley%2C+Calif.&ItemPublisher=Stax%2C+p1988.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b167454158&Site=LPAMRAMI&Title=The+Dramatics+live"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LZR 1681 (C) [Disc]"
+                    ],
+                    "uri": "i17426437",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LZR 1681 (C) [Disc]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433068003650"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433068003650"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b14725291",
+        "_score": 16.682514,
+        "_source": {
+          "extent": [
+            "1 sound disc (50 min.) : digital ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes by Tony Thomas and Len Engel ([8] p. : ill.) inserted in container.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Motion picture music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Varèse Sarabande"
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1985
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "title": [
+            "The Blue Max original motion picture soundtrack"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LDC 23438 (F)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "creatorLiteral": [
+            "Goldsmith, Jerry"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "idOclc": [
+            "15721299"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 23438 (F)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "14725291"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "15721299"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "VCD 47238 Varèse Sarabande"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M210000192"
+            }
+          ],
+          "uniformTitle": [
+            "Blue Max. Selections",
+            "Blue Max (Motion picture)"
+          ],
+          "updatedAt": 1711045755251,
+          "publicationStatement": [
+            "North Hollywood, Calif. : Varèse Sarabande, p1985."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 23438 (F)",
+            "urn:bnum:14725291",
+            "urn:oclc:15721299",
+            "urn:identifier:VCD 47238 Varèse Sarabande",
+            "urn:identifier:(WaOLN)M210000192"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Motion picture music."
+          ],
+          "titleDisplay": [
+            "The Blue Max [sound recording] : original motion picture soundtrack / music composed and conducted by Jerry Goldsmith."
+          ],
+          "uri": "b14725291",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "North Hollywood, Calif."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Blue Max."
+          ],
+          "tableOfContents": [
+            "Main title -- The new arrival -- First blood -- The first victory -- The victim -- A toast to Bruno -- The attack, parts I & II -- A lonely hero -- A small favor -- The lovers -- Finale, part I -- Prelude, part II -- The bridge -- Stachel's confession -- Retreat, parts I & II -- Stachel in Berlin, parts I & II -- Kaeti has a plan -- Stachel's last flight -- End title."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          16.682514,
+          "b14725291"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b14725291",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 23438 (F)",
+                      "urn:barcode:33433047707090"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 23438 (F)"
+                    ],
+                    "shelfMark_sort": "a*LDC 23438 (F)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 23438 (F)"
+                    ],
+                    "uri": "i14506177",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 23438 (F)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433047707090"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433047707090"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16739633",
+        "_score": 16.682514,
+        "_source": {
+          "extent": [
+            "1 sound disc (55 min.) : analog, 33 1/3 rpm, stereo. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Excerpts from the original soundtrack of the film by Francesco Rosi.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Digital recording.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts",
+            "Motion picture music",
+            "Motion picture music -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Erato ; RCA Records [distributor]"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1984
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Carmen (excerpts)"
+          ],
+          "shelfMark": [
+            "*LSRX 15843"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [
+            "Bizet, Georges, 1838-1875"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Migenes-Johnson, Julia",
+            "Domingo, Plácido, 1941-",
+            "Raimondi, Ruggero",
+            "Esham, Faith",
+            "Daniel, Susan",
+            "Watson, Lillian",
+            "Bogart, John-Paul",
+            "Le Roux, François",
+            "Maazel, Lorin, 1930-2014",
+            "Orchestre national de France"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LSRX 15843"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16739633"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11575926"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "HBC1-5302 Erato"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A110000037"
+            }
+          ],
+          "idOclc": [
+            "11575926"
+          ],
+          "uniformTitle": [
+            "Carmen. Selections"
+          ],
+          "updatedAt": 1712869129476,
+          "publicationStatement": [
+            "[France] : Erato ; New York : RCA Records [distributor], c1984."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LSRX 15843",
+            "urn:bnum:16739633",
+            "urn:oclc:11575926",
+            "urn:identifier:HBC1-5302 Erato",
+            "urn:identifier:(WaOLN)A110000037"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts.",
+            "Motion picture music -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Carmen [sound recording] : (excerpts) / Georges Bizet."
+          ],
+          "uri": "b16739633",
+          "formatId": "j",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[France] : New York"
+          ],
+          "titleAlt": [
+            "Carmen."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Habanera : \"L'amour est un oiseau rebelle\" -- Duo : \"Parle-moi de ma mère\" -- Séguedille et duo : \"Près des remparts de Séville\" -- Chanson bohème : \"Les tringles des sistres tintaient\" -- Couplets : \"Votre toast, je peux vous le rendre\" -- \"La fleur que tu m'avais jetée\" -- Air : \"Je dis que rien ne m'épouvante\" -- Marche et chœur final : \"C'est toi?\" -- \"C'est moi!\""
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          16.682514,
+          "b16739633"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16739633",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LSRX 15843 [Disc]",
+                      "urn:barcode:33433067981898"
+                    ],
+                    "physicalLocation": [
+                      "*LSRX 15843 [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LSRX 15843 [Disc]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Bizet%2C+Georges%2C+1838-1875.&CallNumber=*LSRX+15843+%5BDisc%5D&Date=1984&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16739633&ItemISxN=i174199776&ItemNumber=33433067981898&ItemPlace=%5BFrance%5D+%3A+New+York&ItemPublisher=Erato+%3B+RCA+Records+%5Bdistributor%5D%2C+c1984.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b16739633x&Site=LPAMRAMI&Title=Carmen+%28excerpts%29"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LSRX 15843 [Disc]"
+                    ],
+                    "uri": "i17419977",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LSRX 15843 [Disc]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433067981898"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433067981898"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16319759",
+        "_score": 16.302696,
+        "_source": {
+          "extent": [
+            "1 sound disc : analog, 33 1/3 rpm, stereo. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Rhythm and blues music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "All selections by Tony Hester except as indicated.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"All selections previously released as Volt singles\"--Container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes by Jack Sbarbori on container.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Rhythm and blues music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Stax"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1984
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "title": [
+            "The best of the Dramatics"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LSRX 17345 (C)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [
+            "Dramatics (Musical group) prf"
+          ],
+          "idLccn": [
+            "95785357"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Hester, Tony"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "idOclc": [
+            "13676631"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LSRX 17345 (C)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16319759"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "13676631"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "95785357"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "MPS-8526 Stax"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A280000022"
+            }
+          ],
+          "updatedAt": 1712868370066,
+          "publicationStatement": [
+            "Berkeley, Calif. : Stax, p1984."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LSRX 17345 (C)",
+            "urn:bnum:16319759",
+            "urn:oclc:13676631",
+            "urn:lccn:95785357",
+            "urn:identifier:MPS-8526 Stax",
+            "urn:identifier:(WaOLN)A280000022"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Rhythm and blues music."
+          ],
+          "titleDisplay": [
+            "The best of the Dramatics [sound recording]."
+          ],
+          "uri": "b16319759",
+          "formatId": "j",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Berkeley, Calif."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Whatcha see is whatcha get (3:32) -- Thankful for your love (4:25) -- Get up and get down (3:10) -- Fall in love lady love (3:34) -- And I panicked / Jimmy Roach (3:34) -- In the rain (5:08) -- Toast to the fool / Snyder-Davis (4:13) -- Hey you! Get off my mountain (3:28) -- Fell for you (3:12) -- The Devil is dope (3:38)."
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          16.302696,
+          "b16319759"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16319759",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LSRX 17345 (C) [Disc]",
+                      "urn:barcode:33433035629520"
+                    ],
+                    "physicalLocation": [
+                      "*LSRX 17345 (C) [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LSRX 17345 (C) [Disc]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Dramatics+%28Musical+group%29+prf&CallNumber=*LSRX+17345+%28C%29+%5BDisc%5D&Date=1984&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16319759&ItemISxN=i156311252&ItemNumber=33433035629520&ItemPlace=Berkeley%2C+Calif.&ItemPublisher=Stax%2C+p1984.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b163197593&Site=LPAMRAMI&Title=The+best+of+the+Dramatics"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LSRX 17345 (C) [Disc]"
+                    ],
+                    "uri": "i15631125",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LSRX 17345 (C) [Disc]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433035629520"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433035629520"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b15562608",
+        "_score": 15.957559,
+        "_source": {
+          "extent": [
+            "1 sound disc : digital, stereo. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes in English, French, German and Italian and texts with German translations (23 p.) inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Südfunk-Chor ; Rupert Huber, Eric Ericson, Helmut Wolf, conductors.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded 1979-1992, Süddeutschen Rundfunks Stuttgart.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in Latin and Italian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Choruses, Sacred, Unaccompanied",
+            "Choruses, Secular (Mixed voices, 4 parts) with piano",
+            "Choruses, Secular (Men's voices)",
+            "Vocal quartets"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Carus"
+          ],
+          "language": [
+            {
+              "id": "lang:ita",
+              "label": "Italian"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1993
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1979"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "I gondolieri Chor- und Ensemblemusik"
+          ],
+          "shelfMark": [
+            "*LDC 28973"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1993"
+          ],
+          "creatorLiteral": [
+            "Rossini, Gioacchino, 1792-1868"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Huber, Rupert",
+            "Ericson, Eric, 1918-2013",
+            "Wolf, Helmut, 1939-"
+          ],
+          "dateStartYear": [
+            1993
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 28973"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15562608"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "48950194"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "83.127 Carus"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M300000523"
+            }
+          ],
+          "idOclc": [
+            "48950194"
+          ],
+          "uniformTitle": [
+            "Péchés de vieillesse. Selections"
+          ],
+          "dateEndYear": [
+            1979
+          ],
+          "updatedAt": 1712866804867,
+          "publicationStatement": [
+            "Stuttgart : Carus, c1993."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 28973",
+            "urn:bnum:15562608",
+            "urn:oclc:48950194",
+            "urn:identifier:83.127 Carus",
+            "urn:identifier:(WaOLN)M300000523"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1993"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Choruses, Sacred, Unaccompanied.",
+            "Choruses, Secular (Mixed voices, 4 parts) with piano.",
+            "Choruses, Secular (Men's voices)",
+            "Vocal quartets."
+          ],
+          "titleDisplay": [
+            "I gondolieri [sound recording] : Chor- und Ensemblemusik / Gioachino Rossini."
+          ],
+          "uri": "b15562608",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Stuttgart"
+          ],
+          "titleAlt": [
+            "Péchés de vieillesse."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Cantemus Domino (2:41) -- Il candore in fuga (1:58) -- Eja mater (4:19) -- O salutaris hostia (3:13) -- Le fede (3:22) -- La speranza (4:33) -- La carità (4:27) -- Choeur de chasseurs démocrates (4:10) -- Choeur (4:18) -- Preghiera (4:46) -- Brindisi (1:45) -- I Gondolieri (4:28) -- La passeggiata (5:40) -- Toast pour le nouvel an (2:23) -- O giorno sereno (5:11) -- Quartetto pastorale (4:48) -- Il Carnevale (2:29)."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          15.957559,
+          "b15562608"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15562608",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 28973 [Notes]",
+                      "urn:barcode:33433016107595"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 28973 [Notes]"
+                    ],
+                    "shelfMark_sort": "a*LDC 28973 [Notes]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 28973 [Notes]"
+                    ],
+                    "uri": "i12459171",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 28973 [Notes]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433016107595"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433016107595"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15562608",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 28973 [CD]",
+                      "urn:barcode:33433016107603"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 28973 [CD]"
+                    ],
+                    "shelfMark_sort": "a*LDC 28973 [CD]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Rossini%2C+Gioacchino%2C+1792-1868.&CallNumber=*LDC+28973+%5BCD%5D&Date=1993&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15562608&ItemISxN=i12459170x&ItemNumber=33433016107603&ItemPlace=Stuttgart&ItemPublisher=Carus%2C+c1993.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b155626085&Site=LPAMRAMI&Title=I+gondolieri+Chor-+und+Ensemblemusik"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 28973 [CD]"
+                    ],
+                    "uri": "i12459170",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 28973 [CD]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433016107603"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433016107603"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b22147641",
+        "_score": 15.63583,
+        "_source": {
+          "extent": [
+            "1 sound disc : digital ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A musical comedy in 2 acts, with 5 scenes, a prologue and an epilogue.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Book by Herbert Fields. Based on Mark Twain's novel \"A Connecticut Yankee in King Arthur's Court\".",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"A Connecticut Yankee\" opened Nov. 3, 1927, Vanderbilt Theatre, New York, NY; closed Oct. 27, 1928, after 421 performances.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "The revival of \"A Connecticut Yankee\" opened Nov. 17, 1943, Martin Beck Theatre, New York, NY; closed Mar. 11, 1944, after 135 performances.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes and synopsis by Stanley Green ([6] p. : ill., photos.) inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Eddie Albert (Capt. Martin Barrett, U.S.N., (later) The Yankee) ; Janet Blair (Corp. Alice Courtleigh, W.A.C., (later) The Demoiselle Alisande) ; Boris Karloff (Adm. Arthur K. Arthur, U.S.N., (later) King Arthur) ; Gale Sherwood (Fay Merrill, W.A.V.E., (later) Queen Morgan La Fay) ; Leonard Elliot[t] (Judge Thurston Merril, (later) Merlin, the magician) ; John Conte (Sir Kay the Seneschal) ; Beverlee Dennis (Mistress Evelyn la Rondelle) ; supporting cast & musicians ; Charles Sandford, conductor.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded Dec. 3, 1955.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Musicals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "AEI"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1996
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1955"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A Connecticut Yankee"
+          ],
+          "shelfMark": [
+            "*LDC 18658 (F)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1996"
+          ],
+          "creatorLiteral": [
+            "Rodgers, Richard, 1902-1979"
+          ],
+          "idLccn": [
+            "765911004324"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Twain, Mark, 1835-1910",
+            "Fields, Herbert, 1897-1958",
+            "Hart, Lorenz, 1895-1943",
+            "Albert, Eddie",
+            "Blair, Janet",
+            "Karloff, Boris, 1887-1969",
+            "Sherwood, Gale",
+            "Elliott, Leonard",
+            "Conte, John",
+            "Dennis, Beverlee",
+            "Sandford, Charles"
+          ],
+          "addedAuthorTitle": [
+            "Connecticut Yankee in King Arthur's court."
+          ],
+          "dateStartYear": [
+            1996
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 18658 (F)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22147641"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "39000519"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "765911004324"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "AEI-CD 043 AEI"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M290000216"
+            }
+          ],
+          "idOclc": [
+            "39000519"
+          ],
+          "uniformTitle": [
+            "Connecticut Yankee. Selections"
+          ],
+          "popularity": 0,
+          "dateEndYear": [
+            1955
+          ],
+          "updatedAt": 1729184273855,
+          "publicationStatement": [
+            "Beverly Hills, Calif. : AEI, p1996."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 18658 (F)",
+            "urn:bnum:22147641",
+            "urn:oclc:39000519",
+            "urn:lccn:765911004324",
+            "urn:identifier:AEI-CD 043 AEI",
+            "urn:identifier:(WaOLN)M290000216"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1996"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Musicals."
+          ],
+          "titleDisplay": [
+            "A Connecticut Yankee [sound recording] / music by Richard Rodgers ; lyrics by Lorenz Hart ; directed by Max Liebman."
+          ],
+          "uri": "b22147641",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Beverly Hills, Calif."
+          ],
+          "titleAlt": [
+            "Connecticut Yankee."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "The prologue: Introduction ; A toast ; This is my night to howl ; My heart stood still.",
+            "Act 1. Thou swell -- At the round table -- On a desert island with thee -- To keep my love alive -- Act one finale: Rise and shine (hibbedy bibbedy) -- Entr'acte.",
+            "Act 2. Entr'acte -- Ye lunchtime follies -- Can't you do a friend a favor? -- I feel at home with you -- You always love the same girl -- An entertainment -- The Camelot samba.",
+            "The epilogue: Finale ; Playout music ; My heart stood still."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          15.63583,
+          "b22147641"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b22147641",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 18658 (F)",
+                      "urn:barcode:33433047678341"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 18658 (F)"
+                    ],
+                    "shelfMark_sort": "a*LDC 18658 (F)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 18658 (F)"
+                    ],
+                    "uri": "i37861134",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 18658 (F)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433047678341"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433047678341"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b10756597",
+        "_score": 15.338375,
+        "_source": {
+          "extent": [
+            "1 score (   v.) : ill. (some col.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Rock music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Words and music by Forbert.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Rock music",
+            "Rock music -- United States"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Columbia Pictures Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Steve Forbert songbook : piano, vocal, chords."
+          ],
+          "shelfMark": [
+            "JNN 82-2"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "creatorLiteral": [
+            "Forbert, Steve"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNN 82-2"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10756597"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG82-C2179"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0763482"
+            }
+          ],
+          "idOclc": [
+            "NYPG82-C2179"
+          ],
+          "uniformTitle": [
+            "Songs. Selections; arranged"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1711108548806,
+          "publicationStatement": [
+            "[S.l.] : Columbia Pictures Publications, [1980-"
+          ],
+          "identifier": [
+            "urn:shelfmark:JNN 82-2",
+            "urn:bnum:10756597",
+            "urn:oclc:NYPG82-C2179",
+            "urn:identifier:(WaOLN)nyp0763482"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Rock music -- United States."
+          ],
+          "titleDisplay": [
+            "Steve Forbert songbook : piano, vocal, chords."
+          ],
+          "uri": "b10756597",
+          "formatId": "c",
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "[S.l.]"
+          ],
+          "titleAlt": [
+            "Songs."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "The oil song -- Tonight I feel sa far away from home -- Goin' down to Laurel -- Steve Forbet's midsummer night's toast -- Thinkin' -- What kinda guy? -- It isn't gonna be that way -- Big city cat -- Grand Central Station, March 18, 1977 -- Settle down -- You cannot win if you do not play -- The sweet love that ya give (sure goes a long, long way) -- Romeo's tune -- I'm in love with you -- Say goodbye to little Jo -- Wait -- Make it all so real -- Baby -- Complications -- January 23-30, 1978 -- Sadly sorta like a soap opera."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          15.338375,
+          "b10756597"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b10756597",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JNN 82-2 v. 1",
+                      "urn:barcode:33433068925019"
+                    ],
+                    "physicalLocation": [
+                      "JNN 82-2"
+                    ],
+                    "shelfMark_sort": "aJNN 82-2 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JNN 82-2 v. 1"
+                    ],
+                    "uri": "i13905447",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JNN 82-2 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433068925019"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pam32||Performing Arts Research Collections - Music"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433068925019"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pam32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b18893666",
+        "_score": 15.062544,
+        "_source": {
+          "extent": [
+            "1 sound disc (74:55) : digital, stereo. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "From the opera in 4 acts.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Libretto by Henri Meilhac and Ludovic Halévy, after the novel by Prosper Mérimée.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Synopsis in English by Kenneth Chalmers, and libretto with English translation (54 p. : ports.) inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded July 1975, Henry Wood Hall, London.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in French.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "London"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1998
+          ],
+          "dateEndString": [
+            "1976"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Carmen highlights"
+          ],
+          "shelfMark": [
+            "*LDC 51486"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1998"
+          ],
+          "creatorLiteral": [
+            "Bizet, Georges, 1838-1875"
+          ],
+          "idLccn": [
+            "028945820422"
+          ],
+          "seriesStatement": [
+            "Opera gala"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Meilhac, Henri, 1831-1897",
+            "Halévy, Ludovic, 1834-1908",
+            "Troyanos, Tatiana",
+            "Domingo, Plácido, 1941-",
+            "Dam, José van",
+            "Te Kanawa, Kiri",
+            "Solti, Georg, 1912-1997",
+            "Mérimée, Prosper, 1803-1870",
+            "John Alldis Choir. prf",
+            "Haberdashers' Aske's School (Elstree, England). Boys' Chorus. prf",
+            "London Philharmonic Orchestra. prf"
+          ],
+          "addedAuthorTitle": [
+            "Carmen."
+          ],
+          "dateStartYear": [
+            1998
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 51486"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "18893666"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "39928406"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "028945820422"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "289 458 204-2 London"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)39928406"
+            }
+          ],
+          "idOclc": [
+            "39928406"
+          ],
+          "popularity": 0,
+          "uniformTitle": [
+            "Carmen. Selections",
+            "Opera gala."
+          ],
+          "dateEndYear": [
+            1976
+          ],
+          "updatedAt": 1741051098829,
+          "publicationStatement": [
+            "New York, N.Y. : London, [1998], p1978."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 51486",
+            "urn:bnum:18893666",
+            "urn:oclc:39928406",
+            "urn:lccn:028945820422",
+            "urn:identifier:289 458 204-2 London",
+            "urn:identifier:(OCoLC)39928406"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1998"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Carmen [sound recording] : highlights / Bizet."
+          ],
+          "uri": "b18893666",
+          "lccClassification": [
+            "AV1.2.B59 C32 1998a"
+          ],
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "New York, N.Y."
+          ],
+          "titleAlt": [
+            "Carmen."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Prélude (2:15) -- Mais nous ne voyons pas la Carmencita! ; L'amour est un oiseau rebelle : (Habanera) (5:31) -- Parle-mois de ma mère (9:27) -- Près des remparts de Séville : (Seguidilla) (4:43) -- Les tringles des sistres tintaient (4:53) -- Vivat, vivat le torero! ; Votre toast : (Toreador song) (6:55) -- Nous avons en tête une affaire (4:55) -- La fleur que tu m'avais jetée : (Flower song) (3:52) -- Non! tu ne m'aimes pas! (4:18) -- Mêlons! Coupons! (7:27) -- Je dis que rien ne m'épouvante (5:43) -- Les voici, les voici (4:14) -- C'est toi! C'est moi! (10:03)."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          15.062544,
+          "b18893666"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b18893666",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 51486",
+                      "urn:barcode:33433085960031"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 51486"
+                    ],
+                    "shelfMark_sort": "a*LDC 051486",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 51486"
+                    ],
+                    "uri": "i26345655",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 51486"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085960031"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433085960031"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b18893666",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 51486",
+                      "urn:barcode:33433085960023"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 51486"
+                    ],
+                    "shelfMark_sort": "a*LDC 051486",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Bizet%2C+Georges%2C+1838-1875&CallNumber=*LDC+51486&Date=1998&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db18893666&ItemISxN=i263456547&ItemNumber=33433085960023&ItemPlace=New+York%2C+N.Y.&ItemPublisher=London%2C+%5B1998%5D%2C+p1978.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b18893666x&Site=LPAMRAMI&Title=Carmen+highlights&Transaction.CustomFields.MapsLocationNote=%5BCD%5D"
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 51486"
+                    ],
+                    "uri": "i26345654",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 51486"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085960023"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433085960023"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b15557108",
+        "_score": 14.932272,
+        "_source": {
+          "extent": [
+            "1 sound disc (64:00) : digital ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Program notes by Peter Dempsey inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "All selections previously released.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Musicals",
+            "Musicals -- Excerpts",
+            "Popular music",
+            "Popular music -- 1931-1940"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Naxos Nostalgia"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            2001
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1932"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mad dogs and Englishmen the complete recordings, vol. 2 : 1932-1936"
+          ],
+          "shelfMark": [
+            "*LDC 28494 (F)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2001"
+          ],
+          "creatorLiteral": [
+            "Coward, Noël, 1899-1973"
+          ],
+          "idLccn": [
+            "636943255926"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2001
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 28494 (F)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15557108"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "48993177"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "636943255926"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "8.120559 Naxos Nostalgia"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M170000377"
+            }
+          ],
+          "idOclc": [
+            "48993177"
+          ],
+          "dateEndYear": [
+            1932
+          ],
+          "updatedAt": 1712866798575,
+          "publicationStatement": [
+            "[S.l.] : Naxos Nostalgia, p2001."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 28494 (F)",
+            "urn:bnum:15557108",
+            "urn:oclc:48993177",
+            "urn:lccn:636943255926",
+            "urn:identifier:8.120559 Naxos Nostalgia",
+            "urn:identifier:(WaOLN)M170000377"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2001"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Musicals -- Excerpts.",
+            "Popular music -- 1931-1940."
+          ],
+          "titleDisplay": [
+            "Mad dogs and Englishmen [sound recording] : the complete recordings, vol. 2 : 1932-1936 / Noël Coward."
+          ],
+          "uri": "b15557108",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[S.l.]"
+          ],
+          "titleAlt": [
+            "Complete recordings. vol. 2, 1932-1936",
+            "Noël Coward. Vol. 2, Mad dogs and Englishmen"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Mad dogs and Englishmen (2:50) -- Let's say goodbye (3:22) -- Party's over now (3:40) -- Something to do with spring (2:29) -- Noel Coward presents (9:00). Tokay ; World weary ; Caballero ; Green carnations ; I'll see you again ; Poor little rich girl ; Zigeuner ; Dear little cafe ; Call of life ; Ladies of the town -- I travel alone (2:29) -- Most of ev'ry day (2:31) -- Love in bloom (3:08) -- Fare thee well (2:44) -- Mrs. Worthington (2:00) -- We were so young (3:20) -- Family album : scenes (8:04). Here's a toast ; Hearts and flowers -- Shadow play : scenes (8:46). Then ; Play, orchestra ; You were there -- Red peppers : scenes (8:48). Has anybody seen our ship ; Men about town."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          14.932272,
+          "b15557108"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15557108",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 28494 (F) [Notes]",
+                      "urn:barcode:33433015996212"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 28494 (F) [Notes]"
+                    ],
+                    "shelfMark_sort": "a*LDC 28494 (F) [Notes]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 28494 (F) [Notes]"
+                    ],
+                    "uri": "i12455194",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 28494 (F) [Notes]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015996212"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433015996212"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15557108",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 28494 (F) [CD]",
+                      "urn:barcode:33433015996220"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 28494 (F) [CD]"
+                    ],
+                    "shelfMark_sort": "a*LDC 28494 (F) [CD]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Coward%2C+No%C3%ABl%2C+1899-1973.&CallNumber=*LDC+28494+%28F%29+%5BCD%5D&Date=2001&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15557108&ItemISxN=i124551932&ItemNumber=33433015996220&ItemPlace=%5BS.l.%5D&ItemPublisher=Naxos+Nostalgia%2C+p2001.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b155571084&Site=LPAMRAMI&Title=Mad+dogs+and+Englishmen+the+complete+recordings%2C+vol.+2+%3A+1932-1936"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 28494 (F) [CD]"
+                    ],
+                    "uri": "i12455193",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 28494 (F) [CD]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015996220"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433015996220"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b18350241",
+        "_score": 14.806064,
+        "_source": {
+          "extent": [
+            "1 sound disc : digital, mono. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Opera arias and one song.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Notes on the performer in German and English by Einhard Luther ([3] p.) inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded Sept. 30, 1927 (tracks 6, 8-9) ; Apr. 24, 1928 (tracks 1-2, 14); May 24, 1928 (tracks 10-11); June 9, 1932 (tracks 3-4); Sept. 25, 1933 (track 7); Dec. 20, 1933 (track 5) ; Feb. 26, 1934 (tracks 16-17) ; Mar. 1935 (track 18).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in German.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts",
+            "Songs (High voice) with orchestra"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Lebendige Vergangenheit"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1995
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1927"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Hans Reinmar"
+          ],
+          "shelfMark": [
+            "*LDC 16806"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1995"
+          ],
+          "creatorLiteral": [
+            "Reinmar, Hans, 1895-1961"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Wittrisch, Marcel, 1901-1955",
+            "Weigert, Herman",
+            "Weissmann, Frieder",
+            "Meyrowitz, Selmar, 1875-1941",
+            "Reuss, Wilhelm Franz, 1886-1945",
+            "Schmidt-Isserstedt, Hans, 1900-1973",
+            "Borchert, Leo",
+            "Mozart, Wolfgang Amadeus, 1756-1791",
+            "Verdi, Giuseppe, 1813-1901",
+            "Offenbach, Jacques, 1819-1880",
+            "Meyerbeer, Giacomo, 1791-1864",
+            "Bizet, Georges, 1838-1875",
+            "Wagner, Richard, 1813-1883",
+            "Marschner, Heinrich, 1795-1861",
+            "Humperdinck, Engelbert, 1854-1921",
+            "Nessler, Victor E. (Victor Ernst), 1841-1890",
+            "Abt, Franz, 1819-1885",
+            "Staatskapelle Berlin",
+            "Berliner Philharmoniker",
+            "Städtische Oper Berlin. Orchester"
+          ],
+          "addedAuthorTitle": [
+            "Don Giovanni.",
+            "Ballo in maschera.",
+            "Simon Boccanegra.",
+            "Don Carlos.",
+            "Otello.",
+            "Contes d'Hoffmann.",
+            "Africaine.",
+            "Carmen.",
+            "Tannhäuser.",
+            "Hans Heiling.",
+            "Königskinder (Opera).",
+            "Trompeter von Säkkingen.",
+            "Lieder"
+          ],
+          "dateStartYear": [
+            1995
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 16806"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "18350241"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "47251445"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "MONO 89112 Lebendige Vergangenheit"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "89112 Lebendige Vergangenheit"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)47251445"
+            }
+          ],
+          "idOclc": [
+            "47251445"
+          ],
+          "popularity": 0,
+          "dateEndYear": [
+            1927
+          ],
+          "updatedAt": 1729181193496,
+          "publicationStatement": [
+            "[Austria] : Lebendige Vergangenheit, p1995."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 16806",
+            "urn:bnum:18350241",
+            "urn:oclc:47251445",
+            "urn:identifier:MONO 89112 Lebendige Vergangenheit",
+            "urn:identifier:89112 Lebendige Vergangenheit",
+            "urn:identifier:(OCoLC)47251445"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1995"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts.",
+            "Songs (High voice) with orchestra."
+          ],
+          "titleDisplay": [
+            "Hans Reinmar [sound recording]."
+          ],
+          "uri": "b18350241",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[Austria]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Don Juan. Treibt der Champagner ; Feinsliebchen, komm ans Fenster / Mozart -- Ein Maskenball. Ja, nur du hast dies Herz ; Simone Boccanegra. Adel, Plebejer, Genuas Volk ; Don Carlos. Schon seh ich den Tag erscheinen ; Othello. Ich glaube an einen Gott ; Es war zur Nachtzeit / Verdi -- Hoffmanns Erzählungen. Leuchte, heller Spiegel / Offenbach -- Die Afrikanerin. Dir, Königin, bin ich ergeben ; Wie hat mein Herz geschlagen / Meyerbeer -- Carmen. Euren Toast kann ich wohl erwidern / Bizet -- Tannhäuser. Als du in kühnem Sange ; Blick' ich umher ; O du mein holder Abendstern / Wagner -- Hans Heiling. An jenem Tag / Marschner -- Königskinder. Verdorben - gestorben / Humperdink ; Der Trompeter von Säckingen. Behüt' dich Gott / Nessler -- Wenn man beim Wein sitzt Soldatenart / Abt."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          14.806064,
+          "b18350241"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b18350241",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 16806",
+                      "urn:barcode:33433087273144"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 16806"
+                    ],
+                    "shelfMark_sort": "a*LDC 016806",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 16806"
+                    ],
+                    "uri": "i24953245",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 16806"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433087273144"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433087273144"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b18350241",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 16806",
+                      "urn:barcode:33433087273151"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 16806"
+                    ],
+                    "shelfMark_sort": "a*LDC 016806",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Reinmar%2C+Hans%2C+1895-1961.&CallNumber=*LDC+16806&Date=1995&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db18350241&ItemISxN=i24953244x&ItemNumber=33433087273151&ItemPlace=%5BAustria%5D&ItemPublisher=Lebendige+Vergangenheit%2C+p1995.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b183502413&Site=LPAMRAMI&Title=Hans+Reinmar&Transaction.CustomFields.MapsLocationNote=%5BCD%5D"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 16806"
+                    ],
+                    "uri": "i24953244",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 16806"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433087273151"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433087273151"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16745779",
+        "_score": 14.803373,
+        "_source": {
+          "extent": [
+            "1 sound disc : analog, 33 1/3 rpm ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Opera arias and scenes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Biographical and program notes by Leo Riemens in German on container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded 1907-1913; originally released on Parlophon, Odeon or Gramophone labels.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in German.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Court Opera Classics"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cornelis Bronsgeest 1878-1957."
+          ],
+          "shelfMark": [
+            "*LRX 8448"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "creatorLiteral": [
+            "Bronsgeest, Cornelis"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Lohfing, Max, 1870-1953",
+            "Denera, Erna, 1881-1938",
+            "Shore, Dinah, 1917-1994",
+            "Krasa, Rudolf, 1859-1936",
+            "Mozart, Wolfgang Amadeus, 1756-1791",
+            "Kreutzer, Conradin, 1780-1849",
+            "Wagner, Richard, 1813-1883",
+            "Verdi, Giuseppe, 1813-1901",
+            "Bizet, Georges, 1838-1875"
+          ],
+          "addedAuthorTitle": [
+            "Don Giovanni.",
+            "Nachtlager in Granada.",
+            "Fliegende Holländer.",
+            "Tannhäuser.",
+            "Trovatore.",
+            "Aïda.",
+            "Carmen.",
+            "Ring des Nibelungen.",
+            "Parsifal."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LRX 8448"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16745779"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "10481461"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "CO 421 Court Opera Classics"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A280000002"
+            }
+          ],
+          "idOclc": [
+            "10481461"
+          ],
+          "popularity": 0,
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1729005907857,
+          "publicationStatement": [
+            "[Austria] : Court Opera Classics, [198-?]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LRX 8448",
+            "urn:bnum:16745779",
+            "urn:oclc:10481461",
+            "urn:identifier:CO 421 Court Opera Classics",
+            "urn:identifier:(WaOLN)A280000002"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Cornelis Bronsgeest [sound recording] : 1878-1957."
+          ],
+          "uri": "b16745779",
+          "formatId": "j",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[Austria]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Don Juan. Ha, das Mahl ist schon bereitet! / Mozart (with Max Lohfing, bass) -- Nachtlager in Granade. Ein Schütz bin ich / Kreutzer -- Fliegende Holländer. Wie aus der Ferne längst vergang'ner Zeiten / Wagner (with Erna Denera, soprano) -- Tannhäuser. Als du in kühnem Sange uns bestrittest ; Blick' ich umher in diesem edlen Kreise ; Wie Todesahnung Dämm'rung deckt die Lande / Wagner -- Der Troubadour. Ihres Auges himmlisch Strahlen ; O dürfte ich es glauben / Verdi -- Aida. Zu dir fürht mich ein ernster Grund, Aida / Verdi (with Frances Rose) -- Carmen. Euren Toast kann ich wohl erwidern / Bizet -- Götterdämmerung. Brünhild, die hehrste Frau / Wagner -- Parsifal. Wehe! Wehe mir der Qual / Wagner (with Rudolf Krasa)."
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          14.803373,
+          "b16745779"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16745779",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LRX 8448 [Disc]",
+                      "urn:barcode:33433068004625"
+                    ],
+                    "physicalLocation": [
+                      "*LRX 8448 [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LRX 8448 [Disc]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Bronsgeest%2C+Cornelis&CallNumber=*LRX+8448+%5BDisc%5D&Date=1980&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16745779&ItemISxN=i174269018&ItemNumber=33433068004625&ItemPlace=%5BAustria%5D&ItemPublisher=Court+Opera+Classics%2C+%5B198-%3F%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b167457792&Site=LPAMRAMI&Title=Cornelis+Bronsgeest+1878-1957."
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LRX 8448 [Disc]"
+                    ],
+                    "uri": "i17426901",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LRX 8448 [Disc]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433068004625"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433068004625"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b21916387",
+        "_score": 14.793478,
+        "_source": {
+          "extent": [
+            "1 online resource (1 sound file)"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Sung in French.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Deutsche Grammophon"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            2014
+          ],
+          "buildingLocationIds": [],
+          "dateEndString": [
+            "1983"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Carmen : opera highlights"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2014"
+          ],
+          "creatorLiteral": [
+            "Bizet, Georges, 1838-1875"
+          ],
+          "idLccn": [
+            "DEF058230702",
+            "DEF058230703",
+            "DEF058230706",
+            "DEF058230709",
+            "DEF058230711",
+            "DEF058230745",
+            "DEF058230746",
+            "DEF058230757",
+            "DEF058230721",
+            "DEF058230765",
+            "DEF058230723",
+            "DEF058230701",
+            "DEF058230705",
+            "DEF058230724",
+            "DEF058230712"
+          ],
+          "seriesStatement": [
+            "Virtuoso"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "contributorLiteral": [
+            "Ricciarelli, Katia",
+            "Baltsa, Agnes",
+            "Carreras, José",
+            "Dam, José van",
+            "Karajan, Herbert von",
+            "Opéra de Paris. Chœur, singer",
+            "Berliner Philharmoniker, instrumentalist"
+          ],
+          "dateStartYear": [
+            2014
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "21916387"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "982193692"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230702"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230703"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230706"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230709"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230711"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230745"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230746"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230757"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230721"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230765"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230723"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230701"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230705"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230724"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230712"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "00028947864011 Deutsche Grammophon"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)982193692"
+            }
+          ],
+          "idOclc": [
+            "982193692"
+          ],
+          "uniformTitle": [
+            "Carmen. Selections",
+            "Virtuoso (Universal Music Group)"
+          ],
+          "dateEndYear": [
+            1983
+          ],
+          "updatedAt": 1711271371612,
+          "publicationStatement": [
+            "Berlin : Deutsche Grammophon, [2014]",
+            "©2014, ℗1983"
+          ],
+          "identifier": [
+            "urn:bnum:21916387",
+            "urn:oclc:982193692",
+            "urn:lccn:DEF058230702",
+            "urn:lccn:DEF058230703",
+            "urn:lccn:DEF058230706",
+            "urn:lccn:DEF058230709",
+            "urn:lccn:DEF058230711",
+            "urn:lccn:DEF058230745",
+            "urn:lccn:DEF058230746",
+            "urn:lccn:DEF058230757",
+            "urn:lccn:DEF058230721",
+            "urn:lccn:DEF058230765",
+            "urn:lccn:DEF058230723",
+            "urn:lccn:DEF058230701",
+            "urn:lccn:DEF058230705",
+            "urn:lccn:DEF058230724",
+            "urn:lccn:DEF058230712",
+            "urn:identifier:00028947864011 Deutsche Grammophon",
+            "urn:identifier:(OCoLC)982193692"
+          ],
+          "genreForm": [
+            "Streaming audio."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2014"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Carmen : opera highlights / Bizet."
+          ],
+          "uri": "b21916387",
+          "electronicResources": [
+            {
+              "label": "Access Naxos Music Library",
+              "url": "https://nypl.naxosmusiclibrary.com/catalogue/item.asp?cid=00028947864011"
+            }
+          ],
+          "formatId": "w",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Berlin"
+          ],
+          "titleAlt": [
+            "Carmen."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Prélude -- Sur la place chacun passe -- Avec la garde montante -- L'amour est un oiseau rebelle -- Parle-moi de ma mère -- Près des remparts de Séville -- Les tringles des sistres tintaient -- Vous avez quelque chose à nous dire -- Vivat! Vivat le toréro! -- Votre toast, je peux vous le rendre -- La fleur que tu m'avais jetée -- En vain, pour éviter les réponses amères/Parlez encore, parlez, mes belles -- À dos cuartos! -- [Musique de transition] -- C'est toi!/C'est moi!"
+          ]
+        },
+        "sort": [
+          14.793478,
+          "b21916387"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16159529",
+        "_score": 14.564494,
+        "_source": {
+          "extent": [
+            "<4> sound discs : analog, 33 1/3 rpm ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Lebendige Vergangenheit: LV 108, LV 110, LV 187, LV 1330.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Opera excerpts.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes by Clemens Höslinger in German on container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded 1920-1938.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung principally in German.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Lebendige Vergangenheit"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Heinrich Schlusnus"
+          ],
+          "shelfMark": [
+            "*LZR 5122 (C)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "creatorLiteral": [
+            "Schlusnus, Heinrich, 1888-1952"
+          ],
+          "idLccn": [
+            "77762223"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Hutt, Robert, 1878-1942"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LZR 5122 (C)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16159529"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "12913709"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77762223"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "LV 108 Lebendige Vergangenheit"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "LV 110 Lebendige Vergangenheit"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "LV 187 Lebendige Vergangenheit"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "LV 1330 LebendigeVergangenheit"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A230000008"
+            }
+          ],
+          "idOclc": [
+            "12913709"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1712868092957,
+          "publicationStatement": [
+            "Austria : Lebendige Vergangenheit, [between 1970 and <1986>]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LZR 5122 (C)",
+            "urn:bnum:16159529",
+            "urn:oclc:12913709",
+            "urn:lccn:77762223",
+            "urn:identifier:LV 108 Lebendige Vergangenheit",
+            "urn:identifier:LV 110 Lebendige Vergangenheit",
+            "urn:identifier:LV 187 Lebendige Vergangenheit",
+            "urn:identifier:LV 1330 LebendigeVergangenheit",
+            "urn:identifier:(WaOLN)A230000008"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Heinrich Schlusnus [sound recording]."
+          ],
+          "uri": "b16159529",
+          "lccClassification": [
+            "M1505"
+          ],
+          "formatId": "j",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Austria"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Disc 3. Tannhäuser. Blick' ich umher in diesem edlen Kreise / Wagner -- Wilhelm Tell. Ha, wohin? Sprich, was soll dein Eilen? / Rossini -- La traviata. Hat dein heimatliches Land keinen Reiz für deinen Sinn ; Die Macht des Schicksals. In dieser heil'gen Stunde (Robert Hutt) / Verdi -- Die Perlenfischer. Dort in des Tempels Grund / Bizet (Robert Hutt) -- Die Afrikanerin. Dir, Königin, bin ich ergeben ; Wie hat mein Herz geschlagen / Meyerbeer -- Die Walküre. Leb' wohl, du kühnes, herrliches Kind ; Loge, hör'! lausche hierher! / Wagner -- Carmen. Euren Toast kann ich wohl erwidern / Bizet -- Othello. Ich glaube an einen Gott ; Saht ihr nicht manchmal in Desdemonens Händen (Robert Hutt) / Verdi -- La bohème. Ach, Geliebte! Nie kehrst du in meinen Arm / Puccini (Robert Hutt)."
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          14.564494,
+          "b16159529"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16159529",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LZR 5122 (C) [Disc]",
+                      "urn:barcode:33433035869852"
+                    ],
+                    "physicalLocation": [
+                      "*LZR 5122 (C) [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LZR 5122 (C) [Disc]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Schlusnus%2C+Heinrich%2C+1888-1952.&CallNumber=*LZR+5122+%28C%29+%5BDisc%5D&Date=1970&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16159529&ItemISxN=i155655607&ItemNumber=33433035869852&ItemPlace=Austria&ItemPublisher=Lebendige+Vergangenheit%2C+%5Bbetween+1970+and+%3C1986%3E%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b161595297&Site=LPAMRAMI&Title=Heinrich+Schlusnus"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LZR 5122 (C) [Disc]"
+                    ],
+                    "uri": "i15565560",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LZR 5122 (C) [Disc]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433035869852"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433035869852"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16645835",
+        "_score": 14.511077,
+        "_source": {
+          "extent": [
+            "1 sound cassette : analog, stereo."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cassette contains Joseph Papp toasting his friend and benefactor George T. Delacorte, the recipiant of the Alexander Hamilton medal (year unknown), and Papp singing several songs from the 1930's at Columbia University.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"J. Papp at Columbia Univ.\"--Cassette.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Credits and information taken from auditioning of cassette.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "On container spine: J Papp. Columbia.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "NYSF inventory no. 1729.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Forms part of the New York Shakespeare Festival records; for papers, see the Billy Rose Theatre Collection, *T-Mss 1993-028; for sheet music and scores, see the Music Division, JPB 04-03.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "The New York Shakespeare Festival and Gail Merrifield Papp;",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Forms part of: New York Shakespeare Festival recordings collection.",
+              "type": "bf:Note"
+            }
+          ],
+          "partOf": [
+            "New York Shakespeare Festival recordings collection."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Delacorte, George T. (George Thomas), 1893-1991",
+            "Songs with instrumental ensemble",
+            "Award presentations",
+            "Award presentations -- New York (State)",
+            "Award presentations -- New York (State) -- New York"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            1980
+          ],
+          "dateEndString": [
+            "1989"
+          ],
+          "title": [
+            "J. Papp at Columbia University [speech and performance]"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "*LTC 10267"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "creatorLiteral": [
+            "Papp, Joseph"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Hart, Lorenz, 1895-1943",
+            "Rodgers, Richard, 1902-1979",
+            "Dixon, Mort, 1892-1956",
+            "Rose, Billy, 1899-1966",
+            "Warren, Harry, 1893-1981",
+            "Harburg, E. Y. (Edgar Yipsel), 1896-1981",
+            "Gorney, Jay, 1896-1990",
+            "Silverman, Stanley",
+            "Columbia University",
+            "New York Shakespeare Festival Public Theater. dnr"
+          ],
+          "addedAuthorTitle": [
+            "Songs."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "idOclc": [
+            "166556166"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LTC 10267"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16645835"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "166556166"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)166556166"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M310000283"
+            }
+          ],
+          "popularity": 0,
+          "dateEndYear": [
+            1989
+          ],
+          "updatedAt": 1751511227775,
+          "publicationStatement": [
+            "[198-?]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LTC 10267",
+            "urn:bnum:16645835",
+            "urn:oclc:166556166",
+            "urn:identifier:(OCoLC)166556166",
+            "urn:identifier:(WaOLN)M310000283"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Delacorte, George T. (George Thomas), 1893-1991.",
+            "Songs with instrumental ensemble.",
+            "Award presentations -- New York (State) -- New York."
+          ],
+          "titleDisplay": [
+            "J. Papp at Columbia University [sound recording]  : [speech and performance] / [toast and performance by J. Papp ; music arranged and conducted by Stanley Silverman.]"
+          ],
+          "uri": "b16645835",
+          "formatId": "j",
+          "recordTypeId": "j",
+          "issuance": [
+            {
+              "id": "urn:biblevel:d",
+              "label": "subunit"
+            }
+          ],
+          "titleAlt": [
+            "Joseph Papp at Columbia",
+            "New York Shakespeare Festival recordings collection."
+          ],
+          "tableOfContents": [
+            "What do you want with money? ; Hallelujah, I'm a bum again / Rodgers, Hart -- I found a million dollar baby (In a five-and ten cent store) / Warren, Dixon & Rose -- Brother, can you spare a dime? / Gorney, Harburg -- Hallelujah, I'm a bum again (reprise)"
+          ]
+        },
+        "sort": [
+          14.511077,
+          "b16645835"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b23663179",
+        "_score": 14.48096,
+        "_source": {
+          "extent": [
+            "1 online resource (1 audio file)"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Sung in French.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Erato"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            2005
+          ],
+          "dateEndString": [
+            "1982"
+          ],
+          "title": [
+            "Carmen : highlights"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2005"
+          ],
+          "creatorLiteral": [
+            "Bizet, Georges, 1838-1875"
+          ],
+          "idLccn": [
+            "FRZ208211315",
+            "FRZ208211319",
+            "FRZ208211322",
+            "FRZ208211309",
+            "FRZ208211343",
+            "FRZ208211349",
+            "FRZ208211350",
+            "FRZ208211306",
+            "FRZ208211301",
+            "FRZ208211333"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "contributorLiteral": [
+            "Migenes-Johnson, Julia",
+            "Esham, Faith",
+            "Domingo, Plácido, 1941-",
+            "Raimondi, Ruggero",
+            "Maazel, Lorin, 1930-2014",
+            "Radio-France. Chœurs, singer",
+            "Radio-France. Maîtrise, singer",
+            "Orchestre national de France, instrumentalist"
+          ],
+          "dateStartYear": [
+            2005
+          ],
+          "idOclc": [
+            "1519478846"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "23663179"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1519478846"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "FRZ208211315"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "FRZ208211319"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "FRZ208211322"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "FRZ208211309"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "FRZ208211343"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "FRZ208211349"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "FRZ208211350"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "FRZ208211306"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "FRZ208211301"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "FRZ208211333"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "825646080465 Erato"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1519478846"
+            }
+          ],
+          "popularity": 0,
+          "uniformTitle": [
+            "Carmen. Selections"
+          ],
+          "dateEndYear": [
+            1982
+          ],
+          "updatedAt": 1750711169043,
+          "publicationStatement": [
+            "[France] : Erato, [2005]"
+          ],
+          "genreForm": [
+            "Excerpts."
+          ],
+          "identifier": [
+            "urn:bnum:23663179",
+            "urn:oclc:1519478846",
+            "urn:lccn:FRZ208211315",
+            "urn:lccn:FRZ208211319",
+            "urn:lccn:FRZ208211322",
+            "urn:lccn:FRZ208211309",
+            "urn:lccn:FRZ208211343",
+            "urn:lccn:FRZ208211349",
+            "urn:lccn:FRZ208211350",
+            "urn:lccn:FRZ208211306",
+            "urn:lccn:FRZ208211301",
+            "urn:lccn:FRZ208211333",
+            "urn:identifier:825646080465 Erato",
+            "urn:identifier:(OCoLC)1519478846"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2005"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Carmen : highlights / Bizet."
+          ],
+          "uri": "b23663179",
+          "electronicResources": [
+            {
+              "label": "Access Naxos Music Library",
+              "url": "https://nypl-v4.naxosmusiclibrary.com/catalogue/item.asp?cid=825646080465"
+            }
+          ],
+          "formatId": "w",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[France]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Carmen."
+          ],
+          "tableOfContents": [
+            "Ouverture (2:09) -- Habanera : \"L'amour est un oiseau rebelle\" (4:17) -- Duo : \"Parle-moi de ma mère\" (8:49) -- Séguedille et duo : \"Près des remparts de Séville\" (4:12) -- Chanson bohème : \"Les tringles des sistres tintaient\" (5:33) -- Couplets : \"Votre toast, je peux vous le rendre\" (4:46) -- \"La fleur que tu m'avais jetée (4:04) -- Air : \"Je dis que rien ne m'épouvante\" (5:07) -- Marche et chœur : \"Les voici, voici la quadrille des toreros\" (6:50) -- Duo et chœur final : \"C'est toi? C'est moi!\" (9:27)."
+          ]
+        },
+        "sort": [
+          14.48096,
+          "b23663179"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16171601",
+        "_score": 14.34354,
+        "_source": {
+          "extent": [
+            "9 videodiscs (ca. 1500 min.) : sd., b&w and color ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Originally televised between 1958-1972; originally released as a compilation in 1990.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Each episode approx. 1 hour.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Episode guide with brief program notes (18 p. : ports.) inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Produced and directed by Roger Englander; some episodes directed by Charles S. Dubin.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "DVD, full screen (1.33:1); NTSC, all regions; Dolby digital 5.1 and Dolby stereo.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Closed-captioned.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Mahler, Gustav, 1860-1911",
+            "Stravinsky, Igor, 1882-1971",
+            "Sibelius, Jean, 1865-1957",
+            "Shostakovich, Dmitriĭ Dmitrievich, 1906-1975",
+            "Berlioz, Hector, 1803-1869",
+            "Beethoven, Ludwig van, 1770-1827",
+            "Music appreciation",
+            "Nationalism in music",
+            "Instrumentation and orchestration",
+            "Symphony",
+            "Classicism in music",
+            "Humor in music",
+            "Concerto",
+            "Folk music",
+            "Impressionism (Music)",
+            "Melody",
+            "Music",
+            "Music -- Latin America",
+            "Jazz",
+            "Sonata form",
+            "Musical intervals and scales",
+            "Orchestral music",
+            "Orchestral music -- Analysis, appreciation",
+            "Waltz",
+            "Ballets"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kultur"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            2004
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1958"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Leonard Bernstein's Young People's Concerts with the New York Philharmonic"
+          ],
+          "shelfMark": [
+            "*LDV 353"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2004"
+          ],
+          "creatorLiteral": [
+            "Bernstein, Leonard, 1918-1990"
+          ],
+          "idLccn": [
+            "032031150393"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Bernstein, Leonard, 1918-1990",
+            "Bernstein, Leonard, 1918-1990",
+            "Englander, Roger",
+            "Dubin, Charles",
+            "New York Philharmonic. prf",
+            "Kultur Video",
+            "CBS Entertainment (Firm) prd"
+          ],
+          "dateStartYear": [
+            2004
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDV 353"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16171601"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0769715036"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "56401997"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG05-F11196"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "032031150393"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "D1503 Kultur"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)G020000106"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)56401997"
+            }
+          ],
+          "idOclc": [
+            "56401997",
+            "NYPG05-F11196"
+          ],
+          "uniformTitle": [
+            "Young people's concerts"
+          ],
+          "dateEndYear": [
+            1958
+          ],
+          "updatedAt": 1712868249718,
+          "publicationStatement": [
+            "West Long Branch, NJ : Kultur, [2004]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDV 353",
+            "urn:bnum:16171601",
+            "urn:isbn:0769715036",
+            "urn:oclc:56401997",
+            "urn:oclc:NYPG05-F11196",
+            "urn:lccn:032031150393",
+            "urn:identifier:D1503 Kultur",
+            "urn:identifier:(WaOLN)G020000106",
+            "urn:identifier:(OCoLC)56401997"
+          ],
+          "idIsbn": [
+            "0769715036"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mov",
+              "label": "Moving image"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2004"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Mahler, Gustav, 1860-1911.",
+            "Stravinsky, Igor, 1882-1971.",
+            "Sibelius, Jean, 1865-1957.",
+            "Shostakovich, Dmitriĭ Dmitrievich, 1906-1975.",
+            "Berlioz, Hector, 1803-1869.",
+            "Beethoven, Ludwig van, 1770-1827.",
+            "Music appreciation.",
+            "Nationalism in music.",
+            "Instrumentation and orchestration.",
+            "Symphony.",
+            "Classicism in music.",
+            "Humor in music.",
+            "Concerto.",
+            "Folk music.",
+            "Impressionism (Music)",
+            "Melody.",
+            "Music -- Latin America.",
+            "Jazz.",
+            "Sonata form.",
+            "Musical intervals and scales.",
+            "Orchestral music -- Analysis, appreciation.",
+            "Waltz.",
+            "Ballets."
+          ],
+          "titleDisplay": [
+            "Leonard Bernstein's Young People's Concerts [videorecording] : with the New York Philharmonic / CBS Entertainment ; the Leonard Bernstein Office, Inc."
+          ],
+          "uri": "b16171601",
+          "formatId": "v",
+          "recordTypeId": "g",
+          "placeOfPublication": [
+            "West Long Branch, NJ"
+          ],
+          "titleAlt": [
+            "Young people's concerts",
+            "Young People's Concerts with the New York Philharmonic"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Disc 1. What does music mean? ; What is American music? ; What is orchestration? -- Disc 2. What makes music symphonic? ; What is classical music? ; Humor in music -- Disc 3. What is a concerto? ; Who is Gustav Mahler? ; Folk music in the concert hall -- Disc 4. What is Impressionism? ; Happy birthday, Igor Stravinsky ; What is Melody? -- Disc 5. The Latin American spirit ; Jazz in the concert hall ; What is sonata form? -- Disc 6. A tribute to Sibelius ; Musical atoms : a study of intervals ; The sound of an orchestra -- Disc 7. A birthday tribute to Shostakovich ; What is a mode? ; A toast to Vienna in 3/4 time -- Disc 8. Quiz-concert : how musical are you? ; Berlioz takes a trip ; Two ballet birds -- Disc 9. Fidelio : a celebration of life."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ],
+          "idIsbn_clean": [
+            "0769715036"
+          ]
+        },
+        "sort": [
+          14.34354,
+          "b16171601"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16171601",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDV 353 [Video]",
+                      "urn:barcode:33433062962687"
+                    ],
+                    "physicalLocation": [
+                      "*LDV 353 [Video]"
+                    ],
+                    "shelfMark_sort": "a*LDV 353 [Video]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:11||videorecording, non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Bernstein%2C+Leonard%2C+1918-1990.&CallNumber=*LDV+353+%5BVideo%5D&Date=2004&Form=30&Genre=videorecording%2C+non-circ&ItemEdition=Special+collector%27s+ed.&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16171601&ItemISxN=i155793962&ItemNumber=33433062962687&ItemPlace=West+Long+Branch%2C+NJ&ItemPublisher=Kultur%2C+%5B2004%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b161716015&Site=LPAMRAMI&Title=Leonard+Bernstein%27s+Young+People%27s+Concerts+with+the+New+York+Philharmonic"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDV 353 [Video]"
+                    ],
+                    "uri": "i15579396",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDV 353 [Video]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062962687"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433062962687"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:11",
+                        "label": "videorecording, non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "DVD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16171601",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDV 353 [Notes]",
+                      "urn:barcode:33433062962695"
+                    ],
+                    "physicalLocation": [
+                      "*LDV 353 [Notes]"
+                    ],
+                    "shelfMark_sort": "a*LDV 353 [Notes]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDV 353 [Notes]"
+                    ],
+                    "uri": "i15579397",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDV 353 [Notes]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062962695"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433062962695"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "DVD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16550061",
+        "_score": 14.34354,
+        "_source": {
+          "extent": [
+            "1 sound disc (77 min.) : digital, mono. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Opera and operetta excerpts, songs, and spirituals.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Biographical notes on the singer in German and English ([6] p.) inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded 1946-1949.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in Italian, French, or English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts",
+            "Songs (Low voice) with orchestra"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Lebendige Vergangenheit"
+          ],
+          "language": [
+            {
+              "id": "lang:ita",
+              "label": "Italian"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1999
+          ],
+          "dateEndString": [
+            "1946"
+          ],
+          "title": [
+            "Robert Merrill"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "*LDC 24736 (F)"
+          ],
+          "createdString": [
+            "1999"
+          ],
+          "creatorLiteral": [
+            "Merrill, Robert, 1917-2004"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Kirsten, Dorothy, 1910-1992",
+            "Morel, Jean-Paul",
+            "Weissmann, Frieder",
+            "Leinsdorf, Erich, 1912-1993",
+            "Case, Russ, 1912-1964",
+            "Rossini, Gioacchino, 1792-1868",
+            "Verdi, Giuseppe, 1813-1901",
+            "Gounod, Charles, 1818-1893",
+            "Thomas, Ambroise, 1811-1896",
+            "Massenet, Jules, 1842-1912",
+            "Meyerbeer, Giacomo, 1791-1864",
+            "Offenbach, Jacques, 1819-1880",
+            "Bizet, Georges, 1838-1875",
+            "Giordano, Umberto, 1867-1948",
+            "Leoncavallo, Ruggiero, 1858-1919",
+            "Herbert, Victor, 1859-1924",
+            "Lehár, Franz, 1870-1948",
+            "Speaks, Oley, 1876-1948",
+            "Rasbach, Oscar, 1888-1975",
+            "Berlin, Irving, 1888-1989",
+            "RCA Victor Orchestra. prf"
+          ],
+          "addedAuthorTitle": [
+            "Barbiere di Siviglia.",
+            "Traviata.",
+            "Faust.",
+            "Hamlet.",
+            "Hérodiade.",
+            "Africaine.",
+            "Contes d'Hoffmann.",
+            "Carmen.",
+            "Thaïs.",
+            "Andrea Chénier.",
+            "Zazà.",
+            "Naughty Marietta.",
+            "Land des Lächelns.",
+            "Sylvia.",
+            "Trees.",
+            "Always."
+          ],
+          "dateStartYear": [
+            1999
+          ],
+          "idOclc": [
+            "50522147"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 24736 (F)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16550061"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "50522147"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "89501 Lebendige Vergangenheit"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "MONO 89501 Lebendige Vergangenheit"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)50522147"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M110000082"
+            }
+          ],
+          "popularity": 0,
+          "uniformTitle": [
+            "Jonah and the whale.",
+            "Down to the river."
+          ],
+          "dateEndYear": [
+            1946
+          ],
+          "updatedAt": 1751309312226,
+          "publicationStatement": [
+            "[Austria] : Lebendige Vergangenheit, p1999."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 24736 (F)",
+            "urn:bnum:16550061",
+            "urn:oclc:50522147",
+            "urn:identifier:89501 Lebendige Vergangenheit",
+            "urn:identifier:MONO 89501 Lebendige Vergangenheit",
+            "urn:identifier:(OCoLC)50522147",
+            "urn:identifier:(WaOLN)M110000082"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts.",
+            "Songs (Low voice) with orchestra."
+          ],
+          "titleDisplay": [
+            "Robert Merrill [sound recording]."
+          ],
+          "uri": "b16550061",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[Austria]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Il barbiere di Siviglia. Largo al factotum / Rossini -- La Traviata. Ah! Dite alla giovine ; Di Provenza il mar / Verdi -- Faust. Avant de quitter ces lieux / Gounod -- Hamlet. O vin dissipe la tristesse / Thomas -- Hérodiade. Vision fugitive / Massenet -- L'Africana. Adamastor, re dell'onde profonde / Meyerbeer -- Les contes d'Hoffmann. Scintille diamant / Offenbach -- Carmen. Votre toast, je peux vous le rendre / Bizet -- Thais. Te souvient-il du lumineux voyage / Massenet (with Dorothy Kirsten) -- Andrea Chenier. Nemico della patria / Giordano -- Zazá. Zazá, picolla singara / Leoncavallo --Naughty Marietta. I'm falling in love with someone ; Ah! Sweet mystery of life / Young-Herbert -- Land of smile. Yours is my heart alone / Smith-Lehár -- Sylvia / Scollard-Speaks -- Trees / Kilmer-Rasbach -- Always / Berlin -- Jonah and the whale / arr. MacGimsey -- Down to de rivah / arr. MacGimsey."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          14.34354,
+          "b16550061"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16550061",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433067801856"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 24736 (F) [Notes]",
+                      "urn:barcode:33433067801856"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LDC 24736 (F) [Notes]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433067801856",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LDC 24736 (F) [Notes]"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "*LDC 24736 (F) [Notes]"
+                    ],
+                    "shelfMark_sort": "a*LDC 24736 (F) [Notes]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17328535"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16550061",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Merrill%2C+Robert%2C+1917-2004&CallNumber=*LDC+24736+%28F%29+%5BCD%5D&Date=1999&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16550061&ItemISxN=i17328534x&ItemNumber=33433067801609&ItemPlace=%5BAustria%5D&ItemPublisher=Lebendige+Vergangenheit%2C+p1999.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b16550061x&Site=LPAMRAMI&Title=Robert+Merrill"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433067801609"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 24736 (F) [CD]",
+                      "urn:barcode:33433067801609"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LDC 24736 (F) [CD]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433067801609",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LDC 24736 (F) [CD]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LDC 24736 (F) [CD]"
+                    ],
+                    "shelfMark_sort": "a*LDC 24736 (F) [CD]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17328534"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b23229783",
+        "_score": 14.34354,
+        "_source": {
+          "extent": [
+            "1 audio disc (68 min., 10 sec.) : digital ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Pacific 1860, words and music by Noel Coward ; South Pacific, music by Richard Rodgers ; lyrics by Oscar Hammerstein II.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Analog recording.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes by Bucky Willard inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "The 1st work recorded in 1946.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Musicals",
+            "Musicals -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Encore Productions/Box Office Recordings"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1993
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1946"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Pacific 1860 : &, South Pacific : Mary Martin at Drury Lane--."
+          ],
+          "shelfMark": [
+            "*LDC 47816"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1993"
+          ],
+          "creatorLiteral": [
+            "Coward, Noël, 1899-1973"
+          ],
+          "idLccn": [
+            "2013627392",
+            "764805289328"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Hammerstein, Oscar, II, 1895-1960",
+            "Martin, Mary, 1913-1990",
+            "Payn, Graham",
+            "Cecil, Sylvia",
+            "Evans, Wilbur, 1905-1987",
+            "Mantovani, 1905-1980",
+            "Burston, Reginald",
+            "Rodgers, Richard, 1902-1979",
+            "Drury Lane Theatre Orchestra, performer"
+          ],
+          "addedAuthorTitle": [
+            "South Pacific."
+          ],
+          "dateStartYear": [
+            1993
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 47816"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "23229783"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "34961152"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2013627392"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "764805289328"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "ENBO-CD #8/93 Encore Productions/Box Office Recordings"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)34961152"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1037196333 (OCoLC)1059478510"
+            }
+          ],
+          "idOclc": [
+            "34961152"
+          ],
+          "popularity": 0,
+          "dateEndYear": [
+            1946
+          ],
+          "updatedAt": 1729185215237,
+          "publicationStatement": [
+            "[England?] : Encore Productions/Box Office Recordings, [1993]",
+            "℗1993"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 47816",
+            "urn:bnum:23229783",
+            "urn:oclc:34961152",
+            "urn:lccn:2013627392",
+            "urn:lccn:764805289328",
+            "urn:identifier:ENBO-CD #8/93 Encore Productions/Box Office Recordings",
+            "urn:identifier:(OCoLC)34961152",
+            "urn:identifier:(OCoLC)1037196333 (OCoLC)1059478510"
+          ],
+          "genreForm": [
+            "Musicals."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1993"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Musicals.",
+            "Musicals -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Pacific 1860 : &, South Pacific : Mary Martin at Drury Lane--."
+          ],
+          "uri": "b23229783",
+          "lccClassification": [
+            "AV1.2.C687 P32 1993"
+          ],
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[England?]"
+          ],
+          "titleAlt": [
+            "South Pacific.",
+            "Mary Martin at Drury Lane--"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Pacific 1860. His Excellency regrets (3:28) -- If I were a man (1:02) ; Uncle Harry (3:12) -- Dear Madame Salvador (2:08) ; My horse has cast a shoe (2:21) -- Bright was the day (4:45) -- One, two, three (2:03) ; I never knew (2:36) -- I saw no shadow (3:58) -- Invitation to the waltz (3:35) -- I wish I wasn't such a big girl (4:40) -- Pretty little bridesmaids (2:48) ; Mother's lament (1:38) -- This is a changing world (4:46) -- Fumfumbolo (4:30) -- This is a night for lovers (3:03) ; The toast music/Finale (1:39) -- South Pacific. Selection (part 1) (4:37) -- Twin soliloquies (2:46) -- Finale/Some enchanted evening (3:10) -- Selection (Part 2) (4:44)."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          14.34354,
+          "b23229783"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b23229783",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 47816",
+                      "urn:barcode:33433085449688"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 47816"
+                    ],
+                    "shelfMark_sort": "a*LDC 047816",
+                    "catalogItemType_packed": [
+                      "catalogItemType:60||pamphlets, singles, 1-50 pages"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 47816"
+                    ],
+                    "uri": "i40728472",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 47816"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085449688"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433085449688"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:60",
+                        "label": "pamphlets, singles, 1-50 pages"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Audio"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b23229783",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 47816",
+                      "urn:barcode:33433085449696"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 47816"
+                    ],
+                    "shelfMark_sort": "a*LDC 047816",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Coward%2C+No%C3%ABl%2C+1899-1973&CallNumber=*LDC+47816&Date=1993&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db23229783&ItemISxN=i407284710&ItemNumber=33433085449696&ItemPlace=%5BEngland%3F%5D&ItemPublisher=%E2%84%971993&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b232297836&Site=LPAMRAMI&Title=Pacific+1860+%3A+%26%2C+South+Pacific+%3A+Mary+Martin+at+Drury+Lane--.&Transaction.CustomFields.MapsLocationNote=%5BCD%5D"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 47816"
+                    ],
+                    "uri": "i40728471",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 47816"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085449696"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433085449696"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Audio"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b19776596",
+        "_score": 14.341276,
+        "_source": {
+          "extent": [
+            "570 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Reprint. Originally published: Chicago : Werner Company, 1887.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cooking, American",
+            "Home economics",
+            "Home economics -- United States"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ottenheimer Publishers"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1999
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "dateEndString": [
+            "1887"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The White House cook book : cooking, toilet and household recipes, menus, dinner-giving, table etiquette, care of the sick, health suggestions, facts worth knowing, etc., etc. : the whole comprising a comprehensive cyclopedia of information for the home"
+          ],
+          "shelfMark": [
+            "JFF 13-230"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1999"
+          ],
+          "creatorLiteral": [
+            "Gillette, F. L. (Fanny Lemira), 1828-1926"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ziemann, Hugo"
+          ],
+          "dateStartYear": [
+            1999
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 13-230"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "19776596"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0824103394"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780824103392"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "44968025"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)44968025"
+            }
+          ],
+          "idOclc": [
+            "44968025"
+          ],
+          "dateEndYear": [
+            1887
+          ],
+          "updatedAt": 1711223710998,
+          "publicationStatement": [
+            "[S.l.] : Ottenheimer Publishers, 1999, c1887."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFF 13-230",
+            "urn:bnum:19776596",
+            "urn:isbn:0824103394",
+            "urn:isbn:9780824103392",
+            "urn:oclc:44968025",
+            "urn:identifier:(OCoLC)44968025"
+          ],
+          "idIsbn": [
+            "0824103394",
+            "9780824103392"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cooking, American.",
+            "Home economics -- United States."
+          ],
+          "titleDisplay": [
+            "The White House cook book : cooking, toilet and household recipes, menus, dinner-giving, table etiquette, care of the sick, health suggestions, facts worth knowing, etc., etc. : the whole comprising a comprehensive cyclopedia of information for the home / by Mrs. F.L. Gillette and Hugo Ziemann."
+          ],
+          "uri": "b19776596",
+          "lccClassification": [
+            "TX715 .G413 1999"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "[S.l.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Carving -- Soups -- Fish -- Shell fish -- Poultry and game -- Meats -- Mutton and lamb -- Pork -- Sauces adn dressing for meats and fish -- Salads -- Catsups -- Pickles -- Vegetables -- Macaroni -- Butter and cheese -- Eggs -- Omelets -- Sandwiches -- Bread -- Biscuits, rolls, muffins, etc. -- Toast -- Cakes -- Pastry, pies, and tarts -- Custards, cream and desserts -- Ice cream and ices -- Dumplings and puddings -- Sauces for pudding -- Preserves, jellies, etc. -- Canned fruits -- Coloring for fruit and confectionary -- Confectionary -- Coffee, tea, and beverages -- Varieties of seasonable food -- Menus -- Management of state dinners at White House -- Preparations for the sick -- Suggestions in regard to health -- Miscellaneous recipes -- Facts worth knowing -- Toilet recipes and items -- French words in cooking -- Articles required for the kitchen -- Dyeing or coloring -- Small points on table etiquette -- Dinner-giving -- Measures and weights in ordinary use."
+          ],
+          "dimensions": [
+            "26 cm."
+          ],
+          "idIsbn_clean": [
+            "0824103394",
+            "9780824103392"
+          ]
+        },
+        "sort": [
+          14.341276,
+          "b19776596"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b19776596",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFF 13-230",
+                      "urn:barcode:33433101197964"
+                    ],
+                    "physicalLocation": [
+                      "JFF 13-230"
+                    ],
+                    "shelfMark_sort": "aJFF 13-000230",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFF 13-230"
+                    ],
+                    "uri": "i30026234",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFF 13-230"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101197964"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433101197964"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b21889069",
+        "_score": 14.338375,
+        "_source": {
+          "extent": [
+            "1 online resource (1 sound file)."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Libretto by Henri Meilhac and Ludovic Halévy, based on the short story by Prosper Mérimée.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Previously released material.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded 1963.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "RCA Victor Gold Seal",
+            "Distributed by BMG Music"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            1990
+          ],
+          "dateEndString": [
+            "1963"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Carmen : highlights"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1990"
+          ],
+          "creatorLiteral": [
+            "Bizet, Georges, 1838-1875"
+          ],
+          "idLccn": [
+            "USBC16300177",
+            "USBC16300178",
+            "USBC16300179",
+            "USBC16300180",
+            "USBC16300181",
+            "USBC16300182",
+            "USBC16300183",
+            "USBC16300184",
+            "USBC16300185",
+            "USBC16300186",
+            "USBC16300187",
+            "USBC16300188",
+            "USBC16300189",
+            "USBC16300190",
+            "USBC16300191",
+            "USBC16300192",
+            "USBC16300193",
+            "USBC16300194",
+            "USBC16300195"
+          ],
+          "seriesStatement": [
+            "Opera series"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "contributorLiteral": [
+            "Meilhac, Henri, 1831-1897",
+            "Halévy, Ludovic, 1834-1908",
+            "Price, Leontyne",
+            "Freni, Mirella, 1935-2020",
+            "Corelli, Franco",
+            "Merrill, Robert, 1917-2004",
+            "Karajan, Herbert von",
+            "Mérimée, Prosper, 1803-1870",
+            "Konzertvereinigung Wiener Staatsopernchor",
+            "Wiener Philharmoniker"
+          ],
+          "addedAuthorTitle": [
+            "Carmen."
+          ],
+          "dateStartYear": [
+            1990
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "21889069"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "906156941"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300177"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300178"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300179"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300180"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300181"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300182"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300183"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300184"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300185"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300186"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300187"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300188"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300189"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300190"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300191"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300192"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300193"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300194"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "USBC16300195"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "090266019021 RCA Records"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)906156941"
+            }
+          ],
+          "idOclc": [
+            "906156941"
+          ],
+          "popularity": 0,
+          "uniformTitle": [
+            "Carmen. Selections",
+            "Opera series."
+          ],
+          "dateEndYear": [
+            1963
+          ],
+          "updatedAt": 1741059610706,
+          "publicationStatement": [
+            "New York, NY : RCA Victor Gold Seal, [1990]",
+            "Distributed by BMG Music",
+            "℗1990"
+          ],
+          "identifier": [
+            "urn:bnum:21889069",
+            "urn:oclc:906156941",
+            "urn:lccn:USBC16300177",
+            "urn:lccn:USBC16300178",
+            "urn:lccn:USBC16300179",
+            "urn:lccn:USBC16300180",
+            "urn:lccn:USBC16300181",
+            "urn:lccn:USBC16300182",
+            "urn:lccn:USBC16300183",
+            "urn:lccn:USBC16300184",
+            "urn:lccn:USBC16300185",
+            "urn:lccn:USBC16300186",
+            "urn:lccn:USBC16300187",
+            "urn:lccn:USBC16300188",
+            "urn:lccn:USBC16300189",
+            "urn:lccn:USBC16300190",
+            "urn:lccn:USBC16300191",
+            "urn:lccn:USBC16300192",
+            "urn:lccn:USBC16300193",
+            "urn:lccn:USBC16300194",
+            "urn:lccn:USBC16300195",
+            "urn:identifier:090266019021 RCA Records",
+            "urn:identifier:(OCoLC)906156941"
+          ],
+          "genreForm": [
+            "Streaming audio."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1990"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Carmen : highlights / Bizet."
+          ],
+          "uri": "b21889069",
+          "lccClassification": [
+            "M1505.B58 C37 1990"
+          ],
+          "electronicResources": [
+            {
+              "label": "Access Naxos Music Library",
+              "url": "https://nypl.naxosmusiclibrary.com/catalogue/item.asp?cid=090266019021"
+            }
+          ],
+          "formatId": "w",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "New York, NY"
+          ],
+          "titleAlt": [
+            "Carmen."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Overture -- Dans l'air, nous suivons des yeux (Chorus of cigarette girls) -- La voilà, la voilà -- L'amour est un oiseau rebelle (Habanera) -- Près des remparts de Séville -- Act II Entr'acte -- Tringles des sistres tintaient (Gypsy song) -- Messieurs, pastia me dit -- Vivat! vvivat le Toréreo! -- Votre toast (Toreador song) -- Nous avons en tête une affaire (Quintet) -- Lalalala -- Attends un pueu, Carmen -- Fleur que tu m'avais jetée (Flowere song) -- Mêlons! Coupons! (Card scene) -- Je dis que rien ne m'épouvante (Micaela's air) -- Act IV Entr'acte -- C'est toi -- C'est moi! -- Où va-tu? -- Laisse-moi!"
+          ]
+        },
+        "sort": [
+          14.338375,
+          "b21889069"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b21893916",
+        "_score": 14.338375,
+        "_source": {
+          "extent": [
+            "1 online resource (1 sound file)."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Historical and program notes by Ken Bloom, William Bolcom, Ted Chapin, Michael Feinstein, Hugh Martin, Albert Petrak, and Bill Rudman in container insert.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded between 1926 and 1971.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Popular music",
+            "Musicals",
+            "Musicals -- Excerpts",
+            "Piano music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Harbinger Records"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            2008
+          ],
+          "buildingLocationIds": [],
+          "dateEndString": [
+            "1926"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Command performance"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2008"
+          ],
+          "creatorLiteral": [
+            "Rodgers, Richard, 1902-1979"
+          ],
+          "seriesStatement": [
+            "Songwriter showcase series"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "dateStartYear": [
+            2008
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "21893916"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "906568194"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "HCD2501 Harbinger Records"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)906568194"
+            }
+          ],
+          "idOclc": [
+            "906568194"
+          ],
+          "uniformTitle": [
+            "Works. Selections",
+            "Songwriter showcase series."
+          ],
+          "dateEndYear": [
+            1926
+          ],
+          "updatedAt": 1711271640438,
+          "publicationStatement": [
+            "New York : Harbinger Records, ℗2008."
+          ],
+          "identifier": [
+            "urn:bnum:21893916",
+            "urn:oclc:906568194",
+            "urn:identifier:HCD2501 Harbinger Records",
+            "urn:identifier:(OCoLC)906568194"
+          ],
+          "genreForm": [
+            "Demo recordings.",
+            "Streaming audio."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2008"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Popular music.",
+            "Musicals -- Excerpts.",
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Command performance / Richard Rodgers."
+          ],
+          "uri": "b21893916",
+          "lccClassification": [
+            "M1630.18.R637 C66 2008"
+          ],
+          "electronicResources": [
+            {
+              "label": "Access Naxos Music Library",
+              "url": "https://nypl.naxosmusiclibrary.com/catalogue/item.asp?cid=HCD2501"
+            }
+          ],
+          "formatId": "w",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "titleAlt": [
+            "Works."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "The girl friend -- The blue room -- Mountain greenery -- What's the use of talking? -- Where's that rainbow? -- Selections from the stage musical Peggy-Ann -- My heart stood still -- Selections from the stage musical Spring is here -- No bottom -- Roll, Mississippi -- Soon -- Pablo, you are my heart -- Down by the river -- The steely glint in my eye -- The notorious Colonel Blake -- It's easy to remember -- Introduction -- A little of you on toast -- Falling in love with love ; Lover -- My heart stood still -- A wonderful guy -- Waltz for a ball -- Rodgers talks about Hart and Hammerstein."
+          ]
+        },
+        "sort": [
+          14.338375,
+          "b21893916"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b15898906",
+        "_score": 14.134297,
+        "_source": {
+          "extent": [
+            "1 sound disc (60 min.) : digital ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Excerpts from musicals, operettas, or revues.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Tracks 5-8 arr. for voice and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "All selections previously released.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes by Peter Dempsey and recording details in English (8 p.) inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded between Apr. 25, 1928, and Oct. 28, 1931, in England.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Musicals",
+            "Musicals -- Excerpts",
+            "Musicals -- Excerpts, Arranged",
+            "Revues",
+            "Revues -- Excerpts",
+            "Revues -- Excerpts, Arranged"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Naxos ; Distributed by Naxos of America Inc."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            2000
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1928"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A room with a view the complete recordings, vol. 1: 1928-1932"
+          ],
+          "shelfMark": [
+            "*LDC 30092"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2000"
+          ],
+          "creatorLiteral": [
+            "Coward, Noël, 1899-1973"
+          ],
+          "idLccn": [
+            "636943252925"
+          ],
+          "seriesStatement": [
+            "Naxos nostalgia",
+            "The complete recordings / Noël Coward ; vol. 1, 1928-1932",
+            "Coward, Noël, 1899-1973. Works. Selections ; v. 1."
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Lawrence, Gertrude",
+            "Gibbons, Carroll",
+            "Noble, Ray, 1903-1978"
+          ],
+          "addedAuthorTitle": [
+            "This year of grace.",
+            "Dream is over;",
+            "Bitter-sweet.",
+            "Private lives.",
+            "Half-caste woman.",
+            "Cavalcade."
+          ],
+          "dateStartYear": [
+            2000
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 30092"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15898906"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "47374437"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "636943252925"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "8.120529 Naxos"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M220000285"
+            }
+          ],
+          "idOclc": [
+            "47374437"
+          ],
+          "uniformTitle": [
+            "Vocal music. Selections"
+          ],
+          "popularity": 0,
+          "dateEndYear": [
+            1928
+          ],
+          "updatedAt": 1729004698478,
+          "publicationStatement": [
+            "[S.l.] : Naxos ; Franklin, Tenn. : Distributed by Naxos of America Inc., p2001."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 30092",
+            "urn:bnum:15898906",
+            "urn:oclc:47374437",
+            "urn:lccn:636943252925",
+            "urn:identifier:8.120529 Naxos",
+            "urn:identifier:(WaOLN)M220000285"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2000"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Musicals -- Excerpts.",
+            "Musicals -- Excerpts, Arranged.",
+            "Revues -- Excerpts.",
+            "Revues -- Excerpts, Arranged."
+          ],
+          "titleDisplay": [
+            "A room with a view [sound recording] : the complete recordings, vol. 1: 1928-1932 / Noël Coward."
+          ],
+          "uri": "b15898906",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[S.l.] : Franklin, Tenn."
+          ],
+          "titleAlt": [
+            "Vocal music."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "This year of grace. Dance, little lady (2:43) ; A room with a view (3:29) ; Mary Make-Believe (3:07) ; Try to learn to love (3:22) ; Loralei [i.e. Lorelei] (3:04) -- The dream is over (A dream of youth) (3:23) -- Bitter sweet. Zigeuner (2:49) -- This year of grace. World weary (3:00) -- Love scene from Private lives, Act 1 : Some day I'll find you (with Gertrude Lawrence, vocals) (4:42) -- Scene from Private lives, Act 2 : I never realised ; If you were the only girl in the world (with Gertrude Lawrence, vocals) (4:19) -- Half-caste woman (3:19) -- Any little fish (2:20) -- Lover of my dreams : (Mirabelle valse) (2:39) -- Cavalcade vocal medley (8:11) -- Cavalcade, epilogue : Toast to England : [spoken] (0:38) -- Noël Coward medley (8:50)."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          14.134297,
+          "b15898906"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15898906",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 30092 [Notes]",
+                      "urn:barcode:33433031368065"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 30092 [Notes]"
+                    ],
+                    "shelfMark_sort": "a*LDC 30092 [Notes]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 30092 [Notes]"
+                    ],
+                    "uri": "i14681160",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 30092 [Notes]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433031368065"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433031368065"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Audio"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15898906",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 30092 [CD]",
+                      "urn:barcode:33433031368057"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 30092 [CD]"
+                    ],
+                    "shelfMark_sort": "a*LDC 30092 [CD]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Coward%2C+No%C3%ABl%2C+1899-1973.&CallNumber=*LDC+30092+%5BCD%5D&Date=2000&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15898906&ItemISxN=i146811598&ItemNumber=33433031368057&ItemPlace=%5BS.l.%5D+%3A+Franklin%2C+Tenn.&ItemPublisher=Naxos+%3B+Distributed+by+Naxos+of+America+Inc.%2C+p2001.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b158989065&Site=LPAMRAMI&Title=A+room+with+a+view+the+complete+recordings%2C+vol.+1%3A+1928-1932"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 30092 [CD]"
+                    ],
+                    "uri": "i14681159",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 30092 [CD]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433031368057"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433031368057"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Audio"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16331391",
+        "_score": 14.13223,
+        "_source": {
+          "extent": [
+            "2 sound discs : digital, stereo ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Compact discs.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes ([14] p. : ports.) inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded between 1981 and 2004.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Rock music",
+            "Heavy metal (Music)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Hip-O Records"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            2005
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1981"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Red, white & Crüe"
+          ],
+          "shelfMark": [
+            "*LDC 39144"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2005"
+          ],
+          "creatorLiteral": [
+            "Mötley Crüe (Musical group)"
+          ],
+          "idLccn": [
+            "075021033825"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2005
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 39144"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16331391"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "60193423"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "075021033825"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "B0003909-02 Hip-O Records"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M110000050"
+            }
+          ],
+          "idOclc": [
+            "60193423"
+          ],
+          "dateEndYear": [
+            1981
+          ],
+          "updatedAt": 1712868406763,
+          "publicationStatement": [
+            "Santa Monica, Calif. : Hip-O Records, p2005."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 39144",
+            "urn:bnum:16331391",
+            "urn:oclc:60193423",
+            "urn:lccn:075021033825",
+            "urn:identifier:B0003909-02 Hip-O Records",
+            "urn:identifier:(WaOLN)M110000050"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2005"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Rock music.",
+            "Heavy metal (Music)"
+          ],
+          "titleDisplay": [
+            "Red, white & Crüe [sound recording] / Mötley Crüe."
+          ],
+          "uri": "b16331391",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Santa Monica, Calif."
+          ],
+          "titleAlt": [
+            "Red, white and Crüe"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Disc 1. Live wire -- Piece of your action -- Toast of the town -- Too fast for love -- Black widow -- Looks that kill -- Too young to fall in love (Remix) -- Helter skelter -- Shout at the Devil -- Smokin' in the boys room -- Use it or lose it -- Girls, girls, girls -- Wild side -- You're all I need -- All in the name of-- -- Kickstart my heart -- Without you -- Don't go away mad (Just go away) -- Same ol' situation (S.O.S.) -- Dr. Feelgood.",
+            "Disc 2. Anarchy in the UK -- Primal scream -- Home sweet home (Remix) -- Hooligan's holiday (Brown nose edit) -- Misunderstood (Successful format version) -- Planet boom -- Bittersuite -- Afraid (Alternative rave mix) -- Beauty -- Generation swine -- Bitter pill -- Enslaved -- Hell on high heels -- New tattoo (Single version) -- If I die tomorrow -- Sick love song -- Street fighting man."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          14.13223,
+          "b16331391"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16331391",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 39144 [Notes]",
+                      "urn:barcode:33433062945013"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 39144 [Notes]"
+                    ],
+                    "shelfMark_sort": "a*LDC 39144 [Notes]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 39144 [Notes]"
+                    ],
+                    "uri": "i15640816",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 39144 [Notes]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062945013"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433062945013"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16331391",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 39144 [CD]",
+                      "urn:barcode:33433062945377"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 39144 [CD]"
+                    ],
+                    "shelfMark_sort": "a*LDC 39144 [CD]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=M%C3%B6tley+Cr%C3%BCe+%28Musical+group%29&CallNumber=*LDC+39144+%5BCD%5D&Date=2005&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16331391&ItemISxN=i156408156&ItemNumber=33433062945377&ItemPlace=Santa+Monica%2C+Calif.&ItemPublisher=Hip-O+Records%2C+p2005.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b16331391x&Site=LPAMRAMI&Title=Red%2C+white+%26+Cr%C3%BCe"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 39144 [CD]"
+                    ],
+                    "uri": "i15640815",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 39144 [CD]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062945377"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433062945377"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b21880982",
+        "_score": 14.062544,
+        "_source": {
+          "extent": [
+            "1 online resource (61 min.)"
+          ],
+          "note": [
+            {
+              "noteType": "Event",
+              "label": "Recorded Jul. 6-20, 1964, Salle Wagram, Paris.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in French.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "EMI Classics"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            1998
+          ],
+          "buildingLocationIds": [],
+          "dateEndString": [
+            "1964"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Carmen (highlights)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1998"
+          ],
+          "creatorLiteral": [
+            "Bizet, Georges, 1838-1875"
+          ],
+          "idLccn": [
+            "GBAYC9701429",
+            "GBAYC9701432",
+            "GBAYC9701435",
+            "GBAYC9701439",
+            "GBAYC9701443",
+            "GBAYC9701446",
+            "GBAYC9701453",
+            "GBAYC9701459",
+            "GBAYC9701462",
+            "GBAYC9701469",
+            "GBAYC9701470"
+          ],
+          "seriesStatement": [
+            "Classical music library"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "contributorLiteral": [
+            "Callas, Maria, 1923-1977",
+            "Guiot, Andréa",
+            "Sautereau, Nadine",
+            "Gedda, Nicolai",
+            "Massard, Robert",
+            "Prêtre, Georges",
+            "Chœurs d'enfants Jean Pesneaud. prf",
+            "Chœurs René Duclos. prf",
+            "Opéra de Paris. Orchestre. prf"
+          ],
+          "dateStartYear": [
+            1998
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "21880982"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "809793139"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9701429"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9701432"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9701435"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9701439"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9701443"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9701446"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9701453"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9701459"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9701462"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9701469"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "GBAYC9701470"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "0724356666351 EMI Classics"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)809793139"
+            }
+          ],
+          "idOclc": [
+            "809793139"
+          ],
+          "uniformTitle": [
+            "Carmen. Selections"
+          ],
+          "dateEndYear": [
+            1964
+          ],
+          "updatedAt": 1711279400901,
+          "publicationStatement": [
+            "New York, N.Y. : EMI Classics, [1998], p1964."
+          ],
+          "identifier": [
+            "urn:bnum:21880982",
+            "urn:oclc:809793139",
+            "urn:lccn:GBAYC9701429",
+            "urn:lccn:GBAYC9701432",
+            "urn:lccn:GBAYC9701435",
+            "urn:lccn:GBAYC9701439",
+            "urn:lccn:GBAYC9701443",
+            "urn:lccn:GBAYC9701446",
+            "urn:lccn:GBAYC9701453",
+            "urn:lccn:GBAYC9701459",
+            "urn:lccn:GBAYC9701462",
+            "urn:lccn:GBAYC9701469",
+            "urn:lccn:GBAYC9701470",
+            "urn:identifier:0724356666351 EMI Classics",
+            "urn:identifier:(OCoLC)809793139"
+          ],
+          "genreForm": [
+            "Sound recordings."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1998"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Carmen [electronic resource] : (highlights) / Bizet."
+          ],
+          "uri": "b21880982",
+          "lccClassification": [
+            "M1505"
+          ],
+          "electronicResources": [
+            {
+              "label": "Access Naxos Music Library",
+              "url": "https://nypl.naxosmusiclibrary.com/catalogue/item.asp?cid=0724356666351"
+            }
+          ],
+          "formatId": "w",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "New York, N.Y."
+          ],
+          "titleAlt": [
+            "Carmen."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Carmen. Act 1. Avec la garde montante ; L'amour est un oiseau rebelle (Habanera) ; Duo: Parle-moi de ma mère! ; Séguidille: Près des ramparts de Séville -- Carmen. Act 2. Chanson bohème: les tringles des sistres tintaient ; Couplets du Toréador; Votre toast, je peux vous le rendre ; Air de la fleur: La fleur que tu m'avais jetée ... Non, tu ne m'aimes pas -- Carmen. Act 3. Trio des Cartes: Mêlons! Coupons! ; C'est des contrebandiers ... Air de Micaëla:Je dis, que rien ne m'épouvante -- Carmen. Act 4. Les voici! voici la quadrille!: Les voici! ; C'est toi! ... Viva! viva! la course est belle!"
+          ]
+        },
+        "sort": [
+          14.062544,
+          "b21880982"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16685833",
+        "_score": 13.937926,
+        "_source": {
+          "extent": [
+            "1 sound disc : digital, mono. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vocal solo excerpts from operas.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes in German and English (1 folded sheet [4 p.]) inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded in 1913 (2nd-5th works), in 1914 (1st work) and in 1917 (6th-19th works) on various labels.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in German.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts",
+            "Songs (Medium voice) with orchestra"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Lebendige Vergangenheit"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1998
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1913"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Harry De Garmo (1887-1919)"
+          ],
+          "shelfMark": [
+            "*LDC 22428 (F)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1998"
+          ],
+          "creatorLiteral": [
+            "De Garmo, Harry, 1887-1919"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Wagner, Richard, 1813-1883",
+            "Bizet, Georges, 1838-1875",
+            "Verdi, Giuseppe, 1813-1901",
+            "Leoncavallo, Ruggiero, 1858-1919",
+            "Mozart, Wolfgang Amadeus, 1756-1791",
+            "Offenbach, Jacques, 1819-1880",
+            "Albert, Eugen d', 1864-1932"
+          ],
+          "addedAuthorTitle": [
+            "Fliegende Holländer.",
+            "Meistersinger von Nürnberg.",
+            "Ring des Nibelungen.",
+            "Tannhäuser.",
+            "Carmen.",
+            "Otello.",
+            "Pagliacci.",
+            "Don Giovanni.",
+            "Contes d'Hoffmann.",
+            "Tiefland."
+          ],
+          "dateStartYear": [
+            1998
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 22428 (F)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16685833"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "64432808"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "89175 Lebendige Vergangenheit"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)64432808"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M060000012"
+            }
+          ],
+          "idOclc": [
+            "64432808"
+          ],
+          "popularity": 0,
+          "dateEndYear": [
+            1913
+          ],
+          "updatedAt": 1729005817064,
+          "publicationStatement": [
+            "[Austria] : Lebendige Vergangenheit, p1998."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 22428 (F)",
+            "urn:bnum:16685833",
+            "urn:oclc:64432808",
+            "urn:identifier:89175 Lebendige Vergangenheit",
+            "urn:identifier:(OCoLC)64432808",
+            "urn:identifier:(WaOLN)M060000012"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1998"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts.",
+            "Songs (Medium voice) with orchestra."
+          ],
+          "titleDisplay": [
+            "Harry De Garmo (1887-1919) [sound recording]."
+          ],
+          "uri": "b16685833",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[Austria]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Der fliegende Holländer. Die Frist ist um / Wagner -- Die Meistersinger von Nürnberg. Was duftet doch der Flieder ; Verachtet mir die Meister nicht / Wagner -- Das Rheingold. Abendlich strahlt der Sonne Auge / Wagner -- Siegfried. Auf wolkigen Höh'n wohnen die Götter / Wagner -- Tannhäuser. Als du in kühnem Sange uns bestrittest ; O du mein holder Abendstern / Wagner -- Das Rheingold. Abendlich strahlt der Sonne Auge / Wagner -- Die Walküre. Leb' wohl, du kühnes, herrliches Kind / Wagner -- Siegfried. Auf wolkigen Höh'n wohnen die Götter / Wagner -- Carmen. Euren Toast kann ich wohl erwidern / Bizet -- Othello. Ich glaube an einen Gott / Verdi -- Bajazzo. Schaut her, ich bin's / Leoncavallo -- Don Juan. Treibt der Champagner das Blut erst im Kreise ; Horch auf den Klang der Zither / Mozart -- Der Meistersing von Nürnberg. Was duftet doch der Flieder ; Jerum! Jerum! / Wagner -- Hoffmanns Erzählungen. Leuchte, heller Spiegel / Offenbach -- Tiefland. Hüll' in die Mantille dich fester ein / d'Albert."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          13.937926,
+          "b16685833"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16685833",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 22428 (F) [Notes]",
+                      "urn:barcode:33433067801666"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 22428 (F) [Notes]"
+                    ],
+                    "shelfMark_sort": "a*LDC 22428 (F) [Notes]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 22428 (F) [Notes]"
+                    ],
+                    "uri": "i17406041",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 22428 (F) [Notes]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433067801666"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433067801666"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16685833",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 22428 (F) [CD]",
+                      "urn:barcode:33433067801419"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 22428 (F) [CD]"
+                    ],
+                    "shelfMark_sort": "a*LDC 22428 (F) [CD]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=De+Garmo%2C+Harry%2C+1887-1919.&CallNumber=*LDC+22428+%28F%29+%5BCD%5D&Date=1998&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16685833&ItemISxN=i174060403&ItemNumber=33433067801419&ItemPlace=%5BAustria%5D&ItemPublisher=Lebendige+Vergangenheit%2C+p1998.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b16685833x&Site=LPAMRAMI&Title=Harry+De+Garmo+%281887-1919%29"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 22428 (F) [CD]"
+                    ],
+                    "uri": "i17406040",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 22428 (F) [CD]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433067801419"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433067801419"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16862886",
+        "_score": 13.937926,
+        "_source": {
+          "extent": [
+            "1 sound disc (60 min.) : digital, mono. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Bawdy and scurrilous comedy routines and recitations.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Recordings from the collections of Edison National Historic Site, National Park Service, United States Department of the Interior (tracks 1-14); and Bruce R. Young, Hanson, Massachusetts (tracks 15-43).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Various performers.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes by Patrick Feaster and David Giovannoni and texts (58 p. : ill., ports.) inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded between 1892 and 1900.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "American wit and humor",
+            "Sex",
+            "Sex -- Humor",
+            "Bawdy poetry",
+            "Bawdy songs"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Archeophone"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            2007
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1892"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Actionable offenses indecent phonograph recordings from the 1890s."
+          ],
+          "shelfMark": [
+            "*LDC 45271"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2007"
+          ],
+          "idLccn": [
+            "778632900509"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Stewart, Cal, 1856-1919",
+            "Hunting, Russell",
+            "White, James H. (James Henry)",
+            "Feaster, Patrick, 1971-",
+            "Giovannoni, David"
+          ],
+          "dateStartYear": [
+            2007
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 45271"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16862886"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "153972294"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "778632900509"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "1007 Archeophone"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "ARCH 1007 Archeophone"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)153972294"
+            }
+          ],
+          "idOclc": [
+            "153972294"
+          ],
+          "dateEndYear": [
+            1892
+          ],
+          "updatedAt": 1712869693068,
+          "publicationStatement": [
+            "Champaign, Ill. : Archeophone, p2007."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 45271",
+            "urn:bnum:16862886",
+            "urn:oclc:153972294",
+            "urn:lccn:778632900509",
+            "urn:identifier:1007 Archeophone",
+            "urn:identifier:ARCH 1007 Archeophone",
+            "urn:identifier:(OCoLC)153972294"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2007"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "American wit and humor.",
+            "Sex -- Humor.",
+            "Bawdy poetry.",
+            "Bawdy songs."
+          ],
+          "titleDisplay": [
+            "Actionable offenses [sound recording] : indecent phonograph recordings from the 1890s."
+          ],
+          "uri": "b16862886",
+          "formatId": "i",
+          "recordTypeId": "i",
+          "placeOfPublication": [
+            "Champaign, Ill."
+          ],
+          "titleAlt": [
+            "Indecent phonograph recordings from the 1890s"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Learning a city gal how to milk ; The tapeworm story / believed to be by Cal Stewart -- Gimlet's soliloquy ; The rascal detector ; The whores' union ; Boarding the Folsom ; A few conundrums / by an unknown performer, possibly Russell Hunting -- Out of order ; Did he charge too much ; Reilly as a policeman ; Sim Hadley on a racket / believed to be by Russell Hunting -- Sim Hadley on a racket ; Michael Casey exhibiting his panorama ; Dennis Reilly at Maggie Murphy's home after nine o'clock / believed to be by James White -- Stroll on Capitol Hill ; A hard head ; The virtues of raw oysters ; Jokes, riddles, verses, a limerick, and a toast ; More verses and jokes ; The lady's friend ; A song ; The Irishman's prayer ; A joke ; Verses and songs ; Poem: \"I sit here thinking, Will, of you\" / by an unknown performer, probably home recordings."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          13.937926,
+          "b16862886"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16862886",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 45271 [Notes (Texts)]",
+                      "urn:barcode:33433079152835"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 45271 [Notes (Texts)]"
+                    ],
+                    "shelfMark_sort": "a*LDC 45271 [Notes (Texts)]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 45271 [Notes (Texts)]"
+                    ],
+                    "uri": "i17719148",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 45271 [Notes (Texts)]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433079152835"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433079152835"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Audio"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16862886",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 45271 [CD]",
+                      "urn:barcode:33433079152843"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 45271 [CD]"
+                    ],
+                    "shelfMark_sort": "a*LDC 45271 [CD]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=*LDC+45271+%5BCD%5D&Date=2007&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16862886&ItemISxN=i177191478&ItemNumber=33433079152843&ItemPlace=Champaign%2C+Ill.&ItemPublisher=Archeophone%2C+p2007.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b168628867&Site=LPAMRAMI&Title=Actionable+offenses+indecent+phonograph+recordings+from+the+1890s."
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 45271 [CD]"
+                    ],
+                    "uri": "i17719147",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 45271 [CD]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433079152843"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433079152843"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Audio"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b13907462",
+        "_score": 13.9360485,
+        "_source": {
+          "extent": [
+            "1 sound disc (1 hr., 2 min., 41 sec.) : digital, stereo. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Legacy: JK 57890 (on program notes: 57890).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For orchestra with enhanced brass and percussion sections featuring a wind machine.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Title from container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Music composed principally by Jerry Goldsmith.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Arranged by Arthur Morton (24th-30th works).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Ed. recorded: [New York, NY] : Hastings Music Corp. (BMI) 1966.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Originally released on LP in 1966 (Mainstream: S/6081); this CD includes some previously unreleased \"wild cues\" heard as background music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Notes by Ford A. Thaxton and David Hirsch ([4] p. : ill.) inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded at Shepperton Studios, London, England, Apr. 4, 1966.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Motion picture music",
+            "World War, 1914-1918",
+            "World War, 1914-1918 -- Songs and music",
+            "Wind machine music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Legacy : Manufactured by Sony Music Entertainment"
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1995
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1966"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The Blue Max original sound track recording"
+          ],
+          "shelfMark": [
+            "*LDC 12826 (F)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1995"
+          ],
+          "creatorLiteral": [
+            "Goldsmith, Jerry"
+          ],
+          "idLccn": [
+            "074645789026"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Morton, Arthur",
+            "Heinrich, Prince of Prussia, 1862-1929",
+            "Strauss, Johann, 1825-1899",
+            "Piefke, Johann Gottfried, 1815-1884",
+            "Haydn, Joseph, 1732-1809",
+            "Wilhelm, Carl, 1815-1873",
+            "National Philharmonic Orchestra (Great Britain)"
+          ],
+          "addedAuthorTitle": [
+            "Präsentiermarsch.",
+            "Künstlerleben.",
+            "Preussens Gloria.",
+            "Gott erhalte Franz, den Kaiser;",
+            "Wacht am Rhein;"
+          ],
+          "dateStartYear": [
+            1995
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 12826 (F)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13907462"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "33198568"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "074645789026"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Legacy JK 57890"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Legacy 57890"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Mainstream S/6081"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0496971"
+            }
+          ],
+          "idOclc": [
+            "33198568"
+          ],
+          "uniformTitle": [
+            "Blue Max",
+            "Blue Max (Motion picture)"
+          ],
+          "popularity": 0,
+          "dateEndYear": [
+            1966
+          ],
+          "updatedAt": 1729003287216,
+          "publicationStatement": [
+            "New York, NY : Legacy : Manufactured by Sony Music Entertainment, p1995."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 12826 (F)",
+            "urn:bnum:13907462",
+            "urn:oclc:33198568",
+            "urn:lccn:074645789026",
+            "urn:identifier:Legacy JK 57890",
+            "urn:identifier:Legacy 57890",
+            "urn:identifier:Mainstream S/6081",
+            "urn:identifier:(WaOLN)nyp0496971"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1995"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Motion picture music.",
+            "World War, 1914-1918 -- Songs and music.",
+            "Wind machine music."
+          ],
+          "titleDisplay": [
+            "The Blue Max [sound recording] : original sound track recording / Jerry Goldsmith."
+          ],
+          "uri": "b13907462",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "New York, NY"
+          ],
+          "titleAlt": [
+            "Blue Max",
+            "Pour le mérite."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "The Blue Max (Main title) (2:24) -- The new arrival (1:23) -- A toast to Bruno (1:41) -- First blood (2:23) -- First victory (:41)--  The captive (1:45) -- The victim (2:33) -- The Cobra (1:39) -- The attack (6:30) -- A small favor (:56) -- Love theme (1:16) -- The rivals (:26) -- Finale to part 1 (1:05) -- Prelude to part 2 (1:40) -- Love theme (:55) -- The bridge (3:14) -- Love theme (1:33) -- Retreat (7:36) -- Stachel to Berlin (2:25) -- Nothing needed (:39) -- Kaeti has a plan (3:30) -- Stachel's last flight (1:58) -- End title (2:34) -- Pour le mérite / trad. (2:15) -- Presentiar march / trad. (1:26) -- Student song medley / trad. (2:09) -- Artist's life / J. Strauss (:59) -- Gloria march / G. Piefke (:21) -- Deutschland über alles / J. Haydn (:48) -- Watch on the Rhine / K. Wilhelm (1:42)."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          13.9360485,
+          "b13907462"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b13907462",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 12826 (F)",
+                      "urn:barcode:33433047665371"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 12826 (F)"
+                    ],
+                    "shelfMark_sort": "a*LDC 12826 (F)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 12826 (F)"
+                    ],
+                    "uri": "i14434950",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 12826 (F)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433047665371"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433047665371"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Audio"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b21916755",
+        "_score": 13.803373,
+        "_source": {
+          "extent": [
+            "1 online resource (1 sound file)"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Opera excerpts.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Libretto by Henri Meilhac and Ludovic Halévy, based on the novel by Propser Mérimée.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in French.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Deutsche Grammophon"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Carmen : Querschnitt = highlights"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [
+            "Bizet, Georges, 1838-1875"
+          ],
+          "idLccn": [
+            "DEF058230702",
+            "DEF058230703",
+            "DEF058230706",
+            "DEF058230709",
+            "DEF058230711",
+            "DEF058230745",
+            "DEF058230746",
+            "DEF058230757",
+            "DEF058230721",
+            "DEF058230765",
+            "DEF058230723",
+            "DEF058230701",
+            "DEF058230705",
+            "DEF058230724",
+            "DEF058230712"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "contributorLiteral": [
+            "Meilhac, Henri, 1831-1897",
+            "Halévy, Ludovic, 1834-1908",
+            "Ricciarelli, Katia",
+            "Baltsa, Agnes",
+            "Carreras, José",
+            "Dam, José van",
+            "Karajan, Herbert von",
+            "Mérimée, Prosper, 1803-1870",
+            "Opéra de Paris. Chœur, singer",
+            "Schöneberger Sängerknaben, singer",
+            "Berliner Philharmoniker, instrumentalist"
+          ],
+          "addedAuthorTitle": [
+            "Carmen."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "21916755"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "983830749"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230702"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230703"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230706"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230709"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230711"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230745"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230746"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230757"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230721"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230765"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230723"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230701"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230705"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230724"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230712"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "00028941332226 Deutsche Grammophon"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)983830749"
+            }
+          ],
+          "idOclc": [
+            "983830749"
+          ],
+          "popularity": 0,
+          "uniformTitle": [
+            "Carmen. Selections"
+          ],
+          "updatedAt": 1741059613256,
+          "publicationStatement": [
+            "Hamburg : Deutsche Grammophon, [1984]"
+          ],
+          "identifier": [
+            "urn:bnum:21916755",
+            "urn:oclc:983830749",
+            "urn:lccn:DEF058230702",
+            "urn:lccn:DEF058230703",
+            "urn:lccn:DEF058230706",
+            "urn:lccn:DEF058230709",
+            "urn:lccn:DEF058230711",
+            "urn:lccn:DEF058230745",
+            "urn:lccn:DEF058230746",
+            "urn:lccn:DEF058230757",
+            "urn:lccn:DEF058230721",
+            "urn:lccn:DEF058230765",
+            "urn:lccn:DEF058230723",
+            "urn:lccn:DEF058230701",
+            "urn:lccn:DEF058230705",
+            "urn:lccn:DEF058230724",
+            "urn:lccn:DEF058230712",
+            "urn:identifier:00028941332226 Deutsche Grammophon",
+            "urn:identifier:(OCoLC)983830749"
+          ],
+          "genreForm": [
+            "Streaming audio."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Carmen : Querschnitt = highlights / Bizet."
+          ],
+          "uri": "b21916755",
+          "electronicResources": [
+            {
+              "label": "Access Naxos Music Library",
+              "url": "https://nypl.naxosmusiclibrary.com/catalogue/item.asp?cid=00028941332226"
+            }
+          ],
+          "formatId": "w",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Hamburg"
+          ],
+          "titleAlt": [
+            "Carmen."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Prélude, acte I (3:37) -- Sur la place (6:25) -- Avec la garde montante (2:28) -- L'amour est un oiseau rebelle (4:32) -- Dialogue: Monsieur le brigadier ; Parle-moi de ma mère (6:29) -- Près des remparts de Séville (4:49) -- Les tringles des sistres tintaient (4:59) -- Dialogue: Vous avez quelque chose à nous dire (1:21) -- Vivat! vivat le Toréro! (1:39) -- Votre toast, je peux vous le rendre (5:27) -- La fleur que tu m'avais jetée (4:22) -- En vain, pour éviter les réponses amères/Parlez encore, parlez, mes belles (3:08) -- A dos cuartos! (2:24) -- Musique de transition (:40) -- C'est toi!/C'est moi! (10:27)."
+          ]
+        },
+        "sort": [
+          13.803373,
+          "b21916755"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16582506",
+        "_score": 13.751576,
+        "_source": {
+          "extent": [
+            "1 sound disc : digital, mono. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Opera arias.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Biographical notes on the singer in German and English ([3] p.) inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded 1911-1932.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in Italian, French, and Russian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Lebendige Vergangenheit"
+          ],
+          "language": [
+            {
+              "id": "lang:ita",
+              "label": "Italian"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            2000
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1911"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Georges Baklanoff"
+          ],
+          "shelfMark": [
+            "*LDC 39955"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2000"
+          ],
+          "creatorLiteral": [
+            "Baklanoff, Georges, 1881-1938"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Lipkovska︠i︡a, Lidi︠i︡a ︠I︡Akovlevna",
+            "Verdi, Giuseppe, 1813-1901",
+            "Rubinstein, Anton, 1829-1894",
+            "Ponchielli, Amilcare, 1834-1886",
+            "Gounod, Charles, 1818-1893",
+            "Bizet, Georges, 1838-1875",
+            "Delibes, Léo, 1836-1891",
+            "Tchaikovsky, Peter Ilich, 1840-1893",
+            "Leoncavallo, Ruggiero, 1858-1919",
+            "Thomas, Ambroise, 1811-1896",
+            "Mozart, Wolfgang Amadeus, 1756-1791",
+            "Berlioz, Hector, 1803-1869",
+            "Borodin, Aleksandr Porfirʹevich, 1833-1887",
+            "Mussorgsky, Modest Petrovich, 1839-1881"
+          ],
+          "addedAuthorTitle": [
+            "Rigoletto.",
+            "Demon.",
+            "Gioconda.",
+            "Otello.",
+            "Ballo in maschera.",
+            "Faust.",
+            "Carmen.",
+            "Lakmé.",
+            "Evgeniĭ Onegin.",
+            "Pagliacci.",
+            "Hamlet.",
+            "Don Giovanni.",
+            "Damnation de Faust.",
+            "Kn︠i︡azʹ Igorʹ.",
+            "Boris Godunov (Rimsky-Korsakov)."
+          ],
+          "dateStartYear": [
+            2000
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 39955"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16582506"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "49358501"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "89522 Lebendige Vergangenheit"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)49358501"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M230000207"
+            }
+          ],
+          "idOclc": [
+            "49358501"
+          ],
+          "popularity": 0,
+          "dateEndYear": [
+            1911
+          ],
+          "updatedAt": 1729005777927,
+          "publicationStatement": [
+            "[Austria] : Lebendige Vergangenheit, p2000."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 39955",
+            "urn:bnum:16582506",
+            "urn:oclc:49358501",
+            "urn:identifier:89522 Lebendige Vergangenheit",
+            "urn:identifier:(OCoLC)49358501",
+            "urn:identifier:(WaOLN)M230000207"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2000"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Georges Baklanoff [sound recording]."
+          ],
+          "uri": "b16582506",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[Austria]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Rigoletto. Figlia! Mio padre! / Verdi (with Lydia Lipkowska) -- The demon. Do not weep, my child ; I swear by the eternal truth / Rubinstein -- La gioconda. Pescator, affonda l'esca / Ponchielli -- Otello. Credo in un Dio crudel; Era la notte ; Un ballo in maschera. Eri tu che macchiavi / Verdi -- Faust. Le veau d'or / Gounod (sung in Russian) -- Carmen. Vôtre toast / Bizet (sung in Russian) -- Lakmé. Lakmé, ton doux regard se voice / Delibes (sung in Russian) -- The demon. I am he whom you called / Rubinstein -- Eugene Onégin. Written words / Tchaikovsky -- I pagliacci. Si può? / Leoncavallo --Amleto. Nega se puoi la luce ; Hamlet. O vin dissipe la tristesse / Thomas -- Don Giovanni. Deh vieni alla finestra / Mozart -- La damnation de Faust. Voice que faites l'endormie / Gounod -- Eugene Onégin. Alas, there is no doubt / Tchaikovsky -- Prince Igor. No sleep nor rest / Borodin -- Boris Godunov. I have attained the highest power / Mussorgsky."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          13.751576,
+          "b16582506"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16582506",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 39955 [Notes]",
+                      "urn:barcode:33433067822563"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 39955 [Notes]"
+                    ],
+                    "shelfMark_sort": "a*LDC 39955 [Notes]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 39955 [Notes]"
+                    ],
+                    "uri": "i17357358",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 39955 [Notes]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433067822563"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433067822563"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16582506",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 39955 [CD]",
+                      "urn:barcode:33433067822555"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 39955 [CD]"
+                    ],
+                    "shelfMark_sort": "a*LDC 39955 [CD]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Baklanoff%2C+Georges%2C+1881-1938.&CallNumber=*LDC+39955+%5BCD%5D&Date=2000&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16582506&ItemISxN=i173573575&ItemNumber=33433067822555&ItemPlace=%5BAustria%5D&ItemPublisher=Lebendige+Vergangenheit%2C+p2000.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b165825066&Site=LPAMRAMI&Title=Georges+Baklanoff"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 39955 [CD]"
+                    ],
+                    "uri": "i17357357",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 39955 [CD]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433067822555"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433067822555"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b21977011",
+        "_score": 13.517504,
+        "_source": {
+          "extent": [
+            "3 audio discs : digital, CD audio, stereo ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title from container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Book contains lyrics and interview transcripts, as well as biographical and historical notes by Scott Barretta, David Evans, Tom Rankin, and others in English, in box with 3 CDs and 1 DVD.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes download code on card in box.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Recorded and filmed by William Ferris.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "1900-1999",
+            "Blues (Music)",
+            "Blues (Music) -- Mississippi",
+            "Blues (Music) -- Mississippi -- 1961-1970",
+            "Blues (Music) -- Mississippi -- 1971-1980",
+            "Gospel music",
+            "Gospel music -- Mississippi",
+            "Interviews",
+            "Interviews -- Southern States",
+            "Southern States",
+            "Southern States -- Civilization",
+            "Southern States -- Civilization -- 20th century",
+            "Mississippi"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dust-to-Digital"
+          ],
+          "description": [
+            "\"This watershed release represents the life's work of William Ferris, an audio recordist, filmmaker, folklorist, and teacher with an unwavering commitment to establish and to expand the study of the American South. William Ferris was born in Vicksburg, Mississippi in 1942. Growing up on a working farm, Ferris began at a young age documenting the artwork, music, and lives of the people on the farm and in his local community. The archive of recordings that he created and the documentary films that he had a hand in producing have served as powerful tools in institutions of higher learning for decades.\"--"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            2018
+          ],
+          "dateEndString": [
+            "1966"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Voices of Mississippi : artists and musicians documented by William Ferris."
+          ],
+          "shelfMark": [
+            "*LZZ 21-3522"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2018"
+          ],
+          "idLccn": [
+            "880226005320"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ferris, William R",
+            "Barretta, Scott",
+            "Evans, David, 1944-",
+            "Rankin, Tom"
+          ],
+          "dateStartYear": [
+            2018
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LZZ 21-3522"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "21977011"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1035954626"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "880226005320"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "DTD-53 Dust-to-Digital"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1035954626"
+            }
+          ],
+          "idOclc": [
+            "1035954626"
+          ],
+          "popularity": 0,
+          "dateEndYear": [
+            1966
+          ],
+          "updatedAt": 1738274097181,
+          "publicationStatement": [
+            "[Atlanta, Georgia] : Dust-to-Digital, 2018.",
+            "℗2018"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LZZ 21-3522",
+            "urn:bnum:21977011",
+            "urn:oclc:1035954626",
+            "urn:lccn:880226005320",
+            "urn:identifier:DTD-53 Dust-to-Digital",
+            "urn:identifier:(OCoLC)1035954626"
+          ],
+          "genreForm": [
+            "Blues (Music)",
+            "Documentary films.",
+            "Gospel music.",
+            "Interviews.",
+            "Nonfiction films.",
+            "Short films.",
+            "Field recordings."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2018"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "1900-1999",
+            "Blues (Music) -- Mississippi -- 1961-1970.",
+            "Blues (Music) -- Mississippi -- 1971-1980.",
+            "Gospel music -- Mississippi.",
+            "Interviews -- Southern States.",
+            "Blues (Music)",
+            "Gospel music.",
+            "Southern States -- Civilization -- 20th century.",
+            "Mississippi."
+          ],
+          "titleDisplay": [
+            "Voices of Mississippi : artists and musicians documented by William Ferris."
+          ],
+          "uri": "b21977011",
+          "lccClassification": [
+            "M1630.18 .V65 2018"
+          ],
+          "formatId": "c",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[Atlanta, Georgia]"
+          ],
+          "titleAlt": [
+            "Artists and musicians documented by William Ferris"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "[Disc 1]. Blues. 44 blues / (James \"Son Ford\" Thomas) -- I feel so good / (Lovey Williams) -- Stackalee and Billy Lyons / (Wallace \"Pine-Top\" Johnson & Maudie Shirley with Jasper Love) -- Lil' Liza Jane / (Scott Dunbar) -- Big fat mama / (Mississippi Fred McDowell) -- Bottle blowing / (Louis Dotson) -- Bring me my shotgun / (Sonny Boy Watson) -- Eyesight to the blind / (Sam Myers) -- Cairo / (James \"Son Ford\" Thomas) -- Jaybird / (Scott Dunbar) -- Cotton eyed Joe / (Tom Dumas) -- Coal black mare / (Lovey Williams) -- I dreamed I went to the U.N. / (Unidentified musician with Mississippi Fred McDowell) -- Darling if you must leave / (Walter Lee Hood) -- I got a letter from Hot Springs / (Mississippi Fred McDowell) -- Baby loves to boogie / (Wallace \"Pine-Top\" Johnson & Maudie Shirley with Jasper Love) -- Nothing / (Wash Heron & \"Big\" Jack Johnson) -- Dust my broom / (James \"Son Ford\" Thomas) -- The Memphis mail / (Scott Dunbar) -- Have you seen my baby / (Sonny Boy Watson) -- Instrumental guitar piece in A / (James Hughes) -- Train I ride / (Lovey Williams) -- Little red rooster / (Unidentified musician with Mississippi Fred McDowell) -- Darlin' why you treat me so? / (Leland musician) -- Water boy drowned in the Mobile Bay / (Inmates at Parchman Farm) -- I ain't gonna live it no more / (George Lee \"Sun Bud\" Spears) -- I cannot stay here baby / (James \"Son Ford\" Thomas with Sonny Boy Watson).",
+            "[Disc 2]. Gospel. Lord, I'm in Your hand / (Mary & Amanda Gordon) -- You don't know like I know / (the Southland Hummingbirds) -- I'm standing in the safety zone / (Lovey Williams) -- Children, go where I send thee / (Reverend Smith and family) -- What could I do? / (Liddle Hines) -- So glad I got good religion / (Providence Missionary Baptist Church) -- I know the Lord will make a way : (Yes He will) / (Church of God in Christ) -- Home on high / (Walter Lee Hood and Parchman inmates) -- We're so glad to be here / (Fannie Bell Chapman) -- My mother's on that train / (Mary Alice & Alan McGowan) -- You don't knock, you just walk on in / (Reverend Ott & Family) -- They tell me of an uncloudy day / (Walter Lee Hood) -- Thanks for Bill Ferris ; Over yonder where the sun will never shine / (Rose Hill Church) -- I've been born again / (the Southland Hummingbirds) -- The Lord will make a way somehow / (Lovey Williams & family) -- How did you feel when you come out of the wilderness / (Providence Missionary Baptist Church) -- I don't have to worry about where I spend eternity / (Church of God in Christ) -- He's my rock, my sword, and shield / (Fannie Bell Chapman & family) -- Thank you Jesus / (Walter Lee Hood & Parchman inmates) -- Cross of Calvary / (Mary & Amanda Gordon) -- My grave's gonna be decorated on that day / (Church of God in Christ) -- There are days / (the Southland Hummingbirds) -- You can't hide, sinner / (Church of God in Christ) -- Lord, remember me / (Reverend Isaac Thomas & Rose Hill Church) -- Glory, glory : (Lay my burden down) / (Church of God in Christ).",
+            "[Disc 3]. Storytelling. On Bill / (Barry Hannah) -- Regions of the mind and heart / (Alice Walker) -- The South / (Alex Haley) -- A trader is / (Ray Lum) -- The blues to me / (Bobby Rush) -- On Son Thomas and tradition / (Barry Hannah) -- I know it's wrong to be playin' the blues / (James \"Son Ford\" Thomas) -- Jitterbug comes to town / (Sonny Boy Watson) -- You whistlin' / (James \"Son Ford\" Thomas) -- Mule toast and pool hall toast / (Joe \"Skeet\" Skillet) -- The preacher / (Joe Cooper) -- Lyin' / (Wallace \"Pine-Top\" Johnson, Jasper Love, & Maudie Shirley) -- Two brothers, Heaven and Hell ; Creekman killed Charlie Kirkland / (Shelby \"Poppa Jazz\" Brown) -- Lucille / (B.B. King) -- On blues composition / (Allen Ginsberg, James \"Son Ford\" Thomas, and Bill Ferris) -- The decline in human values / (Robert Penn Warren) -- The Bible salesman / (Pecolia Warner) -- Fast traders disguising mules ; Horses too tall to drown ; The ark and the cats ; The panther / (Ray Lum) -- Fixing Charles Lindbergh's engine / (Victor Bobb) -- Lying about being from Mississippi / (Barry Hannah) -- We shall overcome / (Pete Seeger) -- Cemetery conversations / (James \"Son Ford\" Thomas).",
+            "[Disc 4 (DVD)]. Films. Gravel Springs fife and drum / (Otha Turner) (10:00) -- Green Valley grandparents (12:00) -- Ray Lum : mule trader (18:00) -- Fannie Bell Chapman : gospel singer (42:00) -- Four women artists / (Pecolia Warner, Eudora Welty, Ethel Mohamed, Theora Hamblett) (24:00) -- Hush hoggies hush : Tom Johnson's praying pigs (4:00) -- Bottle up and go / (Louis Dotson) (18:00)."
+          ],
+          "dimensions": [
+            "4 3/4 in. + 22 x 27 cm)"
+          ]
+        },
+        "sort": [
+          13.517504,
+          "b21977011"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b21977011",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LZZ 21-3522",
+                      "urn:barcode:33433125489173"
+                    ],
+                    "physicalLocation": [
+                      "*LZZ 21-3522"
+                    ],
+                    "shelfMark_sort": "a*LZZ 21-003522",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=*LZZ+21-3522&Date=2018&Form=30&Genre=musical+sound+recording&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db21977011&ItemISxN=i387460792&ItemNumber=33433125489173&ItemPlace=%5BAtlanta%2C+Georgia%5D&ItemPublisher=%E2%84%972018&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b219770116&Site=LPAMRAMI&Title=Voices+of+Mississippi+%3A+artists+and+musicians+documented+by+William+Ferris.&Transaction.CustomFields.Custom651=Mississippi.+fast+%28OCoLC%29fst01207034"
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LZZ 21-3522"
+                    ],
+                    "uri": "i38746079",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LZZ 21-3522"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433125489173"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah38||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433125489173"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah38",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b14957708",
+        "_score": 13.260014,
+        "_source": {
+          "extent": [
+            "CD 2 of 2 sound discs (75 min.) : digital ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Opera excerpts and songs; orchestra or (track 21) piano acc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Recorded in Paris, 1902 and 1908.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Originally released as 78-rpm discs.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Notes by Ward Marston on the original recordings, and biographical notes by Harold Bruder (15 p. : ill.) inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in French, in part translated from Italian or German.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts",
+            "Operas -- Excerpts, Arranged",
+            "Songs (Medium voice) with orchestra, Arranged"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Marston"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1997
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1902"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The complete Gramophone recordings 1901-1908."
+          ],
+          "shelfMark": [
+            "*LDC 19175 (F)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1997"
+          ],
+          "creatorLiteral": [
+            "Renaud, Maurice, 1861-1933"
+          ],
+          "idLccn": [
+            "638335200521"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Fock, Alfred",
+            "Bizet, Georges, 1838-1875",
+            "Massenet, Jules, 1842-1912",
+            "Gounod, Charles, 1818-1893",
+            "Martini, Johann Paul Aegidus, 1741-1816",
+            "Mozart, Wolfgang Amadeus, 1756-1791",
+            "Berlioz, Hector, 1803-1869",
+            "Donizetti, Gaetano, 1797-1848",
+            "Wagner, Richard, 1813-1883",
+            "Thomas, Ambroise, 1811-1896",
+            "Rossini, Gioacchino, 1792-1868",
+            "Reyer, Ernest, 1823-1909"
+          ],
+          "addedAuthorTitle": [
+            "Carmen.",
+            "Roi de Lahore.",
+            "Soir.",
+            "Noël Païen.",
+            "Plaisir d'amour.",
+            "Hérodiade.",
+            "Don Giovanni.",
+            "Damnation de Faust.",
+            "Favorite.",
+            "Tannhäuser.",
+            "Hamlet.",
+            "Guillaume Tell.",
+            "Sigurd."
+          ],
+          "dateStartYear": [
+            1997
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 19175 (F)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "14957708"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "39358378"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "638335200521"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "52005-2 Marston"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M220000185"
+            }
+          ],
+          "idOclc": [
+            "39358378"
+          ],
+          "popularity": 0,
+          "dateEndYear": [
+            1902
+          ],
+          "updatedAt": 1729004027207,
+          "publicationStatement": [
+            "[U.S.] : Marston, p1997."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 19175 (F)",
+            "urn:bnum:14957708",
+            "urn:oclc:39358378",
+            "urn:lccn:638335200521",
+            "urn:identifier:52005-2 Marston",
+            "urn:identifier:(WaOLN)M220000185"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1997"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts.",
+            "Operas -- Excerpts, Arranged.",
+            "Songs (Medium voice) with orchestra, Arranged."
+          ],
+          "titleDisplay": [
+            "The complete Gramophone recordings [sound recording] : 1901-1908."
+          ],
+          "uri": "b14957708",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[U.S.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Carmen: Votre toast je peux vous le rendre / Bizet (4:00) -- Le roi de Lahore: Promesse de mon avenir / Massenet (3:42) -- Le soir / Gounod (3:10) -- Noël païen / Massenet (2:48) -- Plaisir d'amour / Martini (3:42) -- Hërodiade: Vision fugitive / Massenet (4:06) -- Don Giovanni: Parais à ta fenêtre ; Tu ch'hai la bocca dolce / Mozart (3:45) -- La damnation de Faust: Maintenant, chantons à cette belle...Devant la maison / Barlioz (2:34) -- Hérodiade: Vision fugitive / Massenet (4:07) -- La favorite: Pour tant d'amour / Donizetti (4:04) -- Tannhäuser: O douce étoile / Wagner (3:21) -- La damnation de Faust: Voice des roses / Berlioz (3:27) -- La favorite: Léonor, viens/ Donizetti (4:02) -- Hamlet: Comme un päle fleur / Thomas (3:04) -- Guillaume Tell: Sois immobile / Rossini (2:54) -- Le roi de Lahore: Promesse de mon avenir / Massenet (3:32) -- La favorite: Pour tant d'amour / Donizetti (4:11) -- La damnation de Faust: Devant la maison / Berlioz (1:48) -- Don Giovanni: Parais à ta fenêtre ; Tu ch'hai la bocca dolce / Mozart (3:51) -- Hérodiade: Vision fugitive / Massenet (4:00) -- Sigurd: Et toi, Fréïa / Reyer (2:53)"
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          13.260014,
+          "b14957708"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b14957708",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 19175 (F)",
+                      "urn:barcode:33433047750496"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 19175 (F)"
+                    ],
+                    "shelfMark_sort": "a*LDC 19175 (F)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 19175 (F)"
+                    ],
+                    "uri": "i14528293",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 19175 (F)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433047750496"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433047750496"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Audio"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b15037909",
+        "_score": 12.973868,
+        "_source": {
+          "extent": [
+            "2 sound discs (129 min.) : digital ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Opera excerpts and songs; orchestra acc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Originally released as 78-rpm discs by Victor.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Biographical notes by Harold Bruder ([10] p. : ill., ports.) inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded between 1939 and 1947.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts",
+            "Songs (Medium voice) with orchestra",
+            "Sea songs"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Romophone"
+          ],
+          "language": [
+            {
+              "id": "lang:mul",
+              "label": "Multiple languages"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1999
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1939"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The complete Victor recordings (1939-1947)"
+          ],
+          "shelfMark": [
+            "*LDC 22044 (F)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1999"
+          ],
+          "creatorLiteral": [
+            "Warren, Leonard, 1911-1960"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Peerce, Jan, 1904-1984",
+            "Verdi, Giuseppe, 1813-1901",
+            "Ponchielli, Amilcare, 1834-1886",
+            "Gounod, Charles, 1818-1893",
+            "Offenbach, Jacques, 1819-1880",
+            "Rossini, Gioacchino, 1792-1868",
+            "Bizet, Georges, 1838-1875",
+            "Leoncavallo, Ruggiero, 1858-1919",
+            "Puccini, Giacomo, 1858-1924",
+            "Hardelot, Guy d', 1858-1936",
+            "Tchaikovsky, Peter Ilich, 1840-1893",
+            "Sanderson, W. (Wilfred)",
+            "Speaks, Oley, 1876-1948",
+            "Malotte, Albert Hay, 1895-1964"
+          ],
+          "addedAuthorTitle": [
+            "Falstaff.",
+            "Gioconda.",
+            "Faust.",
+            "Contes d'Hoffmann.",
+            "Barbiere di Siviglia.",
+            "Carmen.",
+            "Rigoletto.",
+            "Ballo in maschera.",
+            "Pagliacci.",
+            "Otello.",
+            "Forza del destino.",
+            "Bohème.",
+            "Trovatore.",
+            "Because.",
+            "Romansy",
+            "Until.",
+            "On the road to Mandalay.",
+            "Lord's prayer.",
+            "Simon Boccanegra."
+          ],
+          "dateStartYear": [
+            1999
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 22044 (F)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15037909"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "42968282"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "82018-2 Romophone"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M090000286"
+            }
+          ],
+          "idOclc": [
+            "42968282"
+          ],
+          "popularity": 1,
+          "dateEndYear": [
+            1939
+          ],
+          "updatedAt": 1729004111370,
+          "publicationStatement": [
+            "England : Romophone, p1999."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 22044 (F)",
+            "urn:bnum:15037909",
+            "urn:oclc:42968282",
+            "urn:identifier:82018-2 Romophone",
+            "urn:identifier:(WaOLN)M090000286"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts.",
+            "Songs (Medium voice) with orchestra.",
+            "Sea songs."
+          ],
+          "titleDisplay": [
+            "The complete Victor recordings (1939-1947) [sound recording]."
+          ],
+          "uri": "b15037909",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "England"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Falstaff: È sogno? o realta? / Verdi -- La Gioconda: O momumneto / Ponchielli -- Faust: O sainte médaille...Avant de quitter ces leiux / Gounod-- Les contes d'Hoffmann: Scintille, diamant / Offenbach -- Il barbiere di Siviglia: Largo al factotum / Rossini -- Carmen: Votre toast / Bizet -- Rigoletto: Pari siamo ; Cortigiani, vil razza, dannata / Verdi -- Un ballo in maschera: Eri tu / Verdi -- I pagliacci: Si può? Si può? / Leoncavallo -- Otello: Credo in un dio crudel / Verdi -- La forza del destino: Solenne in quest'ora ; Invano, Alvaro...Ah! una suora mi lasciasti / Verdi --La bohème: In un coupé...O Mimi, tu più non torni / Puccini -- La Gioconda: Ho! He!...Pescator, affonda l'esca / Ponchielli -- Il trovatore: Tutto è deserto...Il balen del suo sorriso ; Qual suono...Per me ora fatale / Verdi -- A rovin' -- Blow the man down -- The drummer and the cook -- The drunken sailor -- Haul-a-way, Joe -- Rio Grande -- Lowlands -- Shenandoah -- Because / d'Hardelot -- None but the lonely heart / Tchaikovsky -- Danny boy -- Until / Sanderson -- On the road to Mandalay / Speaks -- The Lord's prayer / Malotte -- Simon Boccanegra: Plebe! Patrizi! Popolo...Piango su voi, sul placido / Verdi (with Rose Bampton, Giovanni Martinelli, Lawrence Tibbett and Robert Ncholson)."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          12.973868,
+          "b15037909"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15037909",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 22044 (F)",
+                      "urn:barcode:33433047772151"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 22044 (F)"
+                    ],
+                    "shelfMark_sort": "a*LDC 22044 (F)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LDC 22044 (F)"
+                    ],
+                    "uri": "i14541801",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LDC 22044 (F)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433047772151"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433047772151"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-642b2582d46b8bce91af7dbc71628e49.json
+++ b/test/fixtures/query-642b2582d46b8bce91af7dbc71628e49.json
@@ -1,0 +1,18 @@
+{
+  "took": 53,
+  "timed_out": false,
+  "_shards": {
+    "total": 2,
+    "successful": 2,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 0,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": []
+  }
+}

--- a/test/fixtures/query-776d758935718cf8c8df619a8e3ed06f.json
+++ b/test/fixtures/query-776d758935718cf8c8df619a8e3ed06f.json
@@ -1,0 +1,14146 @@
+{
+  "took": 108,
+  "timed_out": false,
+  "_shards": {
+    "total": 2,
+    "successful": 2,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 879,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b20970375",
+        "_score": 3949.4854,
+        "_source": {
+          "extent": [
+            "119 pages : illustrations (color) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Toast (Bread)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Phaidon Press Limited"
+          ],
+          "description": [
+            "The ultimate canvas for sweet and savory culinary creativity. 50 seasonal recipes that reimagine the \"bread and butter\" of cuisine with simple ingredients in surprising ways. Easy enough for breakfast, yet suitable for brunch, lunch, dinner and even dessert, the possibilities of heaping beautiful seasonal ingredients on bread are limitless. Toast guides home chefs as they explore home cuisine's ultimate creative canvas. Organized by season, Toast features 50 recipes from savory to sweet that unleash the power of fresh ingredients and simple techniques guaranteed to impress and satisfy any kitchen audience on any occasion."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2015
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Toast"
+          ],
+          "shelfMark": [
+            "JFF 16-815"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2015"
+          ],
+          "creatorLiteral": [
+            "Pelzel, Raquel"
+          ],
+          "idLccn": [
+            "2015473840"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sung, Evan"
+          ],
+          "dateStartYear": [
+            2015
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 16-815"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "20970375"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780714869551"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0714869554"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "915941587"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2015473840"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)915941587"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)905521916"
+            }
+          ],
+          "idOclc": [
+            "915941587"
+          ],
+          "popularity": 4,
+          "updatedAt": 1722434139301,
+          "publicationStatement": [
+            "London : Phaidon Press Limited, 2015.",
+            "©2015"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFF 16-815",
+            "urn:bnum:20970375",
+            "urn:isbn:9780714869551",
+            "urn:isbn:0714869554",
+            "urn:oclc:915941587",
+            "urn:lccn:2015473840",
+            "urn:identifier:(OCoLC)915941587",
+            "urn:identifier:(OCoLC)905521916"
+          ],
+          "genreForm": [
+            "Cookbooks."
+          ],
+          "idIsbn": [
+            "9780714869551",
+            "0714869554"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2015"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Toast (Bread)"
+          ],
+          "titleDisplay": [
+            "Toast / by Raquel Pelzel ; photographs by Evan Sung."
+          ],
+          "uri": "b20970375",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "titleAlt": [
+            "Toast : the cookbook"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm"
+          ],
+          "idIsbn_clean": [
+            "9780714869551",
+            "0714869554"
+          ]
+        },
+        "sort": [
+          3949.4854,
+          "b20970375"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b20970375",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFF 16-815",
+                      "urn:barcode:33433118568447"
+                    ],
+                    "physicalLocation": [
+                      "JFF 16-815"
+                    ],
+                    "shelfMark_sort": "aJFF 16-000815",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFF 16-815"
+                    ],
+                    "uri": "i34162229",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFF 16-815"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433118568447"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433118568447"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "pb9928479343506421",
+        "_score": 3610.3367,
+        "_source": {
+          "extent": [
+            "103 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"First performed at the Royal Court Theatre Upstairs ... on 12th February 1999.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Oberon"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1999
+          ],
+          "title": [
+            "Toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1999"
+          ],
+          "creatorLiteral": [
+            "Bean, Richard, 1956-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1999
+          ],
+          "idOclc": [
+            "ocm53231811",
+            "SCSB-964143"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9928479343506421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1840021047"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm53231811"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-964143"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(CStRLIN)GAEGO42263032-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(GEU)(Sirsi)o42263032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)2847934-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm53231811"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager2847934"
+            }
+          ],
+          "popularity": 0,
+          "updatedAt": 1739836292936,
+          "publicationStatement": [
+            "London : Oberon, 1999."
+          ],
+          "idIsbn": [
+            "1840021047"
+          ],
+          "identifier": [
+            "urn:bnum:9928479343506421",
+            "urn:isbn:1840021047",
+            "urn:oclc:ocm53231811",
+            "urn:oclc:SCSB-964143",
+            "urn:identifier:(CStRLIN)GAEGO42263032-B",
+            "urn:identifier:(GEU)(Sirsi)o42263032",
+            "urn:identifier:(NjP)2847934-princetondb",
+            "urn:identifier:(OCoLC)ocm53231811",
+            "urn:identifier:(NjP)Voyager2847934"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Toast / by Richard Bean."
+          ],
+          "uri": "pb9928479343506421",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "1840021047"
+          ]
+        },
+        "sort": [
+          3610.3367,
+          "pb9928479343506421"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "pb9928479343506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR6052.E176 T627 1999",
+                      "urn:barcode:32101095377683"
+                    ],
+                    "physicalLocation": [
+                      "PR6052.E176 T627 1999"
+                    ],
+                    "shelfMark_sort": "aPR6052.E176 T627 001999",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "PR6052.E176 T627 1999"
+                    ],
+                    "uri": "pi23486469710006421",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PR6052.E176 T627 1999"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32101095377683"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101095377683"
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b18806309",
+        "_score": 521.44214,
+        "_source": {
+          "extent": [
+            "386 p. : map ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. 383-[387])",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Polish.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Caucasus",
+            "Caucasus -- Civilization"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wydawn. Czarne"
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2010
+          ],
+          "title": [
+            "Toast za przodków"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "ReCAP 11-4380"
+          ],
+          "createdString": [
+            "2010"
+          ],
+          "creatorLiteral": [
+            "Górecki, Wojciech, 1970-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "seriesStatement": [
+            "Reportaż"
+          ],
+          "dateStartYear": [
+            2010
+          ],
+          "idOclc": [
+            "671293997"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "ReCAP 11-4380"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "18806309"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9788375361940 (pbk)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "8375361941 (pbk)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "671293997"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)671293997"
+            }
+          ],
+          "popularity": 2,
+          "uniformTitle": [
+            "Seria Reportaż."
+          ],
+          "updatedAt": 1746030521128,
+          "publicationStatement": [
+            "Wołowiec : Wydawn. Czarne, 2010."
+          ],
+          "idIsbn": [
+            "9788375361940 (pbk)",
+            "8375361941 (pbk)"
+          ],
+          "identifier": [
+            "urn:shelfmark:ReCAP 11-4380",
+            "urn:bnum:18806309",
+            "urn:isbn:9788375361940 (pbk)",
+            "urn:isbn:8375361941 (pbk)",
+            "urn:oclc:671293997",
+            "urn:identifier:(OCoLC)671293997"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2010"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Caucasus.",
+            "Caucasus -- Civilization."
+          ],
+          "titleDisplay": [
+            "Toast za przodków / Wojciech Górecki."
+          ],
+          "uri": "b18806309",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Wołowiec"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "9788375361940",
+            "8375361941"
+          ]
+        },
+        "sort": [
+          521.44214,
+          "b18806309"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b18806309",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433090460647"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:ReCAP 11-4380",
+                      "urn:barcode:33433090460647"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "ReCAP 11-4380",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433090460647",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "physicalLocation": [
+                      "ReCAP 11-4380"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "ReCAP 11-4380"
+                    ],
+                    "shelfMark_sort": "aReCAP 11-004380",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i26121731"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "hb990099650640203941",
+        "_score": 515.72015,
+        "_source": {
+          "extent": [
+            "247 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "subjectLiteral_exploded": [
+            "Short stories"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Cosmos Books"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2006
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "dateEndString": [
+            "2002"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Toast / Charles Stross."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Stross, Charles"
+          ],
+          "createdString": [
+            "2006"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2006
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990099650640203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0809556030 (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "69652590"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-12049344"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)69652590"
+            }
+          ],
+          "idOclc": [
+            "69652590",
+            "SCSB-12049344"
+          ],
+          "dateEndYear": [
+            2002
+          ],
+          "holdings": [],
+          "updatedAt": 1681081853656,
+          "publicationStatement": [
+            "Holicong, PA : Cosmos Books, c2006, c2002."
+          ],
+          "identifier": [
+            "urn:bnum:990099650640203941",
+            "urn:isbn:0809556030 (pbk.)",
+            "urn:oclc:69652590",
+            "urn:oclc:SCSB-12049344",
+            "urn:undefined:(OCoLC)69652590"
+          ],
+          "idIsbn": [
+            "0809556030 (pbk.)"
+          ],
+          "genreForm": [
+            "short stories.",
+            "Short stories",
+            "Science fiction",
+            "Nouvelles."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2006"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Short stories"
+          ],
+          "titleDisplay": [
+            "Toast / Charles Stross."
+          ],
+          "uri": "hb990099650640203941",
+          "lccClassification": [
+            "PR6119.T79 T63 2006"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Holicong, PA"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Antibodies -- Bear trap -- Extracts from the Club Diary -- A colder war -- Toast: a con report -- A boy and his God -- Ship of fools -- Dechlorinating the moderator -- Yellow snow -- Big Brother Iron."
+          ],
+          "idIsbn_clean": [
+            "0809556030"
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          515.72015,
+          "hb990099650640203941"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "hb990099650640203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:32044077499465"
+                    ],
+                    "physicalLocation": [
+                      "PR6119.T79 T63 2006"
+                    ],
+                    "shelfMark_sort": "aPR6119.T79 T63 002006",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "hi232106586300003941",
+                    "shelfMark": [
+                      "PR6119.T79 T63 2006"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PR6119.T79 T63 2006"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32044077499465"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32044077499465"
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "pb9969551973506421",
+        "_score": 515.72015,
+        "_source": {
+          "extent": [
+            "386 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wydawn. \"Czarne\""
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2010
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "title": [
+            "Toast za przodków"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2010"
+          ],
+          "creatorLiteral": [
+            "Górecki, Wojciech, 1970-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "seriesStatement": [
+            "Reportaż"
+          ],
+          "dateStartYear": [
+            2010
+          ],
+          "idOclc": [
+            "ocn671293997",
+            "SCSB-1622764"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9969551973506421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9788375361940"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocn671293997"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-1622764"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(PlWaKWL)lx2010024594"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)6955197-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocn671293997"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager6955197"
+            }
+          ],
+          "uniformTitle": [
+            "Reportaż"
+          ],
+          "updatedAt": 1719969925808,
+          "publicationStatement": [
+            "Wołowiec : Wydawn. \"Czarne\", 2010."
+          ],
+          "idIsbn": [
+            "9788375361940"
+          ],
+          "identifier": [
+            "urn:bnum:9969551973506421",
+            "urn:isbn:9788375361940",
+            "urn:oclc:ocn671293997",
+            "urn:oclc:SCSB-1622764",
+            "urn:identifier:(PlWaKWL)lx2010024594",
+            "urn:identifier:(NjP)6955197-princetondb",
+            "urn:identifier:(OCoLC)ocn671293997",
+            "urn:identifier:(NjP)Voyager6955197"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2010"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Toast za przodków / Wojciech Górecki."
+          ],
+          "uri": "pb9969551973506421",
+          "lccClassification": [
+            "PG7223.I78 T627 2010"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Wołowiec"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "9788375361940"
+          ]
+        },
+        "sort": [
+          515.72015,
+          "pb9969551973506421"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "pb9969551973506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PG7223.I78 T627 2010",
+                      "urn:barcode:32101072287822"
+                    ],
+                    "physicalLocation": [
+                      "PG7223.I78 T627 2010"
+                    ],
+                    "shelfMark_sort": "aPG7223.I78 T627 002010",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "PG7223.I78 T627 2010"
+                    ],
+                    "uri": "pi23652743930006421",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PG7223.I78 T627 2010"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32101072287822"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101072287822"
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b22227752",
+        "_score": 501.26724,
+        "_source": {
+          "extent": [
+            "1 volume (unpaged) : colour illustrations ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"This is a first edition\"--Title page verso.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Multiracial people",
+            "Multiracial people -- Juvenile fiction",
+            "Grandmothers",
+            "Grandmothers -- Juvenile fiction",
+            "Blind people",
+            "Blind people -- Juvenile fiction",
+            "Human skin color",
+            "Human skin color -- Juvenile fiction",
+            "Self-esteem",
+            "Self-esteem -- Juvenile fiction",
+            "Picture books for children"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Pajama Press"
+          ],
+          "description": [
+            "While out on a walk with her blind grandmother, Phoebe tries to describe the skin color of members of her family by comparing them to various foods."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2016
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "French toast"
+          ],
+          "shelfMark": [
+            "JFF 17-1945"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2016"
+          ],
+          "creatorLiteral": [
+            "Winters, Kari-Lynn, 1969-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Thisdale, François, 1964-"
+          ],
+          "dateStartYear": [
+            2016
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 17-1945"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22227752"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781772780062"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1772780065"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "943594881"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)943594881"
+            }
+          ],
+          "idOclc": [
+            "943594881"
+          ],
+          "popularity": 0,
+          "updatedAt": 1729183707636,
+          "publicationStatement": [
+            "Toronto, Ontario, Canada : Pajama Press, 2016."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFF 17-1945",
+            "urn:bnum:22227752",
+            "urn:isbn:9781772780062",
+            "urn:isbn:1772780065",
+            "urn:oclc:943594881",
+            "urn:identifier:(OCoLC)943594881"
+          ],
+          "genreForm": [
+            "Fiction.",
+            "Juvenile works."
+          ],
+          "idIsbn": [
+            "9781772780062",
+            "1772780065"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2016"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Multiracial people -- Juvenile fiction.",
+            "Grandmothers -- Juvenile fiction.",
+            "Blind people -- Juvenile fiction.",
+            "Human skin color -- Juvenile fiction.",
+            "Self-esteem -- Juvenile fiction.",
+            "Picture books for children.",
+            "Blind people.",
+            "Grandmothers.",
+            "Human skin color.",
+            "Self-esteem."
+          ],
+          "titleDisplay": [
+            "French toast / written by Kari-Lynn Winters ; illustrated by François Thisdale."
+          ],
+          "uri": "b22227752",
+          "lccClassification": [
+            "PZ7.W7674 Fr 2016"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Toronto, Ontario, Canada"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 x 27 cm"
+          ],
+          "idIsbn_clean": [
+            "9781772780062",
+            "1772780065"
+          ]
+        },
+        "sort": [
+          501.26724,
+          "b22227752"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b22227752",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFF 17-1945",
+                      "urn:barcode:33433122276318"
+                    ],
+                    "physicalLocation": [
+                      "JFF 17-1945"
+                    ],
+                    "shelfMark_sort": "aJFF 17-001945",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFF 17-1945"
+                    ],
+                    "uri": "i37949151",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFF 17-1945"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433122276318"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433122276318"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b23469693",
+        "_score": 500.26724,
+        "_source": {
+          "extent": [
+            "101 pages : illustrations ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ritter Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            2024
+          ],
+          "title": [
+            "Tiger Toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2024"
+          ],
+          "creatorLiteral": [
+            "Pfeifer, Nika"
+          ],
+          "idLccn": [
+            "9783854156796"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "seriesStatement": [
+            "Ritter Literatur"
+          ],
+          "dateStartYear": [
+            2024
+          ],
+          "idOclc": [
+            "har240149450"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "23469693"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9783854156796"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "har240149450"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9783854156796"
+            }
+          ],
+          "popularity": 0,
+          "updatedAt": 1735052019777,
+          "publicationStatement": [
+            "Klagenfurt : Ritter Verlag, [2024]",
+            "©2024"
+          ],
+          "idIsbn": [
+            "9783854156796"
+          ],
+          "identifier": [
+            "urn:bnum:23469693",
+            "urn:isbn:9783854156796",
+            "urn:oclc:har240149450",
+            "urn:lccn:9783854156796"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2024"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Tiger Toast / Nika Pfeifer."
+          ],
+          "uri": "b23469693",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Klagenfurt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm"
+          ],
+          "idIsbn_clean": [
+            "9783854156796"
+          ]
+        },
+        "sort": [
+          500.26724,
+          "b23469693"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b18054582",
+        "_score": 500.17215,
+        "_source": {
+          "extent": [
+            "1 videodisc (approximately 52 min.) : sound, color ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Original comic opera.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Larry Weinstein, director; Jessica Daniel, Matthew Hornburg, Larry Weinstein, producers; David Franco, director of photography.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "DVD-R format.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Love",
+            "Love -- Drama",
+            "Television operas",
+            "Vignettes",
+            "Vignettes -- Drama"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Bullfrog Films"
+          ],
+          "description": [
+            "\"Comprised of a series of eight comedic mini-operas, each depicting a different stage of a romantic relationship set in contemporary settings. With original music and libretti, each vignette is a self-contained story, but together they work as a cohesive single piece\"--Container."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            2005
+          ],
+          "title": [
+            "Burnt toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2005"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Weinstein, Larry",
+            "Louie, Alexina, 1949-",
+            "Redican, Dan",
+            "Daniel, Jessica",
+            "Hornburg, Matthew",
+            "Franco, David, 1963-",
+            "Gross, Paul, 1959-",
+            "Szabó, Krisztina (Mezzo-soprano)",
+            "Houtman, Martin",
+            "McGillivray, Peter",
+            "Mercer, Shannon",
+            "Stilwell, Jean, 1955-",
+            "Butterfield, Benjamin",
+            "Bayrakdarian, Isabel",
+            "Martin, Bob, 1962-",
+            "Balaban, Liane, 1980-",
+            "Colvin, Michael (Tenor)",
+            "Sadiq, Zorana",
+            "Braun, Russell, 1968-",
+            "Monoyios, Ann, 1949-",
+            "McNaughton, Doug",
+            "Hannigan, Barbara",
+            "Pauk, Alex, 1945-",
+            "Esprit Orchestra. prf",
+            "Bullfrog Films. pmn",
+            "Rhombus Media (Firm) pmn",
+            "Canadian Television Fund",
+            "Canadian Broadcasting Corporation",
+            "Channel Four Films (Firm)",
+            "Zweites Deutsches Fernsehen",
+            "Association relative à la télévision européenne"
+          ],
+          "dateStartYear": [
+            2005
+          ],
+          "idOclc": [
+            "191872445"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "18054582"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1594583560"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781594583568"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "191872445"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)191872445"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1053113461"
+            }
+          ],
+          "popularity": 2,
+          "updatedAt": 1753724219799,
+          "publicationStatement": [
+            "Oley, PA : Bullfrog Films, [2005]"
+          ],
+          "genreForm": [
+            "Drama.",
+            "Feature films.",
+            "Musical films."
+          ],
+          "idIsbn": [
+            "1594583560",
+            "9781594583568"
+          ],
+          "identifier": [
+            "urn:bnum:18054582",
+            "urn:isbn:1594583560",
+            "urn:isbn:9781594583568",
+            "urn:oclc:191872445",
+            "urn:identifier:(OCoLC)191872445",
+            "urn:identifier:(OCoLC)1053113461"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mov",
+              "label": "Moving image"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2005"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Love -- Drama.",
+            "Television operas.",
+            "Vignettes -- Drama.",
+            "Love.",
+            "Television operas.",
+            "Vignettes."
+          ],
+          "titleDisplay": [
+            "Burnt toast / Bullfrog Films presents Rhombus Media and marblemedia present a film by Larry Weinstein ; music by Alexina Louie ; words by Dan Redican ; produced with the participation of the Canadian Television Fund ; produced in association with the Canadian Broadcasting Corporation ; Channel Four Television Corporation ; ZDF in cooperation with ARTE."
+          ],
+          "uri": "b18054582",
+          "lccClassification": [
+            "PN1997.2 .B87 2005"
+          ],
+          "formatId": "v",
+          "recordTypeId": "g",
+          "placeOfPublication": [
+            "Oley, PA"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "The 8 stages of love. Stage 1: Attraction ; Stage 2: Connection ; Stage 3: Commitment ; Stage 4: Marriage ; Stage 5: Consummation ; Stage 6: Perseverance ; Stage 7: Disintegration ; Stage 8: Starting over."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ],
+          "idIsbn_clean": [
+            "1594583560",
+            "9781594583568"
+          ]
+        },
+        "sort": [
+          500.17215,
+          "b18054582"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b18054582",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:a",
+                        "label": "By appointment only"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:a||By appointment only"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=DVDR+1348+B++&Date=2005&Form=30&Genre=rfvc+-+dvd&ItemInfo1=By+appointment+only&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db18054582&ItemISxN=i246011543&ItemNumber=33333225144951&ItemPlace=Oley%2C+PA&ItemPublisher=Bullfrog+Films%2C+%5B2005%5D&ItemVolume=C.1&Location=Performing+Arts+Reserve+Film+and+Video+Collection&ReferenceNumber=b180545826&Site=LPARF&Title=Burnt+toast"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:75",
+                        "label": "dvd"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:75||dvd"
+                    ],
+                    "enumerationChronology": [
+                      "C.1"
+                    ],
+                    "formatLiteral": [
+                      "DVD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pav28",
+                        "label": "Performing Arts Research Collections - Reserve Film and Video"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pav28||Performing Arts Research Collections - Reserve Film and Video"
+                    ],
+                    "idBarcode": [
+                      "33333225144951"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:DVDR 1348 B  ",
+                      "urn:barcode:33333225144951"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "DVDR 1348 B  ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33333225144951",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "DVDR 1348 B  "
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "DVDR 1348 B  "
+                    ],
+                    "shelfMark_sort": "aDVDR 1348 B ",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i24601154"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b15868157",
+        "_score": 498.63788,
+        "_source": {
+          "extent": [
+            "64 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Conduct of life",
+            "Conduct of life -- Poetry",
+            "Nigeria",
+            "Nigeria -- Poetry",
+            "Black author"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Hope Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "sc"
+          ],
+          "createdYear": [
+            2002
+          ],
+          "title": [
+            "Toast to life & vision"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "Sc D 13-57 no. 1"
+          ],
+          "createdString": [
+            "2002"
+          ],
+          "creatorLiteral": [
+            "Odeleye, Biodun"
+          ],
+          "idLccn": [
+            "2004352407"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2002
+          ],
+          "idOclc": [
+            "54955577"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 13-57 no. 1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15868157"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9783654845 (pbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9789783654846 (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "54955577"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2004352407"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)54955577"
+            }
+          ],
+          "popularity": 2,
+          "updatedAt": 1752439851912,
+          "publicationStatement": [
+            "Ibadan, Nigeria : Hope Publications, 2002."
+          ],
+          "idIsbn": [
+            "9783654845 (pbk.)",
+            "9789783654846 (pbk.)"
+          ],
+          "identifier": [
+            "urn:shelfmark:Sc D 13-57 no. 1",
+            "urn:bnum:15868157",
+            "urn:isbn:9783654845 (pbk.)",
+            "urn:isbn:9789783654846 (pbk.)",
+            "urn:oclc:54955577",
+            "urn:lccn:2004352407",
+            "urn:identifier:(OCoLC)54955577"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2002"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Conduct of life -- Poetry.",
+            "Nigeria -- Poetry.",
+            "Black author."
+          ],
+          "titleDisplay": [
+            "Toast to life & vision / Biodun Odeleye."
+          ],
+          "uri": "b15868157",
+          "lccClassification": [
+            "PR9387.9.O3115 T63 2002"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Ibadan, Nigeria"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Toast to life and vision"
+          ],
+          "tableOfContents": [
+            "Moon among stars -- Vampires on rampage -- The dangling visionary saw -- Much to a name -- Dear mother -- La Rambla -- Personifying death -- Success turns albatross in the hall of nobility."
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "9783654845",
+            "9789783654846"
+          ]
+        },
+        "sort": [
+          498.63788,
+          "b15868157"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15868157",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:61",
+                        "label": "pamphlet volumes, bound with"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:61||pamphlet volumes, bound with"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "idBarcode": [
+                      "33433089426146"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc D 13-57",
+                      "urn:barcode:33433089426146"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 13-57",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433089426146",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "physicalLocation": [
+                      "Sc D 13-57"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "Sc D 13-57"
+                    ],
+                    "shelfMark_sort": "aSc D 13-000057",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i29987107"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "pb99131303145606421",
+        "_score": 492.41635,
+        "_source": {
+          "extent": [
+            "101 pages : illustrations ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ritter Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2024
+          ],
+          "dateEndString": [
+            "2024"
+          ],
+          "title": [
+            "Tiger Toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2024"
+          ],
+          "creatorLiteral": [
+            "Pfeifer, Judith, 1975-"
+          ],
+          "idLccn": [
+            "9783854156796"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "seriesStatement": [
+            "Ritter Literatur"
+          ],
+          "dateStartYear": [
+            2024
+          ],
+          "idOclc": [
+            "on1463809188",
+            "SCSB-15114298"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "99131303145606421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9783854156796"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3854156790"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "on1463809188"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-15114298"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9783854156796"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)on1463809188"
+            }
+          ],
+          "popularity": 0,
+          "uniformTitle": [
+            "Ritter Literatur"
+          ],
+          "dateEndYear": [
+            2024
+          ],
+          "updatedAt": 1753829373697,
+          "publicationStatement": [
+            "Klagenfurt : Ritter Verlag, [2024]",
+            "©2024"
+          ],
+          "genreForm": [
+            "poetry.",
+            "Poetry.",
+            "Poésie."
+          ],
+          "idIsbn": [
+            "9783854156796",
+            "3854156790"
+          ],
+          "identifier": [
+            "urn:bnum:99131303145606421",
+            "urn:isbn:9783854156796",
+            "urn:isbn:3854156790",
+            "urn:oclc:on1463809188",
+            "urn:oclc:SCSB-15114298",
+            "urn:lccn:9783854156796",
+            "urn:identifier:(OCoLC)on1463809188"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2024"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Tiger Toast / Nika Pfeifer."
+          ],
+          "uri": "pb99131303145606421",
+          "lccClassification": [
+            "PT2716.F474 T54 2024"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Klagenfurt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "9783854156796",
+            "3854156790"
+          ]
+        },
+        "sort": [
+          492.41635,
+          "pb99131303145606421"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "pb99131303145606421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "idBarcode": [
+                      "32101115835132"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PT2716.F474 T54 2024",
+                      "urn:barcode:32101115835132"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PT2716.F474 T54 2024",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101115835132",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PT2716.F474 T54 2024"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PT2716.F474 T54 2024"
+                    ],
+                    "shelfMark_sort": "aPT2716.F474 T54 002024",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi231033210850006421"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b12004445",
+        "_score": 477.81015,
+        "_source": {
+          "extent": [
+            "124 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kneipp"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1993
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "Mein Lieblings-Toast : 300 heisse Tips für Toast-Fans"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 94-21395"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1993"
+          ],
+          "creatorLiteral": [
+            "Heindel, Gabriele"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1993
+          ],
+          "idOclc": [
+            "31256373",
+            "NYPGR31256373-B"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 94-21395"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12004445"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3900696349"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "31256373"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGR31256373-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)31256373"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "LC 199410"
+            }
+          ],
+          "updatedAt": 1711150297035,
+          "publicationStatement": [
+            "Leoben : Kneipp, 1993."
+          ],
+          "idIsbn": [
+            "3900696349"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 94-21395",
+            "urn:bnum:12004445",
+            "urn:isbn:3900696349",
+            "urn:oclc:31256373",
+            "urn:oclc:NYPGR31256373-B",
+            "urn:identifier:(OCoLC)31256373",
+            "urn:identifier:LC 199410"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1993"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Mein Lieblings-Toast : 300 heisse Tips für Toast-Fans / Gabriele Heindel."
+          ],
+          "uri": "b12004445",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Leoben"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "3900696349"
+          ]
+        },
+        "sort": [
+          477.81015,
+          "b12004445"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b12004445",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 94-21395",
+                      "urn:barcode:33433041530118"
+                    ],
+                    "physicalLocation": [
+                      "JFD 94-21395"
+                    ],
+                    "shelfMark_sort": "aJFD 94-021395",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFD 94-21395"
+                    ],
+                    "uri": "i13317173",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFD 94-21395"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433041530118"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433041530118"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b11294632",
+        "_score": 473.47043,
+        "_source": {
+          "extent": [
+            "xxi, 273 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Originally published ... by Charles Scribner's Sons ... in 1940\"--T.p. verso.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Vintage Books"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1990
+          ],
+          "dateEndString": [
+            "1940"
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "Angels on toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 90-6303"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1990"
+          ],
+          "creatorLiteral": [
+            "Powell, Dawn"
+          ],
+          "idLccn": [
+            "89040281"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1990
+          ],
+          "idOclc": [
+            "70304237",
+            "NYPG90-B53168"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 90-6303"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11294632"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0679726861"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "70304237"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG90-B53168"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "89040281"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1302350"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)70304237"
+            }
+          ],
+          "dateEndYear": [
+            1940
+          ],
+          "updatedAt": 1711585322970,
+          "publicationStatement": [
+            "New York : Vintage Books, 1990, c1940."
+          ],
+          "idIsbn": [
+            "0679726861"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 90-6303",
+            "urn:bnum:11294632",
+            "urn:isbn:0679726861",
+            "urn:oclc:70304237",
+            "urn:oclc:NYPG90-B53168",
+            "urn:lccn:89040281",
+            "urn:identifier:(WaOLN)nyp1302350",
+            "urn:identifier:(OCoLC)70304237"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1990"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Angels on toast / Dawn Powell ; with an introduction by Gore Vidal."
+          ],
+          "uri": "b11294632",
+          "lccClassification": [
+            "PS3531.O936 A83 1989"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "0679726861"
+          ]
+        },
+        "sort": [
+          473.47043,
+          "b11294632"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b11294632",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 90-6303",
+                      "urn:barcode:33433040606604"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "JFD 90-6303"
+                    ],
+                    "shelfMark_sort": "aJFD 90-006303",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFD 90-6303"
+                    ],
+                    "uri": "i13160245",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFD 90-6303"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433040606604"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433040606604"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b10981311",
+        "_score": 472.47043,
+        "_source": {
+          "extent": [
+            "1 miniature score (12 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: H.P.S. 976.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Fondly dedicated to the memory of André Kostelanetz.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 2:30.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Jalni Publications : Boosey & Hawkes, sole selling agent"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "dateEndString": [
+            "1980"
+          ],
+          "title": [
+            "A musical toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "JNF 87-27"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [
+            "Bernstein, Leonard, 1918-1990"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Kostelanetz, Andre, 1901-1980"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "idOclc": [
+            "11578466",
+            "NYPG85-C1260"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNF 87-27"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10981311"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11578466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG85-C1260"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "HPS 976. Boosey & Hawkes"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0988546"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)11578466"
+            }
+          ],
+          "popularity": 2,
+          "dateEndYear": [
+            1980
+          ],
+          "updatedAt": 1752422485670,
+          "publicationStatement": [
+            "[United States] : Jalni Publications : Boosey & Hawkes, sole selling agent, 1984, c1980."
+          ],
+          "identifier": [
+            "urn:shelfmark:JNF 87-27",
+            "urn:bnum:10981311",
+            "urn:oclc:11578466",
+            "urn:oclc:NYPG85-C1260",
+            "urn:identifier:HPS 976. Boosey & Hawkes",
+            "urn:identifier:(WaOLN)nyp0988546",
+            "urn:identifier:(OCoLC)11578466"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "titleDisplay": [
+            "A musical toast / Leonard Bernstein."
+          ],
+          "uri": "b10981311",
+          "formatId": "c",
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "[United States]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          472.47043,
+          "b10981311"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b10981311",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:57",
+                        "label": "printed music limited circ MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:57||printed music limited circ MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433047232982"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JNF 87-27",
+                      "urn:barcode:33433047232982"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JNF 87-27",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433047232982",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "physicalLocation": [
+                      "JNF 87-27"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JNF 87-27"
+                    ],
+                    "shelfMark_sort": "aJNF 87-000027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i13956002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "cb15861113",
+        "_score": 465.72015,
+        "_source": {
+          "extent": [
+            "288 pages ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Parthian"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2022
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "title": [
+            "Sex on toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2022"
+          ],
+          "creatorLiteral": [
+            "Mills, Tôpher"
+          ],
+          "idLccn": [
+            "60002450032"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Edwards, Jonathan"
+          ],
+          "dateStartYear": [
+            2022
+          ],
+          "idOclc": [
+            "on1263812851",
+            "SCSB-13992812"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "15861113"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781912681877"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1912681870"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "on1263812851"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-13992812"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "60002450032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)on1263812851"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "15861113"
+            }
+          ],
+          "updatedAt": 1719566189606,
+          "publicationStatement": [
+            "Cardigan : Parthian, 2022."
+          ],
+          "idIsbn": [
+            "9781912681877",
+            "1912681870"
+          ],
+          "identifier": [
+            "urn:bnum:15861113",
+            "urn:isbn:9781912681877",
+            "urn:isbn:1912681870",
+            "urn:oclc:on1263812851",
+            "urn:oclc:SCSB-13992812",
+            "urn:lccn:60002450032",
+            "urn:identifier:(OCoLC)on1263812851",
+            "urn:identifier:15861113"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2022"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Sex on toast / Tôpher Mills ; [editor, Jonathan Edwards]."
+          ],
+          "uri": "cb15861113",
+          "lccClassification": [
+            "PR6113.I5865 S39 2022"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Cardigan"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm"
+          ],
+          "idIsbn_clean": [
+            "9781912681877",
+            "1912681870"
+          ]
+        },
+        "sort": [
+          465.72015,
+          "cb15861113"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "cb15861113",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR6113.I5865 S39 2022g",
+                      "urn:barcode:CU27972887"
+                    ],
+                    "physicalLocation": [
+                      "PR6113.I5865 S39 2022g"
+                    ],
+                    "shelfMark_sort": "aPR6113.I5865 S39 2022g",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "PR6113.I5865 S39 2022g"
+                    ],
+                    "uri": "ci10035633",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PR6113.I5865 S39 2022g"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "CU27972887"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU27972887"
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "cb1808514",
+        "_score": 464.68634,
+        "_source": {
+          "extent": [
+            "1 score (3 unnumbered pages, 12 pages) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes by Jack Gottlieb.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 2:30.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Recorded by the Israel Philharmonic, the composer conducting, on Deutsche Grammophon 2532 052.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Also available in a version for symphonic band.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "publisherLiteral": [
+            "Jalni Publications ; Boosey & Hawkes, sole selling agent"
+          ],
+          "dateEndString": [
+            "1980"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A musical toast"
+          ],
+          "creatorLiteral": [
+            "Bernstein, Leonard, 1918-1990"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "Hawkes pocket scores"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "1808514"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm11578466"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "H.P.S. 976 Boosey & Hawkes"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm11578466"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)1808514"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "1808514"
+            }
+          ],
+          "idOclc": [
+            "ocm11578466"
+          ],
+          "uniformTitle": [
+            "Musical toast",
+            "Hawkes pocket scores."
+          ],
+          "dateEndYear": [
+            1980
+          ],
+          "holdings": [],
+          "updatedAt": 1664590433971,
+          "publicationStatement": [
+            "[Place of publication not identified] : Jalni Publications ; New York, N.Y. : Boosey & Hawkes, sole selling agent, 1984, ©1980."
+          ],
+          "identifier": [
+            "urn:bnum:1808514",
+            "urn:oclc:ocm11578466",
+            "urn:undefined:H.P.S. 976 Boosey & Hawkes",
+            "urn:undefined:(OCoLC)ocm11578466",
+            "urn:undefined:(NNC)1808514",
+            "urn:undefined:1808514"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "titleDisplay": [
+            "A musical toast / Leonard Bernstein."
+          ],
+          "uri": "cb1808514",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "formatId": "c",
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "[Place of publication not identified] : New York, N.Y."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Musical toast"
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          464.68634,
+          "cb1808514"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "cb1808514",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:MR61509485"
+                    ],
+                    "physicalLocation": [
+                      "61 B458 M9"
+                    ],
+                    "shelfMark_sort": "a61 B458 M000009",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "ci2278358",
+                    "shelfMark": [
+                      "61 B458 M9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "61 B458 M9"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "MR61509485"
+                      }
+                    ],
+                    "idBarcode": [
+                      "MR61509485"
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "MR"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b21766784",
+        "_score": 448.63788,
+        "_source": {
+          "extent": [
+            "75 pages ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Quattro Poetry"
+          ],
+          "description": [
+            "\"This new poetry collection by Corrado Paina explores the induced meditations and considerations that illness imposes upon a body and mind.\"--"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2018
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "A toast to illness"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 19-3255"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2018"
+          ],
+          "creatorLiteral": [
+            "Paina, Corrado, 1954-"
+          ],
+          "idLccn": [
+            "2018487509"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2018
+          ],
+          "idOclc": [
+            "1030339564"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 19-3255"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "21766784"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781988254616"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1988254612"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1030339564"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2018487509"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1030339564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1030484899"
+            }
+          ],
+          "updatedAt": 1711251518653,
+          "publicationStatement": [
+            "Toronto, Canada : Quattro Poetry, 2018."
+          ],
+          "genreForm": [
+            "Poetry."
+          ],
+          "idIsbn": [
+            "9781988254616",
+            "1988254612"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 19-3255",
+            "urn:bnum:21766784",
+            "urn:isbn:9781988254616",
+            "urn:isbn:1988254612",
+            "urn:oclc:1030339564",
+            "urn:lccn:2018487509",
+            "urn:identifier:(OCoLC)1030339564",
+            "urn:identifier:(OCoLC)1030484899"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2018"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "A toast to illness / Corrado Paina."
+          ],
+          "uri": "b21766784",
+          "lccClassification": [
+            "PR9199.4.P34 T63 2018"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Toronto, Canada"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm"
+          ],
+          "idIsbn_clean": [
+            "9781988254616",
+            "1988254612"
+          ]
+        },
+        "sort": [
+          448.63788,
+          "b21766784"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b21766784",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 19-3255",
+                      "urn:barcode:33433129000943"
+                    ],
+                    "physicalLocation": [
+                      "JFD 19-3255"
+                    ],
+                    "shelfMark_sort": "aJFD 19-003255",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFD 19-3255"
+                    ],
+                    "uri": "i37241733",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFD 19-3255"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433129000943"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433129000943"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16579957",
+        "_score": 447.66882,
+        "_source": {
+          "extent": [
+            "iv, 238 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Nigeria",
+            "Nigeria -- Social conditions",
+            "Nigeria -- Social conditions -- 1960-",
+            "Nigeria -- Economic conditions",
+            "Nigeria -- Economic conditions -- 1960-",
+            "Nigeria -- Politics and government",
+            "Nigeria -- Politics and government -- 1960-"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "S.M.K. Taribo"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1991
+          ],
+          "buildingLocationIds": [
+            "sc"
+          ],
+          "title": [
+            "A toast to Nigeria"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "Sc D 07-1829"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1991"
+          ],
+          "creatorLiteral": [
+            "Taribo, Spiff Micah Kalaokpara"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1991
+          ],
+          "idOclc": [
+            "35139639"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 07-1829"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16579957"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "35139639"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)35139639"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M180000413"
+            }
+          ],
+          "updatedAt": 1711412110199,
+          "publicationStatement": [
+            "[Nigeria?] : S.M.K. Taribo, c1991."
+          ],
+          "identifier": [
+            "urn:shelfmark:Sc D 07-1829",
+            "urn:bnum:16579957",
+            "urn:oclc:35139639",
+            "urn:identifier:(OCoLC)35139639",
+            "urn:identifier:(WaOLN)M180000413"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1991"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Nigeria -- Social conditions -- 1960-",
+            "Nigeria -- Economic conditions -- 1960-",
+            "Nigeria -- Politics and government -- 1960-"
+          ],
+          "titleDisplay": [
+            "A toast to Nigeria / by Spiff Micah Kalaokpara Taribo."
+          ],
+          "uri": "b16579957",
+          "lccClassification": [
+            "PR9387.9.T37 T63 1991"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "[Nigeria?]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          447.66882,
+          "b16579957"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16579957",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc D 07-1829",
+                      "urn:barcode:33433074287149"
+                    ],
+                    "physicalLocation": [
+                      "Sc D 07-1829"
+                    ],
+                    "shelfMark_sort": "aSc D 07-001829",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "Sc D 07-1829"
+                    ],
+                    "uri": "i17355861",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Sc D 07-1829"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074287149"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "idBarcode": [
+                      "33433074287149"
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "hb990094818300203941",
+        "_score": 447.5271,
+        "_source": {
+          "extent": [
+            "64 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "subjectLiteral_exploded": [
+            "Conduct of life",
+            "Conduct of life -- Poetry",
+            "Nigeria",
+            "Nigeria -- Poetry"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Hope Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2002
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Toast to life & vision / Biodun Odeleye."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2002"
+          ],
+          "creatorLiteral": [
+            "Odeleye, Biodun"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2002
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990094818300203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9783654845"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "54955577"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-11213317"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)54955577"
+            }
+          ],
+          "idOclc": [
+            "54955577",
+            "SCSB-11213317"
+          ],
+          "updatedAt": 1715560615849,
+          "publicationStatement": [
+            "Ibadan, Nigeria : Hope Publications, c2002."
+          ],
+          "identifier": [
+            "urn:bnum:990094818300203941",
+            "urn:isbn:9783654845",
+            "urn:oclc:54955577",
+            "urn:oclc:SCSB-11213317",
+            "urn:identifier:(OCoLC)54955577"
+          ],
+          "genreForm": [
+            "Poetry"
+          ],
+          "idIsbn": [
+            "9783654845"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2002"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Conduct of life -- Poetry.",
+            "Nigeria -- Poetry"
+          ],
+          "titleDisplay": [
+            "Toast to life & vision / Biodun Odeleye."
+          ],
+          "uri": "hb990094818300203941",
+          "lccClassification": [
+            "PR9387.9.O3115 T63 2002"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Ibadan, Nigeria"
+          ],
+          "titleAlt": [
+            "Toast to life and vision"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Moon among stars -- Vampires on rampage -- The dangling visionary saw -- Much to a name -- Dear mother -- La Rambla -- Personifying death -- Success turns albatross in the hall of nobility."
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "9783654845"
+          ]
+        },
+        "sort": [
+          447.5271,
+          "hb990094818300203941"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "hb990094818300203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR9387.9.O314 T63 2002",
+                      "urn:barcode:32044089630495"
+                    ],
+                    "physicalLocation": [
+                      "PR9387.9.O314 T63 2002"
+                    ],
+                    "shelfMark_sort": "aPR9387.9.O314 T63 002002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "PR9387.9.O314 T63 2002"
+                    ],
+                    "uri": "hi232089710580003941",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PR9387.9.O314 T63 2002"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32044089630495"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32044089630495"
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b12227432",
+        "_score": 446.66882,
+        "_source": {
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Review of the New York City Ballet in Peter Martins' Sleeping beauty, New York State Theatre, April 24, 1991.",
+              "type": "bf:Note"
+            }
+          ],
+          "partOf": [
+            "Dance and dancers. London. June/July 1991, p. 33-36. ill."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Martins, Peter, 1946-",
+            "New York City Ballet"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            1991
+          ],
+          "buildingLocationIds": [],
+          "title": [
+            "A toast to Beauty."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*MGZA"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1991"
+          ],
+          "creatorLiteral": [
+            "Barnes, Clive, 1927-2008"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1991
+          ],
+          "idOclc": [
+            "NYPY916066942-B"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*MGZA"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12227432"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPY916066942-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NN-PD)916066942"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp2214263"
+            }
+          ],
+          "popularity": 0,
+          "updatedAt": 1723129828477,
+          "identifier": [
+            "urn:shelfmark:*MGZA",
+            "urn:bnum:12227432",
+            "urn:oclc:NYPY916066942-B",
+            "urn:identifier:(NN-PD)916066942",
+            "urn:identifier:(WaOLN)nyp2214263"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1991"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Martins, Peter, 1946-",
+            "New York City Ballet."
+          ],
+          "titleDisplay": [
+            "A toast to Beauty."
+          ],
+          "uri": "b12227432",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "issuance": [
+            {
+              "id": "urn:biblevel:b",
+              "label": "serial component part"
+            }
+          ]
+        },
+        "sort": [
+          446.66882,
+          "b12227432"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b22839633",
+        "_score": 446.66882,
+        "_source": {
+          "extent": [
+            "1 online resource (1 sound file)"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Sung in French.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts",
+            "Songs (High voice) with orchestra",
+            "Orchestral music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "ABC Classics"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            2018
+          ],
+          "buildingLocationIds": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A toast to Melba"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2018"
+          ],
+          "idLccn": [
+            "AUAB01850190",
+            "AUAB01850191",
+            "AUAB01850192",
+            "AUAB01850193",
+            "AUAB01850194",
+            "AUAB01850195",
+            "AUAB01850196",
+            "AUAB01850197",
+            "AUAB01850198",
+            "AUAB01850199",
+            "AUAB01850200",
+            "AUAB01850201",
+            "AUAB01850202",
+            "AUAB01850203",
+            "AUAB01850204",
+            "AUAB01850205",
+            "AUAB01850206"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "contributorLiteral": [
+            "Gore, Lorina",
+            "Letonja, Marko, 1961-",
+            "Gounod, Charles, 1818-1893",
+            "Verdi, Giuseppe, 1813-1901",
+            "Massenet, Jules, 1842-1912",
+            "Bizet, Georges, 1838-1875",
+            "Rimsky-Korsakov, Nikolay, 1844-1908",
+            "Thomas, Ambroise, 1811-1896",
+            "Duparc, Henri, 1848-1933",
+            "Tasmanian Symphony Orchestra, instrumentalist"
+          ],
+          "addedAuthorTitle": [
+            "Roméo et Juliette.",
+            "Rigoletto.",
+            "Faust.",
+            "Manon.",
+            "Mireille.",
+            "Pêcheurs de perles.",
+            "Sadko (Opera).",
+            "Mignon.",
+            "Chanson triste.",
+            "Don César de Bazan."
+          ],
+          "dateStartYear": [
+            2018
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "22839633"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1336891241"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850190"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850191"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850192"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850193"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850194"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850195"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850196"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850197"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850198"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850199"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850200"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850201"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850202"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850203"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850204"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850205"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850206"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "028948163632 ABC Classics"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1336891241"
+            }
+          ],
+          "idOclc": [
+            "1336891241"
+          ],
+          "popularity": 0,
+          "updatedAt": 1729184884377,
+          "publicationStatement": [
+            "[Australia] : ABC Classics, [2018]"
+          ],
+          "identifier": [
+            "urn:bnum:22839633",
+            "urn:oclc:1336891241",
+            "urn:lccn:AUAB01850190",
+            "urn:lccn:AUAB01850191",
+            "urn:lccn:AUAB01850192",
+            "urn:lccn:AUAB01850193",
+            "urn:lccn:AUAB01850194",
+            "urn:lccn:AUAB01850195",
+            "urn:lccn:AUAB01850196",
+            "urn:lccn:AUAB01850197",
+            "urn:lccn:AUAB01850198",
+            "urn:lccn:AUAB01850199",
+            "urn:lccn:AUAB01850200",
+            "urn:lccn:AUAB01850201",
+            "urn:lccn:AUAB01850202",
+            "urn:lccn:AUAB01850203",
+            "urn:lccn:AUAB01850204",
+            "urn:lccn:AUAB01850205",
+            "urn:lccn:AUAB01850206",
+            "urn:identifier:028948163632 ABC Classics",
+            "urn:identifier:(OCoLC)1336891241"
+          ],
+          "genreForm": [
+            "Streaming audio."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2018"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts.",
+            "Songs (High voice) with orchestra.",
+            "Orchestral music."
+          ],
+          "titleDisplay": [
+            "A toast to Melba / Lorina Gore."
+          ],
+          "uri": "b22839633",
+          "electronicResources": [
+            {
+              "label": "Access Naxos Music Library",
+              "url": "https://nypl.naxosmusiclibrary.com/catalogue/item.asp?cid=028948163632"
+            }
+          ],
+          "formatId": "w",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[Australia]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Roméo et Juliette. Ah! Je veux vivre dans le reve / Gounod (3:38) -- Rigoletto. Caro nome / Verdi (5:07) -- Faust. Les nubiennes (2:46) ; Adagio (3:51) / Gounod -- Faust. O Dieu! Que de bijoux! / Gounod (4:53) -- Manon. Obeissons quand leur voix appelle / Massenet (3:07) -- Mireille. Heureux petit berger / Gounod (2:24) ; Faust. Danse antique (1:34) ; Variations de Cleopatre (1:41) / Gounod -- Les pêcheurs de perles. me voilà seule dans la nuit ; Comme autrefois dans la nuit sombre / Bizet (6:20) -- Sadko. Song of the Indian guest / Rimsky-Korsakov (3:47) -- Mignon. Oui, pour ce soir je suis reine des fees / Thomas (5:42) -- Faust. Les Troyens (2:39) ; Variations du Miroir (1:59) ; Danse de Phryne (2:53) / Gounod -- Chanson triste / Duparc (3:22) -- Don Cesar de Bazan. A Seville, belles senoras / Massenet (3:10)."
+          ]
+        },
+        "sort": [
+          446.66882,
+          "b22839633"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "pb9957146923506421",
+        "_score": 440.8876,
+        "_source": {
+          "extent": [
+            "272 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A novel.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Pan Macmillan"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2008
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "title": [
+            "Mushy peas on toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2008"
+          ],
+          "creatorLiteral": [
+            "Clemence, Laurian"
+          ],
+          "idLccn": [
+            "2009351955"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2008
+          ],
+          "idOclc": [
+            "ocn301705470",
+            "SCSB-1508353"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9957146923506421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781770100671"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1770100679"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocn301705470"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-1508353"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2009351955"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)5714692-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocn301705470"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager5714692"
+            }
+          ],
+          "updatedAt": 1719403042751,
+          "publicationStatement": [
+            "Northlands [South Africa] : Pan Macmillan, 2008."
+          ],
+          "genreForm": [
+            "Fiction."
+          ],
+          "idIsbn": [
+            "9781770100671",
+            "1770100679"
+          ],
+          "identifier": [
+            "urn:bnum:9957146923506421",
+            "urn:isbn:9781770100671",
+            "urn:isbn:1770100679",
+            "urn:oclc:ocn301705470",
+            "urn:oclc:SCSB-1508353",
+            "urn:lccn:2009351955",
+            "urn:identifier:(NjP)5714692-princetondb",
+            "urn:identifier:(OCoLC)ocn301705470",
+            "urn:identifier:(NjP)Voyager5714692"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2008"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Mushy peas on toast / Laurian Clemence."
+          ],
+          "uri": "pb9957146923506421",
+          "lccClassification": [
+            "PR9369.4.C54 M87 2008"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Northlands [South Africa]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "9781770100671",
+            "1770100679"
+          ]
+        },
+        "sort": [
+          440.8876,
+          "pb9957146923506421"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "pb9957146923506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR9369.4.C54 M87 2008",
+                      "urn:barcode:32101069223301"
+                    ],
+                    "physicalLocation": [
+                      "PR9369.4.C54 M87 2008"
+                    ],
+                    "shelfMark_sort": "aPR9369.4.C54 M87 002008",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "PR9369.4.C54 M87 2008"
+                    ],
+                    "uri": "pi23713898730006421",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PR9369.4.C54 M87 2008"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32101069223301"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101069223301"
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b20569949",
+        "_score": 436.0121,
+        "_source": {
+          "extent": [
+            "1 online resource."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title from HTML t.p. (viewed May 1, 2009).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access restricted to authorized users.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "Mode of access: World Wide Web.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Alexander Street Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            2007
+          ],
+          "buildingLocationIds": [],
+          "title": [
+            "Toast of New York (1937) shooting script"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2007"
+          ],
+          "creatorLiteral": [
+            "Nichols, Dudley, 1895-1960"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "seriesStatement": [
+            "American film scripts online"
+          ],
+          "contributorLiteral": [
+            "Josephson, Matthew, 1899-1978",
+            "Twist, John, 1898-1976",
+            "Sayre, Joel, 1900-1979"
+          ],
+          "dateStartYear": [
+            2007
+          ],
+          "idOclc": [
+            "ssj0001177068"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "20569949"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ssj0001177068"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaSeSS)ssj0001177068"
+            }
+          ],
+          "uniformTitle": [
+            "Toast of New York (1937 : Online)",
+            "American film scripts online."
+          ],
+          "updatedAt": 1711272493617,
+          "publicationStatement": [
+            "Alexandria, VA : Alexander Street Press, 2007."
+          ],
+          "identifier": [
+            "urn:bnum:20569949",
+            "urn:oclc:ssj0001177068",
+            "urn:identifier:(WaSeSS)ssj0001177068"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2007"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Toast of New York (1937) [electronic resource] : shooting script / story by Matthew Josephson ; screenplay by Dudley Nichols, John Twist and Joel Sayre."
+          ],
+          "uri": "b20569949",
+          "electronicResources": [
+            {
+              "label": "Available onsite at NYPL",
+              "url": "http://WU9FB9WH4A.search.serialssolutions.com/?V=1.0&L=WU9FB9WH4A&S=JCs&C=TC0001177068&T=marc&tab=BOOKS"
+            }
+          ],
+          "formatId": "w",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Alexandria, VA"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Toast of New York (1937 : Online)"
+          ]
+        },
+        "sort": [
+          436.0121,
+          "b20569949"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b22185434",
+        "_score": 426.3195,
+        "_source": {
+          "extent": [
+            "166 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Rosenblatt, Roger",
+            "Rosenblatt, Roger -- Family",
+            "Grandparent and child",
+            "Bereavement",
+            "Parenting",
+            "Grandparents as parents",
+            "Daughters",
+            "Daughters -- Death",
+            "Grandparents"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ecco"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2010
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "Making toast : a family story"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 10-2308"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2010"
+          ],
+          "creatorLiteral": [
+            "Rosenblatt, Roger"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2010
+          ],
+          "idOclc": [
+            "419859876"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 10-2308"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22185434"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "006182593X (hbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780061825934 (hbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "419859876"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)419859876"
+            }
+          ],
+          "updatedAt": 1711340157739,
+          "publicationStatement": [
+            "New York : Ecco, c2010."
+          ],
+          "idIsbn": [
+            "006182593X (hbk.)",
+            "9780061825934 (hbk.)"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 10-2308",
+            "urn:bnum:22185434",
+            "urn:isbn:006182593X (hbk.)",
+            "urn:isbn:9780061825934 (hbk.)",
+            "urn:oclc:419859876",
+            "urn:identifier:(OCoLC)419859876"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2010"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Rosenblatt, Roger -- Family.",
+            "Grandparent and child.",
+            "Bereavement.",
+            "Parenting.",
+            "Grandparents as parents.",
+            "Daughters -- Death.",
+            "Grandparents."
+          ],
+          "titleDisplay": [
+            "Making toast : a family story / Roger Rosenblatt."
+          ],
+          "uri": "b22185434",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ],
+          "idIsbn_clean": [
+            "006182593X",
+            "9780061825934"
+          ]
+        },
+        "sort": [
+          426.3195,
+          "b22185434"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b22185434",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 10-2308",
+                      "urn:barcode:33433087759761"
+                    ],
+                    "physicalLocation": [
+                      "JFD 10-2308"
+                    ],
+                    "shelfMark_sort": "aJFD 10-002308",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFD 10-2308"
+                    ],
+                    "uri": "i37905601",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFD 10-2308"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433087759761"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433087759761"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b18437590",
+        "_score": 425.4032,
+        "_source": {
+          "extent": [
+            "xii, 156 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ijesa (African people)",
+            "Ijesa (African people) -- Biography",
+            "Ilesa (Nigeria)",
+            "Ilesa (Nigeria) -- Description and travel"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Keynotes Publishers"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2008
+          ],
+          "buildingLocationIds": [
+            "sc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A toast of Ijesa people"
+          ],
+          "shelfMark": [
+            "Sc D 10-1128"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2008"
+          ],
+          "creatorLiteral": [
+            "Fatubarin, Ayo"
+          ],
+          "idLccn": [
+            "2009382032"
+          ],
+          "seriesStatement": [
+            "Patriotic reflections on Ijesaland ; no. 2"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2008
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 10-1128"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "18437590"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "978375842X"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9789783758421"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "318127683"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2009382032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)318127683"
+            }
+          ],
+          "idOclc": [
+            "318127683"
+          ],
+          "uniformTitle": [
+            "Patriotic reflections on Ijesaland ; no. 2."
+          ],
+          "updatedAt": 1711108404308,
+          "publicationStatement": [
+            "Ilesa : Keynotes Publishers, c2008."
+          ],
+          "identifier": [
+            "urn:shelfmark:Sc D 10-1128",
+            "urn:bnum:18437590",
+            "urn:isbn:978375842X",
+            "urn:isbn:9789783758421",
+            "urn:oclc:318127683",
+            "urn:lccn:2009382032",
+            "urn:identifier:(OCoLC)318127683"
+          ],
+          "idIsbn": [
+            "978375842X",
+            "9789783758421"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2008"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ijesa (African people) -- Biography.",
+            "Ilesa (Nigeria) -- Description and travel."
+          ],
+          "titleDisplay": [
+            "A toast of Ijesa people / Ayo Fatubarin."
+          ],
+          "uri": "b18437590",
+          "lccClassification": [
+            "DT515.45.I348 F384 2008"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Ilesa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "978375842X",
+            "9789783758421"
+          ]
+        },
+        "sort": [
+          425.4032,
+          "b18437590"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b18437590",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc D 10-1128",
+                      "urn:barcode:33433089279883"
+                    ],
+                    "physicalLocation": [
+                      "Sc D 10-1128"
+                    ],
+                    "shelfMark_sort": "aSc D 10-001128",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "Sc D 10-1128"
+                    ],
+                    "uri": "i25227645",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Sc D 10-1128"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433089279883"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "idBarcode": [
+                      "33433089279883"
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b23679460",
+        "_score": 425.4032,
+        "_source": {
+          "extent": [
+            "84 pages : portrait ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Translated from the Catalan.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Runtime: 104 pages - Not Rated\" -- front cover.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Serra, Albert, 1975-",
+            "Motion picture producers and directors",
+            "Motion picture producers and directors -- Spain",
+            "Motion picture producers and directors -- Spain -- Biography",
+            "Spain"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Coffee House Press"
+          ],
+          "description": [
+            "\"\"Cinema should be this: making perception of time and space more intense.\" The town of Banyoles, an hour and a half from Barcelona, hosts a festival every year on the third weekend in November named after its patron, Saint Martyrianus (or, in Catalan, Martirià). There are horse races, there are local delicacies and dances, and there is always someone elected to be the festival's pregoner--literally, \"town cryer.\" This person is given the signal honor of opening the fair with a celebratory speech, and in 2022, the controversial and acclaimed filmmaker Albert Serra, born in Banyoles, was handed the microphone. He opened his mouth. . . and this book emerged, whole and entirely improvised. Puckish, confrontational, subversive, and always dripping with Serra's impulsive lust for life, A Toast to St Martirià is a headlong journey through the director's formative years and early relationships, all played out against the nightlife of his hometown. These are the experiences that have shaped his own peculiar conception of the movies, art, and life, focused not on metropolitan glamor but the slower pace of the countryside, the little moments lost between edits\"--"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            2025
+          ],
+          "dateEndString": [
+            "2024"
+          ],
+          "title": [
+            "A toast to St Martiriá"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "MWES (Serra, A.) 25-1554"
+          ],
+          "createdString": [
+            "2025"
+          ],
+          "creatorLiteral": [
+            "Serra, Albert, 1975-"
+          ],
+          "idLccn": [
+            "2024051153"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Tree, Matthew, 1958-"
+          ],
+          "dateStartYear": [
+            2025
+          ],
+          "idOclc": [
+            "1482463110"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "MWES (Serra, A.) 25-1554"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "23679460"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781566897273"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1566897270"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1482463110"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2024051153"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1482463110"
+            }
+          ],
+          "popularity": 0,
+          "uniformTitle": [
+            "Brindis per Sant Martirià. English"
+          ],
+          "dateEndYear": [
+            2024
+          ],
+          "updatedAt": 1753976587497,
+          "publicationStatement": [
+            "Minneapolis : Coffee House Press, 2025.",
+            "©2024"
+          ],
+          "genreForm": [
+            "Autobiographies.",
+            "Biographies."
+          ],
+          "idIsbn": [
+            "9781566897273",
+            "1566897270"
+          ],
+          "identifier": [
+            "urn:shelfmark:MWES (Serra, A.) 25-1554",
+            "urn:bnum:23679460",
+            "urn:isbn:9781566897273",
+            "urn:isbn:1566897270",
+            "urn:oclc:1482463110",
+            "urn:lccn:2024051153",
+            "urn:identifier:(OCoLC)1482463110"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2025"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Serra, Albert, 1975-",
+            "Serra, Albert, 1975-",
+            "Motion picture producers and directors -- Spain -- Biography.",
+            "Motion picture producers and directors.",
+            "Spain."
+          ],
+          "titleDisplay": [
+            "A toast to St Martiriá / Albert Serra ; translated by Matthew Tree ; afterword by Alexander García Düttmann."
+          ],
+          "uri": "b23679460",
+          "lccClassification": [
+            "PN1998.3.S442 A3 2025"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Minneapolis"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Brindis per Sant Martirià."
+          ],
+          "dimensions": [
+            "20 cm"
+          ],
+          "idIsbn_clean": [
+            "9781566897273",
+            "1566897270"
+          ]
+        },
+        "sort": [
+          425.4032,
+          "b23679460"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b23679460",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pat32",
+                        "label": "Performing Arts Research Collections - Theatre"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pat32||Performing Arts Research Collections - Theatre"
+                    ],
+                    "idBarcode": [
+                      "33433139820116"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:MWES (Serra, A.) 25-1554",
+                      "urn:barcode:33433139820116"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "MWES (Serra, A.) 25-1554",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433139820116",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "MWES (Serra, A.) 25-1554"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "MWES (Serra, A.) 25-1554"
+                    ],
+                    "shelfMark_sort": "aMWES (Serra, A.) 25-001554",
+                    "status": [
+                      {
+                        "id": "status:t",
+                        "label": "In transit"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:t||In transit"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i41892193"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b13111567",
+        "_score": 425.3195,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "The Nation Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1909
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "title": [
+            "Verse and toast. Series 1-"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "NBI (Rowe, W. H. Verse and toast)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1909"
+          ],
+          "creatorLiteral": [
+            "Rowe, William H., Jr"
+          ],
+          "idLccn": [
+            "09014147"
+          ],
+          "numElectronicResources": [
+            2
+          ],
+          "dateStartYear": [
+            1909
+          ],
+          "idOclc": [
+            "12310878"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NBI (Rowe, W. H. Verse and toast)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13111567"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "12310878"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "09014147"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3090092"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1711009811615,
+          "publicationStatement": [
+            "New York, The Nation Press, 1909-"
+          ],
+          "identifier": [
+            "urn:shelfmark:NBI (Rowe, W. H. Verse and toast)",
+            "urn:bnum:13111567",
+            "urn:oclc:12310878",
+            "urn:lccn:09014147",
+            "urn:identifier:(WaOLN)nyp3090092"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1909"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Verse and toast. Series 1- By Col. William H. Rowe, Jr."
+          ],
+          "uri": "b13111567",
+          "electronicResources": [
+            {
+              "label": "Full text available via HathiTrust--ser. 1",
+              "url": "http://babel.hathitrust.org/cgi/pt?id=nyp.33433066644091"
+            },
+            {
+              "label": "Full text available via HathiTrust--ser. 2",
+              "url": "http://babel.hathitrust.org/cgi/pt?id=nyp.33433066644109"
+            }
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          425.3195,
+          "b13111567"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b13111567",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NBI (Rowe, W. H. Verse and toast) ser. 2",
+                      "urn:barcode:33433066644109"
+                    ],
+                    "physicalLocation": [
+                      "NBI (Rowe, W. H. Verse and toast)"
+                    ],
+                    "shelfMark_sort": "aNBI (Rowe, W. H. Verse and toast) ser. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "NBI (Rowe, W. H. Verse and toast) ser. 2"
+                    ],
+                    "uri": "i16815166",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "NBI (Rowe, W. H. Verse and toast) ser. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433066644109"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "ser. 2"
+                    ],
+                    "idBarcode": [
+                      "33433066644109"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b13111567",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2 ser. 1",
+                      "urn:barcode:33433066644091"
+                    ],
+                    "physicalLocation": [
+                      "NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2"
+                    ],
+                    "shelfMark_sort": "aNBI (Rowe, W. H. Verse and toast) Library has: Series 1-2 ser. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2 ser. 1"
+                    ],
+                    "uri": "i16257903",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2 ser. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433066644091"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "ser. 1"
+                    ],
+                    "idBarcode": [
+                      "33433066644091"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b17133475",
+        "_score": 425.3195,
+        "_source": {
+          "extent": [
+            "1 v. (unpaged) : col. ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dogs",
+            "Dogs -- Fiction",
+            "Wishes",
+            "Wishes -- Fiction"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Houghton Mifflin"
+          ],
+          "description": [
+            "Arthur and Stella Crandall, two dogs, are for the most part content with their lives until a fly comes along and grants Arthur three wishes."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1997
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "title": [
+            "Burnt toast on Davenport Street"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1997"
+          ],
+          "creatorLiteral": [
+            "Egan, Tim"
+          ],
+          "idLccn": [
+            "96013720"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1997
+          ],
+          "idOclc": [
+            "96013720 /AC"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "17133475"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0395796180"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0618111212 (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "96013720 /AC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "96013720"
+            }
+          ],
+          "updatedAt": 1711440045954,
+          "publicationStatement": [
+            "Boston : Houghton Mifflin, c1997."
+          ],
+          "genreForm": [
+            "Humorous fiction.",
+            "Picture books."
+          ],
+          "idIsbn": [
+            "0395796180",
+            "0618111212 (pbk.)"
+          ],
+          "identifier": [
+            "urn:bnum:17133475",
+            "urn:isbn:0395796180",
+            "urn:isbn:0618111212 (pbk.)",
+            "urn:oclc:96013720 /AC",
+            "urn:lccn:96013720"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1997"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dogs -- Fiction.",
+            "Wishes -- Fiction."
+          ],
+          "titleDisplay": [
+            "Burnt toast on Davenport Street / written and illustrated by Tim Egan."
+          ],
+          "uri": "b17133475",
+          "lccClassification": [
+            "PZ7.E2815 Bu 1997"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Boston"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ],
+          "idIsbn_clean": [
+            "0395796180",
+            "0618111212"
+          ]
+        },
+        "sort": [
+          425.3195,
+          "b17133475"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b17133475",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:J PIC E",
+                      "urn:barcode:33333113836635"
+                    ],
+                    "physicalLocation": [
+                      "J PIC E"
+                    ],
+                    "shelfMark_sort": "aJ PIC E",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "J PIC E"
+                    ],
+                    "uri": "i18069850",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "J PIC E"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33333113836635"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33333113836635"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NH"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "cb13686426",
+        "_score": 412.5912,
+        "_source": {
+          "extent": [
+            "volume : color illustrations ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes glossary.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "subjectLiteral_exploded": [
+            "Pʻirosmanašvili, Niko, 1862?-1918",
+            "Pʻirosmanašvili, Niko, 1862?-1918 -- Criticism and interpretation",
+            "Painting, Georgian (South Caucasian)",
+            "Painting, Georgian (South Caucasian) -- 19th century",
+            "Painting, Georgian (South Caucasian) -- 19th century -- History and criticism",
+            "Painting, Georgian (South Caucasian) -- 20th century",
+            "Painting, Georgian (South Caucasian) -- 20th century -- History and criticism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Éditions Coiffard"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2018
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Toast au poisson : récits de la peinture géorgienne"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "creatorLiteral": [
+            "Buachidze, G. S"
+          ],
+          "createdString": [
+            "2018"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2018
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "13686426"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9782919339556 (paperback : v. 1) :"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1087129277"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "on1087129277"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-9262298"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1087129277"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)on1087129277"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(Fr-PaAMA)AAL0797185-0001"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)13686426"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "13686426"
+            }
+          ],
+          "idOclc": [
+            "1087129277",
+            "on1087129277",
+            "SCSB-9262298"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [],
+          "updatedAt": 1674950087527,
+          "publicationStatement": [
+            "[Nantes] : Éditions Coiffard, [2018-]"
+          ],
+          "identifier": [
+            "urn:bnum:13686426",
+            "urn:isbn:9782919339556 (paperback : v. 1) :",
+            "urn:oclc:1087129277",
+            "urn:oclc:on1087129277",
+            "urn:oclc:SCSB-9262298",
+            "urn:undefined:(OCoLC)1087129277",
+            "urn:undefined:(OCoLC)on1087129277",
+            "urn:undefined:(Fr-PaAMA)AAL0797185-0001",
+            "urn:undefined:(NNC)13686426",
+            "urn:undefined:13686426"
+          ],
+          "idIsbn": [
+            "9782919339556 (paperback : v. 1) "
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2018"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Pʻirosmanašvili, Niko, 1862?-1918 -- Criticism and interpretation.",
+            "Painting, Georgian (South Caucasian) -- 19th century -- History and criticism.",
+            "Painting, Georgian (South Caucasian) -- 20th century -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Toast au poisson : récits de la peinture géorgienne / Gaston Bouatchidzé."
+          ],
+          "uri": "cb13686426",
+          "lccClassification": [
+            "ND992.9 .B83 2018"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "[Nantes]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Voume 1 : Pirosmani, ou, La promenade du cerf"
+          ],
+          "idIsbn_clean": [
+            "97829193395561"
+          ],
+          "dimensions": [
+            "24 cm"
+          ]
+        },
+        "sort": [
+          412.5912,
+          "cb13686426"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "cb13686426",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:barcode:AR02401576"
+                    ],
+                    "physicalLocation": [
+                      "ND992.9 .B83 2018g"
+                    ],
+                    "shelfMark_sort": "aND992.9 .B83 2018g v.000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci9545552",
+                    "shelfMark": [
+                      "ND992.9 .B83 2018g v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "ND992.9 .B83 2018g v.1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "AR02401576"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "idBarcode": [
+                      "AR02401576"
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "AR"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ]
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b22202337",
+        "_score": 406.1518,
+        "_source": {
+          "extent": [
+            "xiii, 218 p. : col. ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cooking"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Fairfax Books"
+          ],
+          "description": [
+            "A lot of good things start out with a piece of toast. Breakfast, for one. But toast is also the entree into the kitchen for many of us. It's the dish we first learn not to burn, or what we make when there is nobody around to cook for us. It's a reliable culinary introduction. But what comes next? After Toast takes aspiring cooks into the kitchen fray. Kate Gibbs, whose grandmother Margaret Fulton had her making pizza from scratch before she could see over the kitchen bench, shows young adults what to eat and how to cook. Distilling culinary advice from her own upbringing, Kate offers must-know tricks for the new-to-cooking, modernises classics and inspires an interest in healthy cooking. Basically, this is a guide to real, really awesome, food. Recipes for crunchy, fried Mozzarella-stuffed croquettes, French roast chicken, mini Cheeseburgers and proper salads meet ideas for sprawling weekend feasts. This book raises the bar for the packed lunch, serves up new ideas on snacks, shows teens and twenty-somethings what to cook for mates or Mum, and puts an end to endless fridge searches by answering the perpetual question, 'What can I eat?'",
+            "Cooking for Beginners."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2012
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "After toast : recipes for aspiring cooks"
+          ],
+          "shelfMark": [
+            "JFE 15-2837"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2012"
+          ],
+          "creatorLiteral": [
+            "Gibbs, Kate"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2012
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 15-2837"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22202337"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781742379418"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1742379419"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "809151984"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)809151984"
+            }
+          ],
+          "idOclc": [
+            "809151984"
+          ],
+          "updatedAt": 1711614011021,
+          "publicationStatement": [
+            "Crows Nest, N.S.W. : Fairfax Books, 2012."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFE 15-2837",
+            "urn:bnum:22202337",
+            "urn:isbn:9781742379418",
+            "urn:isbn:1742379419",
+            "urn:oclc:809151984",
+            "urn:identifier:(OCoLC)809151984"
+          ],
+          "genreForm": [
+            "Cookbooks."
+          ],
+          "idIsbn": [
+            "9781742379418",
+            "1742379419"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2012"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cooking."
+          ],
+          "titleDisplay": [
+            "After toast : recipes for aspiring cooks / Kate Gibbs."
+          ],
+          "uri": "b22202337",
+          "lccClassification": [
+            "TX714 .G53155 2012"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Crows Nest, N.S.W."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "To start -- Breakfast -- Snacks -- Lunch -- Dinner -- Dessert -- Parties & friends."
+          ],
+          "dimensions": [
+            "24 cm"
+          ],
+          "idIsbn_clean": [
+            "9781742379418",
+            "1742379419"
+          ]
+        },
+        "sort": [
+          406.1518,
+          "b22202337"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b22202337",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFE 15-2837",
+                      "urn:barcode:33433114669116"
+                    ],
+                    "physicalLocation": [
+                      "JFE 15-2837"
+                    ],
+                    "shelfMark_sort": "aJFE 15-002837",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFE 15-2837"
+                    ],
+                    "uri": "i37923125",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFE 15-2837"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433114669116"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433114669116"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b22904468",
+        "_score": 406.1518,
+        "_source": {
+          "extent": [
+            "189 pages : color illustrations ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Toast (Bread)",
+            "Cooking (Bread)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Bloomsbury Publishing"
+          ],
+          "description": [
+            "\"Prue Leith toasts sourdoughs, focaccias, baguettes, flatbreads and more, then pairs them with everything from seasonal vegetables to meat and fish. The collection spans healthy, hearty, salty, and sometimes sweet. Ideal for a busy home cook who loves a full and balanced plate, the recipes are incredibly versatile and perfect for any time of the day: tomatoes, shallots, and oregano on black olive toast; grilled chicken tikka with yogurt on naan; smoked salmon, wasabi, and avocado on multigrain bread; and bananas and ice cream with brandy syrup on panettone\"--"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2022
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bliss on toast : 75 simple recipes"
+          ],
+          "shelfMark": [
+            "JFD 22-2706"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2022"
+          ],
+          "creatorLiteral": [
+            "Leith, Prue"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2022
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 22-2706"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22904468"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781639730711"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1639730710"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781526654236"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1526654237"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1348882624"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1348882624"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1295805556 (OCoLC)1296085459 (OCoLC)1296118057"
+            }
+          ],
+          "idOclc": [
+            "1348882624"
+          ],
+          "updatedAt": 1711159189887,
+          "publicationStatement": [
+            "New York : Bloomsbury Publishing, 2022.",
+            "©2022"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 22-2706",
+            "urn:bnum:22904468",
+            "urn:isbn:9781639730711",
+            "urn:isbn:1639730710",
+            "urn:isbn:9781526654236",
+            "urn:isbn:1526654237",
+            "urn:oclc:1348882624",
+            "urn:identifier:(OCoLC)1348882624",
+            "urn:identifier:(OCoLC)1295805556 (OCoLC)1296085459 (OCoLC)1296118057"
+          ],
+          "genreForm": [
+            "Cookbooks.",
+            "Recipes."
+          ],
+          "idIsbn": [
+            "9781639730711",
+            "1639730710",
+            "9781526654236",
+            "1526654237"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2022"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Toast (Bread)",
+            "Cooking (Bread)"
+          ],
+          "titleDisplay": [
+            "Bliss on toast : 75 simple recipes / Prue Leith."
+          ],
+          "uri": "b22904468",
+          "lccClassification": [
+            "TX769 .L39 2022"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Introduction -- Cheese & eggs -- Vegetarian & vegan -- Fish -- Meat & poultry -- Desserts -- Keen cooks."
+          ],
+          "dimensions": [
+            "22 cm"
+          ],
+          "idIsbn_clean": [
+            "9781639730711",
+            "1639730710",
+            "9781526654236",
+            "1526654237"
+          ]
+        },
+        "sort": [
+          406.1518,
+          "b22904468"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b22904468",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 22-2706",
+                      "urn:barcode:33433135837288"
+                    ],
+                    "physicalLocation": [
+                      "JFD 22-2706"
+                    ],
+                    "shelfMark_sort": "aJFD 22-002706",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFD 22-2706"
+                    ],
+                    "uri": "i39826201",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFD 22-2706"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433135837288"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433135837288"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b17794539",
+        "_score": 405.1518,
+        "_source": {
+          "extent": [
+            "118 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dragons",
+            "Dragons -- Fiction",
+            "Moving, Household",
+            "Moving, Household -- Fiction",
+            "Arizona",
+            "Arizona -- Fiction"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Holiday House"
+          ],
+          "description": [
+            "When eleven-year-old Rick and his mother move from San Diego to Tucson he is not too happy about the change, but when they get a fire-breathing, time-traveling dragon to replace their broken furnace, his new life starts to get more interesting."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1999
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "title": [
+            "If that breathes fire, we're toast!"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1999"
+          ],
+          "creatorLiteral": [
+            "Stewart, Jennifer J"
+          ],
+          "idLccn": [
+            "98036883"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1999
+          ],
+          "idOclc": [
+            "39655664"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "17794539"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0823414302"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "39655664"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "98036883"
+            }
+          ],
+          "updatedAt": 1711655019767,
+          "publicationStatement": [
+            "New York : Holiday House, c1999."
+          ],
+          "genreForm": [
+            "Time travel fiction."
+          ],
+          "idIsbn": [
+            "0823414302"
+          ],
+          "identifier": [
+            "urn:bnum:17794539",
+            "urn:isbn:0823414302",
+            "urn:oclc:39655664",
+            "urn:lccn:98036883"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dragons -- Fiction.",
+            "Moving, Household -- Fiction.",
+            "Arizona -- Fiction."
+          ],
+          "titleDisplay": [
+            "If that breathes fire, we're toast! / Jennifer J. Stewart."
+          ],
+          "uri": "b17794539",
+          "lccClassification": [
+            "PZ7.S84895 If 1999"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ],
+          "idIsbn_clean": [
+            "0823414302"
+          ]
+        },
+        "sort": [
+          405.1518,
+          "b17794539"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b17794539",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:J FIC S",
+                      "urn:barcode:33333120986738"
+                    ],
+                    "physicalLocation": [
+                      "J FIC S"
+                    ],
+                    "shelfMark_sort": "aJ FIC S",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "J FIC S"
+                    ],
+                    "uri": "i18335641",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "J FIC S"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33333120986738"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33333120986738"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "cb11446537",
+        "_score": 398.40152,
+        "_source": {
+          "extent": [
+            "viii, 82 pages ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "subjectLiteral_exploded": [
+            "Drama",
+            "Englisch",
+            "Bangalore (India)",
+            "Bangalore (India) -- Drama",
+            "India",
+            "India -- Bangalore"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Oxford University Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2014
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Boiled beans on toast : a play"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Karnad, Girish Raghunath, 1938-"
+          ],
+          "createdString": [
+            "2014"
+          ],
+          "idLccn": [
+            "  2014355883"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2014
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "11446537"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780198098607 (pbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "019809860X (pbk.)"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "  2014355883"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocn869791542"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "869791542"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-5805984"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocn869791542"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)869791542"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)11446537"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "11446537"
+            }
+          ],
+          "idOclc": [
+            "ocn869791542",
+            "869791542",
+            "SCSB-5805984"
+          ],
+          "uniformTitle": [
+            "Benda kạḷu ān ṭōsṭ. English"
+          ],
+          "holdings": [],
+          "updatedAt": 1674869027803,
+          "publicationStatement": [
+            "New Delhi : Oxford University Press, 2014."
+          ],
+          "identifier": [
+            "urn:bnum:11446537",
+            "urn:isbn:9780198098607 (pbk.)",
+            "urn:isbn:019809860X (pbk.)",
+            "urn:lccn:  2014355883",
+            "urn:oclc:ocn869791542",
+            "urn:oclc:869791542",
+            "urn:oclc:SCSB-5805984",
+            "urn:undefined:(OCoLC)ocn869791542",
+            "urn:undefined:(OCoLC)869791542",
+            "urn:undefined:(NNC)11446537",
+            "urn:undefined:11446537"
+          ],
+          "idIsbn": [
+            "9780198098607 (pbk.)",
+            "019809860X (pbk.)"
+          ],
+          "genreForm": [
+            "Drama."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:undefined",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2014"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Drama.",
+            "Englisch.",
+            "Bangalore (India) -- Drama.",
+            "India -- Bangalore."
+          ],
+          "titleDisplay": [
+            "Boiled beans on toast : a play / Girish Karnad."
+          ],
+          "uri": "cb11446537",
+          "lccClassification": [
+            "PL4659.K325 B65 2014"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "titleAlt": [
+            "Benda kạḷu ān ṭōsṭ."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "9780198098607",
+            "019809860X"
+          ],
+          "dimensions": [
+            "22 cm"
+          ]
+        },
+        "sort": [
+          398.40152,
+          "cb11446537"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "cb11446537",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:CU24576484"
+                    ],
+                    "physicalLocation": [
+                      "PL4659.K33 B4613 2014g"
+                    ],
+                    "shelfMark_sort": "aPL4659.K33 B4613 2014g",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci8752018",
+                    "shelfMark": [
+                      "PL4659.K33 B4613 2014g"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PL4659.K33 B4613 2014g"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "CU24576484"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU24576484"
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "hb990092192200203941",
+        "_score": 398.08652,
+        "_source": {
+          "extent": [
+            "247 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "subjectLiteral_exploded": [
+            "Slater, Nigel",
+            "Slater, Nigel -- Childhood and youth",
+            "Food habits",
+            "Food habits -- England",
+            "Food habits -- England -- History",
+            "Food habits -- England -- History -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Fourth Estate"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2003
+          ],
+          "title": [
+            "Toast : the story of a boy's hunger / Nigel Slater."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2003"
+          ],
+          "creatorLiteral": [
+            "Slater, Nigel"
+          ],
+          "idLccn": [
+            "^^2005533920"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2003
+          ],
+          "idOclc": [
+            "52396085",
+            "SCSB-12424988"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990092192200203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1841152897"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "52396085"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-12424988"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "^^2005533920"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(MH)009219220HVD01-Aleph"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)52396085"
+            }
+          ],
+          "popularity": 0,
+          "updatedAt": 1747613868258,
+          "publicationStatement": [
+            "London ; New York : Fourth Estate, 2003."
+          ],
+          "idIsbn": [
+            "1841152897"
+          ],
+          "identifier": [
+            "urn:bnum:990092192200203941",
+            "urn:isbn:1841152897",
+            "urn:oclc:52396085",
+            "urn:oclc:SCSB-12424988",
+            "urn:lccn:^^2005533920",
+            "urn:identifier:(MH)009219220HVD01-Aleph",
+            "urn:identifier:(OCoLC)52396085"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2003"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Slater, Nigel -- Childhood and youth.",
+            "Food habits -- England -- History -- 20th century."
+          ],
+          "titleDisplay": [
+            "Toast : the story of a boy's hunger / Nigel Slater."
+          ],
+          "uri": "hb990092192200203941",
+          "lccClassification": [
+            "TX357 .S53 2003"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London ; New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Story of a boy's hunger"
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "1841152897"
+          ]
+        },
+        "sort": [
+          398.08652,
+          "hb990092192200203941"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "hb990092192200203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "idBarcode": [
+                      "HXSKRU"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:TX649.S5 A3 2003",
+                      "urn:barcode:HXSKRU"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TX649.S5 A3 2003",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "HXSKRU",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "physicalLocation": [
+                      "TX649.S5 A3 2003"
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "TX649.S5 A3 2003"
+                    ],
+                    "shelfMark_sort": "aTX649.S5 A3 002003",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "hi232073168660003941"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16478384",
+        "_score": 387.8382,
+        "_source": {
+          "extent": [
+            "xi, 353 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Radio programs",
+            "Radio programs -- Great Britain"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "John Murray"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2006
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Trains and buttered toast : selected radio talks"
+          ],
+          "shelfMark": [
+            "JFD 07-1588"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2006"
+          ],
+          "creatorLiteral": [
+            "Betjeman, John, 1906-1984"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Games, Stephen"
+          ],
+          "dateStartYear": [
+            2006
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 07-1588"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16478384"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0719561264 (hbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780719561269 (hbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "64313449"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)64313449"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M060000409"
+            }
+          ],
+          "idOclc": [
+            "64313449"
+          ],
+          "updatedAt": 1711411478497,
+          "publicationStatement": [
+            "London : John Murray, 2006."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 07-1588",
+            "urn:bnum:16478384",
+            "urn:isbn:0719561264 (hbk.)",
+            "urn:isbn:9780719561269 (hbk.)",
+            "urn:oclc:64313449",
+            "urn:identifier:(OCoLC)64313449",
+            "urn:identifier:(WaOLN)M060000409"
+          ],
+          "idIsbn": [
+            "0719561264 (hbk.)",
+            "9780719561269 (hbk.)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2006"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Radio programs -- Great Britain."
+          ],
+          "titleDisplay": [
+            "Trains and buttered toast : selected radio talks / John Betjeman ; edited and introduced by Stephen Games."
+          ],
+          "uri": "b16478384",
+          "lccClassification": [
+            "PN1991.3.G7 B4 2006"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ],
+          "idIsbn_clean": [
+            "0719561264",
+            "9780719561269"
+          ]
+        },
+        "sort": [
+          387.8382,
+          "b16478384"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16478384",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 07-1588",
+                      "urn:barcode:33433076591738"
+                    ],
+                    "physicalLocation": [
+                      "JFD 07-1588"
+                    ],
+                    "shelfMark_sort": "aJFD 07-001588",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFD 07-1588"
+                    ],
+                    "uri": "i17277151",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFD 07-1588"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076591738"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433076591738"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b19838551",
+        "_score": 387.8382,
+        "_source": {
+          "extent": [
+            "112 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Kraftgriots.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"First published 2006\"--T.p. verso.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Short stories, Nigerian (English)",
+            "Nigerians",
+            "Nigerians -- Conduct of life",
+            "Nigerians -- Conduct of life -- Fiction",
+            "Nigeria",
+            "Nigeria -- Social conditions",
+            "Nigeria -- Social conditions -- Fiction"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kraft Books"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2006
+          ],
+          "buildingLocationIds": [
+            "sc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A toast in the cemetery : short stories"
+          ],
+          "shelfMark": [
+            "Sc D 13-1045 no. 1"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "2006"
+          ],
+          "creatorLiteral": [
+            "Gimba, Abubakar"
+          ],
+          "idLccn": [
+            "2008435857"
+          ],
+          "seriesStatement": [
+            "Short stories"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2006
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 13-1045 no. 1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "19838551"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780391738"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9789780391737"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "277051218"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2008435857"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)277051218"
+            }
+          ],
+          "idOclc": [
+            "277051218"
+          ],
+          "uniformTitle": [
+            "Short stories (Ibadan, Nigeria)"
+          ],
+          "updatedAt": 1711109565523,
+          "publicationStatement": [
+            "Ibadan, Oyo State, Nigeria : Kraft Books, 2006."
+          ],
+          "identifier": [
+            "urn:shelfmark:Sc D 13-1045 no. 1",
+            "urn:bnum:19838551",
+            "urn:isbn:9780391738",
+            "urn:isbn:9789780391737",
+            "urn:oclc:277051218",
+            "urn:lccn:2008435857",
+            "urn:identifier:(OCoLC)277051218"
+          ],
+          "genreForm": [
+            "Nigerian fiction (English)"
+          ],
+          "idIsbn": [
+            "9780391738",
+            "9789780391737"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2006"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Short stories, Nigerian (English)",
+            "Nigerians -- Conduct of life -- Fiction.",
+            "Nigeria -- Social conditions -- Fiction."
+          ],
+          "titleDisplay": [
+            "A toast in the cemetery : short stories / Abubakar Gimba."
+          ],
+          "uri": "b19838551",
+          "lccClassification": [
+            "PR9387.9.G55 T63 2006"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Ibadan, Oyo State, Nigeria"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ],
+          "idIsbn_clean": [
+            "9780391738",
+            "9789780391737"
+          ]
+        },
+        "sort": [
+          387.8382,
+          "b19838551"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b19838551",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc D 13-1045 no. 1-4",
+                      "urn:barcode:33433073344230"
+                    ],
+                    "physicalLocation": [
+                      "Sc D 13-1045"
+                    ],
+                    "shelfMark_sort": "aSc D 13-1045 no. 000001-4",
+                    "catalogItemType_packed": [
+                      "catalogItemType:61||pamphlet volumes, bound with"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "Sc D 13-1045 no. 1-4"
+                    ],
+                    "uri": "i30498572",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Sc D 13-1045 no. 1-4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433073344230"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-4"
+                    ],
+                    "idBarcode": [
+                      "33433073344230"
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:61",
+                        "label": "pamphlet volumes, bound with"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 4
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b18036289",
+        "_score": 386.0121,
+        "_source": {
+          "extent": [
+            "1 score (14 p.) + 2 parts : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Biographical notes, p. [4] of cover.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 8:30.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "At end: September 29, 2003.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Trios (Piano, flutes (2))",
+            "Trios (Piano, flutes (2)) -- Scores and parts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "T. Presser"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2005
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "title": [
+            "French toast : for two flutes and piano"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JNG 09-190"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2005"
+          ],
+          "creatorLiteral": [
+            "Schocker, Gary, 1959-"
+          ],
+          "idLccn": [
+            "2005562075",
+            "680160018024"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2005
+          ],
+          "idOclc": [
+            "62276021"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNG 09-190"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "18036289"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "62276021"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2005562075"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "680160018024"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "114-41247 T. Presser"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)62276021"
+            }
+          ],
+          "updatedAt": 1711020217035,
+          "publicationStatement": [
+            "King of Prussia, PA : T. Presser, c2005."
+          ],
+          "identifier": [
+            "urn:shelfmark:JNG 09-190",
+            "urn:bnum:18036289",
+            "urn:oclc:62276021",
+            "urn:lccn:2005562075",
+            "urn:lccn:680160018024",
+            "urn:identifier:114-41247 T. Presser",
+            "urn:identifier:(OCoLC)62276021"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2005"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Trios (Piano, flutes (2)) -- Scores and parts."
+          ],
+          "titleDisplay": [
+            "French toast : for two flutes and piano / Gary Schocker."
+          ],
+          "uri": "b18036289",
+          "lccClassification": [
+            "M317.S35 F74 2005"
+          ],
+          "formatId": "c",
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "King of Prussia, PA"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Deux moutons -- Les bouffons -- L'amour perdu -- Le printemps -- Le ballet russe."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          386.0121,
+          "b18036289"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b18036289",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JNG 09-190",
+                      "urn:barcode:33433083720965"
+                    ],
+                    "physicalLocation": [
+                      "JNG 09-190"
+                    ],
+                    "shelfMark_sort": "aJNG 09-000190",
+                    "catalogItemType_packed": [
+                      "catalogItemType:57||printed music limited circ MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JNG 09-190"
+                    ],
+                    "uri": "i23188106",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JNG 09-190"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433083720965"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433083720965"
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:57",
+                        "label": "printed music limited circ MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "hb990074688990203941",
+        "_score": 380.08795,
+        "_source": {
+          "extent": [
+            "359 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "publisherLiteral": [
+            "Harper Collins,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1995
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Burnt toast on Sundays / Roland K. Hill."
+          ],
+          "creatorLiteral": [
+            "Hill, Roland"
+          ],
+          "createdString": [
+            "1995"
+          ],
+          "idLccn": [
+            "^^^96981253^"
+          ],
+          "dateStartYear": [
+            1995
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990074688990203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1779040105"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "^^^96981253^"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)35948776"
+            }
+          ],
+          "holdings": [],
+          "updatedAt": 1633051606151,
+          "publicationStatement": [
+            "Harare, Zimbabwe : Harper Collins, 1995."
+          ],
+          "identifier": [
+            "urn:bnum:990074688990203941",
+            "urn:isbn:1779040105",
+            "urn:lccn:^^^96981253^",
+            "urn:undefined:(OCoLC)35948776"
+          ],
+          "idIsbn": [
+            "1779040105"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1995"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Burnt toast on Sundays / Roland K. Hill."
+          ],
+          "uri": "hb990074688990203941",
+          "lccClassification": [
+            "MLCS 96/01149 (P)"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Harare, Zimbabwe :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          380.08795,
+          "hb990074688990203941"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "hb990074688990203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:barcode:HNGRR7"
+                    ],
+                    "physicalLocation": [
+                      "MLCS 96/01149 (P)"
+                    ],
+                    "shelfMark_sort": "aMLCS 96/01149 (P)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "hi232023010330003941",
+                    "shelfMark": [
+                      "MLCS 96/01149 (P)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "MLCS 96/01149 (P)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "HNGRR7"
+                      }
+                    ],
+                    "idBarcode": [
+                      "HNGRR7"
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "hb990088521070203941",
+        "_score": 380.08795,
+        "_source": {
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "subjectLiteral_exploded": [
+            "Schiller, Jeannette, 1911-",
+            "Teachers",
+            "Teachers -- Saskatchewan",
+            "Teachers -- Saskatchewan -- Biography",
+            "Teachers -- British Columbia",
+            "Teachers -- British Columbia -- Biography"
+          ],
+          "publisherLiteral": [
+            "Heirloom Books"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            2001
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A toast to bygone days / Jeannette Schiller."
+          ],
+          "creatorLiteral": [
+            "Schiller, Jeannette, 1911-"
+          ],
+          "createdString": [
+            "2001"
+          ],
+          "dateStartYear": [
+            2001
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990088521070203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0968979203 :"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "48230114"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)48230114"
+            }
+          ],
+          "idOclc": [
+            "48230114"
+          ],
+          "holdings": [],
+          "updatedAt": 1656308261785,
+          "publicationStatement": [
+            "Sidney, B.C. : Heirloom Books, 2001."
+          ],
+          "identifier": [
+            "urn:bnum:990088521070203941",
+            "urn:isbn:0968979203 :",
+            "urn:oclc:48230114",
+            "urn:undefined:(OCoLC)48230114"
+          ],
+          "idIsbn": [
+            "0968979203 "
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2001"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Schiller, Jeannette, 1911-",
+            "Teachers -- Saskatchewan -- Biography.",
+            "Teachers -- British Columbia -- Biography."
+          ],
+          "titleDisplay": [
+            "A toast to bygone days / Jeannette Schiller."
+          ],
+          "uri": "hb990088521070203941",
+          "lccClassification": [
+            "LA2325.S34 A3 2001"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Sidney, B.C."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "0968979203"
+          ]
+        },
+        "sort": [
+          380.08795,
+          "hb990088521070203941"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "hb990088521070203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:HXL53Z"
+                    ],
+                    "physicalLocation": [
+                      "LA2325.S34 A3 2001"
+                    ],
+                    "shelfMark_sort": "aLA2325.S34 A3 002001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "hi232074350580003941",
+                    "shelfMark": [
+                      "LA2325.S34 A3 2001"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "LA2325.S34 A3 2001"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "HXL53Z"
+                      }
+                    ],
+                    "idBarcode": [
+                      "HXL53Z"
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "cb5358913",
+        "_score": 379.2563,
+        "_source": {
+          "extent": [
+            "80 pages ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Bloodaxe"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2005
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The toast of the Kit-Cat Club"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "France, Linda, 1958-"
+          ],
+          "createdString": [
+            "2005"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2005
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "5358913"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1852246774 (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm57065346"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-5192151"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm57065346"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)5358913"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "5358913"
+            }
+          ],
+          "idOclc": [
+            "ocm57065346",
+            "SCSB-5192151"
+          ],
+          "holdings": [],
+          "updatedAt": 1668215227681,
+          "publicationStatement": [
+            "Tarset : Bloodaxe, 2005."
+          ],
+          "identifier": [
+            "urn:bnum:5358913",
+            "urn:isbn:1852246774 (pbk.)",
+            "urn:oclc:ocm57065346",
+            "urn:oclc:SCSB-5192151",
+            "urn:undefined:(OCoLC)ocm57065346",
+            "urn:undefined:(NNC)5358913",
+            "urn:undefined:5358913"
+          ],
+          "idIsbn": [
+            "1852246774 (pbk.)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2005"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "The toast of the Kit-Cat Club / Linda France."
+          ],
+          "uri": "cb5358913",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Tarset"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "1852246774"
+          ],
+          "dimensions": [
+            "22 cm"
+          ]
+        },
+        "sort": [
+          379.2563,
+          "cb5358913"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "cb5358913",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:CU71435093"
+                    ],
+                    "physicalLocation": [
+                      "PR6056.R262 T63 2005g"
+                    ],
+                    "shelfMark_sort": "aPR6056.R262 T63 2005g",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci5619937",
+                    "shelfMark": [
+                      "PR6056.R262 T63 2005g"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PR6056.R262 T63 2005g"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "CU71435093"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU71435093"
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "hb990094315110203941",
+        "_score": 379.2563,
+        "_source": {
+          "extent": [
+            "271 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"A Phyllis Bruce book\".",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "subjectLiteral_exploded": [
+            "Short stories, Canadian"
+          ],
+          "publisherLiteral": [
+            "HarperCollins"
+          ],
+          "description": [
+            "A collection of stories representing the author's extensive writing career."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            2004
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Poached egg on toast : stories / Frances Itani."
+          ],
+          "creatorLiteral": [
+            "Itani, Frances, 1942-"
+          ],
+          "createdString": [
+            "2004"
+          ],
+          "dateStartYear": [
+            2004
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990094315110203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0002005840 :"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780002005845"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "55596486"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)55596486"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1060700968"
+            }
+          ],
+          "idOclc": [
+            "55596486"
+          ],
+          "holdings": [],
+          "updatedAt": 1650234471796,
+          "publicationStatement": [
+            "Toronto : HarperCollins, c2004."
+          ],
+          "identifier": [
+            "urn:bnum:990094315110203941",
+            "urn:isbn:0002005840 :",
+            "urn:isbn:9780002005845",
+            "urn:oclc:55596486",
+            "urn:undefined:(OCoLC)55596486",
+            "urn:undefined:(OCoLC)1060700968"
+          ],
+          "idIsbn": [
+            "0002005840 :",
+            "9780002005845"
+          ],
+          "genreForm": [
+            "short stories.",
+            "Short stories",
+            "Nouvelles."
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2004"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Short stories, Canadian"
+          ],
+          "titleDisplay": [
+            "Poached egg on toast : stories / Frances Itani."
+          ],
+          "uri": "hb990094315110203941",
+          "lccClassification": [
+            "PR9199.3.I83 P63 2004"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Toronto"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Clayton -- An August wind -- Megan -- Marx & Co. -- Pack ice -- P'tit village -- Truth or lies -- Separation -- An evening in the café -- Scenes from a pension -- Messages -- Accident -- Touches -- Foolery -- Earthman pointing -- The eyes have it -- Man without face -- Sarajevo -- In the name of love -- The thickness of one sheet of paper -- What we are capable of -- Poached egg on toast."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          379.2563,
+          "hb990094315110203941"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "hb990094315110203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:32044105914865"
+                    ],
+                    "physicalLocation": [
+                      "PR9199.3.I83 P63 2004"
+                    ],
+                    "shelfMark_sort": "aPR9199.3.I83 P63 002004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "hi232083339710003941",
+                    "shelfMark": [
+                      "PR9199.3.I83 P63 2004"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PR9199.3.I83 P63 2004"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32044105914865"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32044105914865"
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "hb990117890200203941",
+        "_score": 379.2563,
+        "_source": {
+          "extent": [
+            "62 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "subjectLiteral_exploded": [
+            "Chaplin, Charlie, 1889-1977",
+            "Chaplin, Charlie, 1889-1977 -- Drama",
+            "Holmes, Sherlock (Fictitious character)",
+            "Holmes, Sherlock (Fictitious character) -- Drama",
+            "Holmes, Sherlock",
+            "Holmes, Sherlock -- Drama",
+            "London (England)",
+            "London (England) -- Drama",
+            "Watson, John H. (Fictitious character)",
+            "Watson, John H. (Fictitious character) -- Drama"
+          ],
+          "publisherLiteral": [
+            "Samuel French,"
+          ],
+          "description": [
+            "\"The Edgar Prize-winning author Kaminsky tells the tale of one of literature's most famous detectives: Sherlock Holmes. In a witty, imaginative story filled with twists and unexpected surprises, Detective Holmes unravels a murder only to find himself the unwilling target of the killer-at-large. Along with the aid of his loyal and inquisitive companion, Dr. Watson, Sherlock Holmes uses his masterful power of deduction to make a nebulous situation seem \"simply elementary.\" The Final Toast is an exciting new take on the classic characters of fiction we know and love, and its ending will please even the most savvy mystery connoisseurs\"--Publisher's website."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            2008
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The final toast / by Stuart M. Kaminsky."
+          ],
+          "creatorLiteral": [
+            "Kaminsky, Stuart M"
+          ],
+          "createdString": [
+            "2008"
+          ],
+          "dateStartYear": [
+            2008
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990117890200203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780573663772"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0573663777"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)259742094"
+            }
+          ],
+          "holdings": [],
+          "updatedAt": 1636498198661,
+          "publicationStatement": [
+            "New York, NY : Samuel French, c2008."
+          ],
+          "identifier": [
+            "urn:bnum:990117890200203941",
+            "urn:isbn:9780573663772",
+            "urn:isbn:0573663777",
+            "urn:undefined:(OCoLC)259742094"
+          ],
+          "idIsbn": [
+            "9780573663772",
+            "0573663777"
+          ],
+          "genreForm": [
+            "Drama"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2008"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Chaplin, Charlie, 1889-1977 -- Drama.",
+            "Holmes, Sherlock (Fictitious character) -- Drama.",
+            "Holmes, Sherlock -- Drama.",
+            "London (England) -- Drama.",
+            "Watson, John H. (Fictitious character) -- Drama."
+          ],
+          "titleDisplay": [
+            "The final toast / by Stuart M. Kaminsky."
+          ],
+          "uri": "hb990117890200203941",
+          "lccClassification": [
+            "PS3561.A43 F497 2008"
+          ],
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York, NY :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          379.2563,
+          "hb990117890200203941"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "pb9921391513506421",
+        "_score": 379.2563,
+        "_source": {
+          "extent": [
+            "ix, 226 pages : illustrations, portraits ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "subjectLiteral_exploded": [
+            "Drinking in literature",
+            "Drinking",
+            "Drinking -- Literary collections",
+            "Consommation d'alcool dans la littérature"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "André Deutsch"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1997
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Creative spirits : a toast to literary drinkers"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1997"
+          ],
+          "creatorLiteral": [
+            "Booth, John"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1997
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9921391513506421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0233991840"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780233991849"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm41333062"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "41333062"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-506538"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)2139151-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm41333062"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)41333062"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager2139151"
+            }
+          ],
+          "idOclc": [
+            "ocm41333062",
+            "41333062",
+            "SCSB-506538"
+          ],
+          "popularity": 0,
+          "updatedAt": 1725433411057,
+          "publicationStatement": [
+            "London : André Deutsch, 1997."
+          ],
+          "identifier": [
+            "urn:bnum:9921391513506421",
+            "urn:isbn:0233991840",
+            "urn:isbn:9780233991849",
+            "urn:oclc:ocm41333062",
+            "urn:oclc:41333062",
+            "urn:oclc:SCSB-506538",
+            "urn:identifier:(NjP)2139151-princetondb",
+            "urn:identifier:(OCoLC)ocm41333062",
+            "urn:identifier:(OCoLC)41333062",
+            "urn:identifier:(NjP)Voyager2139151"
+          ],
+          "genreForm": [
+            "Literary collections."
+          ],
+          "idIsbn": [
+            "0233991840",
+            "9780233991849"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1997"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Drinking in literature.",
+            "Drinking -- Literary collections.",
+            "Consommation d'alcool dans la littérature."
+          ],
+          "titleDisplay": [
+            "Creative spirits : a toast to literary drinkers / John Booth."
+          ],
+          "uri": "pb9921391513506421",
+          "lccClassification": [
+            "PN56.D8 B6 1997x"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm"
+          ],
+          "idIsbn_clean": [
+            "0233991840",
+            "9780233991849"
+          ]
+        },
+        "sort": [
+          379.2563,
+          "pb9921391513506421"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "pb9921391513506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PN56.D8 B6 1997",
+                      "urn:barcode:32101085641676"
+                    ],
+                    "physicalLocation": [
+                      "PN56.D8 B6 1997"
+                    ],
+                    "shelfMark_sort": "aPN56.D8 B6 001997",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "PN56.D8 B6 1997"
+                    ],
+                    "uri": "pi23519521580006421",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PN56.D8 B6 1997"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32101085641676"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101085641676"
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b13701585",
+        "_score": 378.11566,
+        "_source": {
+          "extent": [
+            "200 p. : ill., map ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. 185-193) and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Wilson, Sunnie, 1908-1999",
+            "Louis, Joe, 1914-1981",
+            "Hotelkeepers",
+            "Hotelkeepers -- Michigan",
+            "Hotelkeepers -- Michigan -- Detroit",
+            "Hotelkeepers -- Michigan -- Detroit -- Biography",
+            "African American businesspeople",
+            "African American businesspeople -- Michigan",
+            "African American businesspeople -- Michigan -- Detroit",
+            "Detroit (Mich.)",
+            "Detroit (Mich.) -- History"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wayne State University Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1998
+          ],
+          "buildingLocationIds": [
+            "sc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Toast of the town : the life and times of Sunnie Wilson"
+          ],
+          "shelfMark": [
+            "Sc E 98-916"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1998"
+          ],
+          "creatorLiteral": [
+            "Wilson, Sunnie, 1908-1999"
+          ],
+          "idLccn": [
+            "97025475"
+          ],
+          "seriesStatement": [
+            "Great Lakes books"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Cohassey, John, 1961-"
+          ],
+          "dateStartYear": [
+            1998
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc E 98-916"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13701585"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0814326951 (alk. paper)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "37260938"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "97025475"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3669560"
+            }
+          ],
+          "idOclc": [
+            "37260938"
+          ],
+          "updatedAt": 1711418976733,
+          "publicationStatement": [
+            "Detroit : Wayne State University Press, c1998."
+          ],
+          "identifier": [
+            "urn:shelfmark:Sc E 98-916",
+            "urn:bnum:13701585",
+            "urn:isbn:0814326951 (alk. paper)",
+            "urn:oclc:37260938",
+            "urn:lccn:97025475",
+            "urn:identifier:(WaOLN)nyp3669560"
+          ],
+          "idIsbn": [
+            "0814326951 (alk. paper)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1998"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Wilson, Sunnie, 1908-1999.",
+            "Louis, Joe, 1914-1981.",
+            "Hotelkeepers -- Michigan -- Detroit -- Biography.",
+            "African American businesspeople -- Michigan -- Detroit.",
+            "Detroit (Mich.) -- History."
+          ],
+          "titleDisplay": [
+            "Toast of the town : the life and times of Sunnie Wilson / Sunnie Wilson with John Cohassey."
+          ],
+          "uri": "b13701585",
+          "lccClassification": [
+            "TX910.5.W58 A3 1998"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Detroit"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ],
+          "idIsbn_clean": [
+            "0814326951"
+          ]
+        },
+        "sort": [
+          378.11566,
+          "b13701585"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b13701585",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc E 98-916",
+                      "urn:barcode:33433059013072"
+                    ],
+                    "physicalLocation": [
+                      "Sc E 98-916"
+                    ],
+                    "shelfMark_sort": "aSc E 98-000916",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "Sc E 98-916"
+                    ],
+                    "uri": "i14417587",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Sc E 98-916"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059013072"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "idBarcode": [
+                      "33433059013072"
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b18012067",
+        "_score": 371.1343,
+        "_source": {
+          "extent": [
+            "97 p. : ill. (chiefly col.) ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Coffee House Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            2009
+          ],
+          "buildingLocationIds": [
+            "sc",
+            "ma"
+          ],
+          "title": [
+            "A toast in the house of friends : poems"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFE 09-1080"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2009"
+          ],
+          "creatorLiteral": [
+            "Oliver, Akilah"
+          ],
+          "idLccn": [
+            "2008012531"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2009
+          ],
+          "idOclc": [
+            "214934641"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 09-1080"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "18012067"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781566892223 (alk. paper)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1566892228 (alk. paper)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "214934641"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2008012531"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)214934641"
+            }
+          ],
+          "updatedAt": 1711411179492,
+          "publicationStatement": [
+            "Minneapolis, Minn. : Coffee House Press, 2009."
+          ],
+          "idIsbn": [
+            "9781566892223 (alk. paper)",
+            "1566892228 (alk. paper)"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFE 09-1080",
+            "urn:bnum:18012067",
+            "urn:isbn:9781566892223 (alk. paper)",
+            "urn:isbn:1566892228 (alk. paper)",
+            "urn:oclc:214934641",
+            "urn:lccn:2008012531",
+            "urn:identifier:(OCoLC)214934641"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2009"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "A toast in the house of friends : poems / Akilah Oliver."
+          ],
+          "uri": "b18012067",
+          "lccClassification": [
+            "PS3565.L4575 T63 2009"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Minneapolis, Minn."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ],
+          "idIsbn_clean": [
+            "9781566892223",
+            "1566892228"
+          ]
+        },
+        "sort": [
+          371.1343,
+          "b18012067"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b18012067",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc D 10-1178",
+                      "urn:barcode:33433089303840"
+                    ],
+                    "physicalLocation": [
+                      "Sc D 10-1178"
+                    ],
+                    "shelfMark_sort": "aSc D 10-001178",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "Sc D 10-1178"
+                    ],
+                    "uri": "i25242885",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Sc D 10-1178"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433089303840"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "idBarcode": [
+                      "33433089303840"
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b18012067",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFE 09-1080",
+                      "urn:barcode:33433083328249"
+                    ],
+                    "physicalLocation": [
+                      "JFE 09-1080"
+                    ],
+                    "shelfMark_sort": "aJFE 09-001080",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFE 09-1080"
+                    ],
+                    "uri": "i23125020",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFE 09-1080"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433083328249"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433083328249"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b21091000",
+        "_score": 371.1343,
+        "_source": {
+          "extent": [
+            "vii, 216 pages : color illustrations ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Being: a revolutionary drinking guide to brewing and batching, mixing and serving, imbibing and jibing, fighting and freedom in the ruins of the ancient civilization known as America.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (pages 203-204) and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Alcoholic beverages",
+            "Alcoholic beverages -- United States",
+            "Alcoholic beverages -- United States -- History",
+            "Drinking of alcoholic beverages",
+            "Drinking of alcoholic beverages -- United States",
+            "Drinking of alcoholic beverages -- United States -- History",
+            "Cocktails"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Abrams Image"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2016
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "Colonial spirits : a toast to our drunken history"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 16-5390"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2016"
+          ],
+          "creatorLiteral": [
+            "Grasse, Steven"
+          ],
+          "idLccn": [
+            "2015955674"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2016
+          ],
+          "idOclc": [
+            "938991316"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 16-5390"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "21091000"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781419722301"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1419722301"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "938991316"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2015955674"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)938991316"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)943677509"
+            }
+          ],
+          "updatedAt": 1711243086460,
+          "publicationStatement": [
+            "New York : Abrams Image, 2016."
+          ],
+          "idIsbn": [
+            "9781419722301",
+            "1419722301"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 16-5390",
+            "urn:bnum:21091000",
+            "urn:isbn:9781419722301",
+            "urn:isbn:1419722301",
+            "urn:oclc:938991316",
+            "urn:lccn:2015955674",
+            "urn:identifier:(OCoLC)938991316",
+            "urn:identifier:(OCoLC)943677509"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2016"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Alcoholic beverages -- United States -- History.",
+            "Drinking of alcoholic beverages -- United States -- History.",
+            "Cocktails."
+          ],
+          "titleDisplay": [
+            "Colonial spirits : a toast to our drunken history / by Steven Grasse."
+          ],
+          "uri": "b21091000",
+          "lccClassification": [
+            "HV5292 .G67 2016"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm"
+          ],
+          "idIsbn_clean": [
+            "9781419722301",
+            "1419722301"
+          ]
+        },
+        "sort": [
+          371.1343,
+          "b21091000"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b21091000",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 16-5390",
+                      "urn:barcode:33433120132745"
+                    ],
+                    "physicalLocation": [
+                      "JFD 16-5390"
+                    ],
+                    "shelfMark_sort": "aJFD 16-005390",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFD 16-5390"
+                    ],
+                    "uri": "i34513730",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFD 16-5390"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433120132745"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433120132745"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "cb2127025",
+        "_score": 370.35986,
+        "_source": {
+          "extent": [
+            "200 pages : illustrations, map ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. 185-193) and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "subjectLiteral_exploded": [
+            "Wilson, Sunnie, 1908-1999",
+            "Louis, Joe, 1914-1981",
+            "Hotelkeepers",
+            "Hotelkeepers -- Detroit",
+            "Hotelkeepers -- Detroit -- Biography",
+            "African American businesspeople",
+            "African American businesspeople -- Detroit",
+            "Detroit (Mich.)",
+            "Detroit (Mich.) -- History"
+          ],
+          "publisherLiteral": [
+            "Wayne State University Press"
+          ],
+          "description": [
+            "As part of the great migration of southern blacks to the north, Sunnie Wilson came to Detroit from South Carolina after graduating from college, and soon became a pillar in the local music industry. He started out as a song and dance performer, but found his niche as a local promoter of boxing and musical acts.",
+            "Soon after arriving in Detroit, Wilson started emceeing shows and booking gigs at clubs. He bought restaurants, like the popular Brown Bomber Chicken Shack in Paradise Valley, and bought the Mark Twain hotel on Garfield off of Woodward to sleep on-the-rise performers not welcome at white establishments, including Duke Ellington and B. B. King. He met and made friends with musicians Cab Calloway, Dizzy Gillespie, Earl Hines, and Lionel Hampton, and still counts Joe Louis as one of his best friends.",
+            "Part oral history, memoir, and biography, Toast of the Town draws from hundreds of hours of taped conversations between Sunnie Wilson and John Cohassey, as Wilson reflects on the changes in Detroit over the last sixty years.",
+            "Through Sunnie Wilson's narrative, Detroit's glory age comes alive, bringing back nights at the hopping Forest Club on Hastings Street, which hosted music greats like Nat King Cole and boasted the longest bar in Michigan, and sunny afternoons at Lake Idlewild, the largest black resort in the United States that attracted thousands every weekend from all over the midwest."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1998
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "dateEndString": [
+            "1998"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Toast of the town : the life and times of Sunnie Wilson"
+          ],
+          "creatorLiteral": [
+            "Wilson, Sunnie, 1908-1999"
+          ],
+          "createdString": [
+            "1998"
+          ],
+          "idLccn": [
+            "   97025475 "
+          ],
+          "seriesStatement": [
+            "Great Lakes books"
+          ],
+          "contributorLiteral": [
+            "Cohassey, John, 1961-"
+          ],
+          "dateStartYear": [
+            1998
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "2127025"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0814326951 (alk. paper)"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "   97025475 "
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "37260938"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm37260938"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)37260938"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm37260938"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)2127025"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "2127025"
+            }
+          ],
+          "idOclc": [
+            "37260938",
+            "ocm37260938"
+          ],
+          "uniformTitle": [
+            "Great Lakes books."
+          ],
+          "dateEndYear": [
+            1998
+          ],
+          "holdings": [],
+          "updatedAt": 1655426926675,
+          "publicationStatement": [
+            "Detroit : Wayne State University Press, [1998], ©1998."
+          ],
+          "identifier": [
+            "urn:bnum:2127025",
+            "urn:isbn:0814326951 (alk. paper)",
+            "urn:lccn:   97025475 ",
+            "urn:oclc:37260938",
+            "urn:oclc:ocm37260938",
+            "urn:undefined:(OCoLC)37260938",
+            "urn:undefined:(OCoLC)ocm37260938",
+            "urn:undefined:(NNC)2127025",
+            "urn:undefined:2127025"
+          ],
+          "idIsbn": [
+            "0814326951 (alk. paper)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1998"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Wilson, Sunnie, 1908-1999.",
+            "Louis, Joe, 1914-1981.",
+            "Hotelkeepers -- Detroit -- Biography.",
+            "African American businesspeople -- Detroit.",
+            "Detroit (Mich.) -- History."
+          ],
+          "titleDisplay": [
+            "Toast of the town : the life and times of Sunnie Wilson / Sunnie Wilson with John Cohassey."
+          ],
+          "uri": "cb2127025",
+          "lccClassification": [
+            "TX910.5.W58 A3 1998"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Detroit"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "0814326951"
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          370.35986,
+          "cb2127025"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "cb2127025",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:CU68848080"
+                    ],
+                    "physicalLocation": [
+                      "TX910.5.W58 A3 1998"
+                    ],
+                    "shelfMark_sort": "aTX910.5.W58 A3 001998",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "ci2594116",
+                    "shelfMark": [
+                      "TX910.5.W58 A3 1998"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "TX910.5.W58 A3 1998"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "CU68848080"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU68848080"
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "pb9917945683506421",
+        "_score": 370.35986,
+        "_source": {
+          "extent": [
+            "200 p. : ill., map ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. 185-193) and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "subjectLiteral_exploded": [
+            "Wilson, Sunnie, 1908-1999",
+            "Louis, Joe, 1914-1981",
+            "Hotelkeepers",
+            "Hotelkeepers -- Michigan",
+            "Hotelkeepers -- Michigan -- Detroit",
+            "Hotelkeepers -- Michigan -- Detroit -- Biography",
+            "African American businesspeople",
+            "African American businesspeople -- Michigan",
+            "African American businesspeople -- Michigan -- Detroit",
+            "Detroit (Mich.)",
+            "Detroit (Mich.) -- History"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wayne State University Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1998
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Toast of the town : the life and times of Sunnie Wilson"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1998"
+          ],
+          "creatorLiteral": [
+            "Wilson, Sunnie, 1908-1999"
+          ],
+          "idLccn": [
+            "97025475"
+          ],
+          "seriesStatement": [
+            "Great Lakes books"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Cohassey, John, 1961-"
+          ],
+          "dateStartYear": [
+            1998
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9917945683506421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0814326951 (alk. paper)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm37260938"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-363077"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "97025475"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(CStRLIN)NJPG98-B38104"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)1794568-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm37260938"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager1794568"
+            }
+          ],
+          "idOclc": [
+            "ocm37260938",
+            "SCSB-363077"
+          ],
+          "popularity": 0,
+          "updatedAt": 1722603731856,
+          "publicationStatement": [
+            "Detroit : Wayne State University Press, c1998."
+          ],
+          "identifier": [
+            "urn:bnum:9917945683506421",
+            "urn:isbn:0814326951 (alk. paper)",
+            "urn:oclc:ocm37260938",
+            "urn:oclc:SCSB-363077",
+            "urn:lccn:97025475",
+            "urn:identifier:(CStRLIN)NJPG98-B38104",
+            "urn:identifier:(NjP)1794568-princetondb",
+            "urn:identifier:(OCoLC)ocm37260938",
+            "urn:identifier:(NjP)Voyager1794568"
+          ],
+          "idIsbn": [
+            "0814326951 (alk. paper)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1998"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Wilson, Sunnie, 1908-1999.",
+            "Louis, Joe, 1914-1981.",
+            "Hotelkeepers -- Michigan -- Detroit -- Biography.",
+            "African American businesspeople -- Michigan -- Detroit.",
+            "Detroit (Mich.) -- History."
+          ],
+          "titleDisplay": [
+            "Toast of the town : the life and times of Sunnie Wilson / Sunnie Wilson with John Cohassey."
+          ],
+          "uri": "pb9917945683506421",
+          "lccClassification": [
+            "TX910.5.W58 A3 1998"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Detroit"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ],
+          "idIsbn_clean": [
+            "0814326951"
+          ]
+        },
+        "sort": [
+          370.35986,
+          "pb9917945683506421"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "pb9917945683506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:TX910.5.W58 A3 1998",
+                      "urn:barcode:32101041878081"
+                    ],
+                    "physicalLocation": [
+                      "TX910.5.W58 A3 1998"
+                    ],
+                    "shelfMark_sort": "aTX910.5.W58 A3 001998",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "TX910.5.W58 A3 1998"
+                    ],
+                    "uri": "pi23624126520006421",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "TX910.5.W58 A3 1998"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32101041878081"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101041878081"
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b13555237",
+        "_score": 370.347,
+        "_source": {
+          "extent": [
+            "257 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "African Americans",
+            "African Americans -- New York (State)",
+            "African Americans -- New York (State) -- New York",
+            "African Americans -- New York (State) -- New York -- Fiction",
+            "Harlem (New York, N.Y.)",
+            "Harlem (New York, N.Y.) -- Fiction"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Doubleday"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1998
+          ],
+          "buildingLocationIds": [
+            "sc",
+            "ma"
+          ],
+          "title": [
+            "A toast before dying : a Mali Anderson Mystery"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFE 98-5504"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1998"
+          ],
+          "creatorLiteral": [
+            "Edwards, Grace F. (Grace Frederica)"
+          ],
+          "idLccn": [
+            "97047429"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1998
+          ],
+          "idOclc": [
+            "38081631"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 98-5504"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13555237"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0385485247"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "38081631"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "97047429"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3530217"
+            }
+          ],
+          "updatedAt": 1711384147469,
+          "publicationStatement": [
+            "New York : Doubleday, 1998."
+          ],
+          "idIsbn": [
+            "0385485247"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFE 98-5504",
+            "urn:bnum:13555237",
+            "urn:isbn:0385485247",
+            "urn:oclc:38081631",
+            "urn:lccn:97047429",
+            "urn:identifier:(WaOLN)nyp3530217"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1998"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "African Americans -- New York (State) -- New York -- Fiction.",
+            "Harlem (New York, N.Y.) -- Fiction."
+          ],
+          "titleDisplay": [
+            "A toast before dying : a Mali Anderson Mystery / Grace F. Edwards."
+          ],
+          "uri": "b13555237",
+          "lccClassification": [
+            "PS3555.D99 T63 1998"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ],
+          "idIsbn_clean": [
+            "0385485247"
+          ]
+        },
+        "sort": [
+          370.347,
+          "b13555237"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b13555237",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc E 98-933",
+                      "urn:barcode:33433059013205"
+                    ],
+                    "physicalLocation": [
+                      "Sc E 98-933"
+                    ],
+                    "shelfMark_sort": "aSc E 98-000933",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "Sc E 98-933"
+                    ],
+                    "uri": "i10699418",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Sc E 98-933"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059013205"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "idBarcode": [
+                      "33433059013205"
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b13555237",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFE 98-5504",
+                      "urn:barcode:33433069269284"
+                    ],
+                    "physicalLocation": [
+                      "JFE 98-5504"
+                    ],
+                    "shelfMark_sort": "aJFE 98-005504",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFE 98-5504"
+                    ],
+                    "uri": "i10699417",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFE 98-5504"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433069269284"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433069269284"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "pb99107169653506421",
+        "_score": 363.38403,
+        "_source": {
+          "extent": [
+            "321 pages : illustrations ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "subjectLiteral_exploded": [
+            "Lee-Schmidt, Young-Nam, 1952-",
+            "Koreans",
+            "Koreans -- Germany",
+            "Koreans -- Germany -- Biography",
+            "Ethnic relations",
+            "Germany",
+            "Germany -- Ethnic relations"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Deutsche Literaturgesellschaft"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2018
+          ],
+          "title": [
+            "Yongi, oder, Die Kunst, einen Toast zu essen"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2018"
+          ],
+          "creatorLiteral": [
+            "Lee-Schmidt, Young-Nam, 1952-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2018
+          ],
+          "idOclc": [
+            "on1040035278",
+            "SCSB-14040180"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "99107169653506421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9783038311713"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3038311715"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "on1040035278"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-14040180"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)10716965-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)on1040035278"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager10716965"
+            }
+          ],
+          "popularity": 0,
+          "updatedAt": 1739410339863,
+          "publicationStatement": [
+            "[Berlin] : Deutsche Literaturgesellschaft, [2018]"
+          ],
+          "genreForm": [
+            "Biographies.",
+            "Autobiographies."
+          ],
+          "idIsbn": [
+            "9783038311713",
+            "3038311715"
+          ],
+          "identifier": [
+            "urn:bnum:99107169653506421",
+            "urn:isbn:9783038311713",
+            "urn:isbn:3038311715",
+            "urn:oclc:on1040035278",
+            "urn:oclc:SCSB-14040180",
+            "urn:identifier:(NjP)10716965-princetondb",
+            "urn:identifier:(OCoLC)on1040035278",
+            "urn:identifier:(NjP)Voyager10716965"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2018"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Lee-Schmidt, Young-Nam, 1952-",
+            "Koreans -- Germany -- Biography.",
+            "Ethnic relations.",
+            "Koreans.",
+            "Germany -- Ethnic relations.",
+            "Germany."
+          ],
+          "titleDisplay": [
+            "Yongi, oder, Die Kunst, einen Toast zu essen / Young-Nam Lee-Schmidt."
+          ],
+          "uri": "pb99107169653506421",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "[Berlin]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm"
+          ],
+          "idIsbn_clean": [
+            "9783038311713",
+            "3038311715"
+          ]
+        },
+        "sort": [
+          363.38403,
+          "pb99107169653506421"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "pb99107169653506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:X04003578",
+                      "urn:barcode:32101106490491"
+                    ],
+                    "physicalLocation": [
+                      "X04003578"
+                    ],
+                    "shelfMark_sort": "aX04003578",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "X04003578"
+                    ],
+                    "uri": "pi23655912680006421",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "X04003578"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32101106490491"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101106490491"
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "pb9911624953506421",
+        "_score": 362.5912,
+        "_source": {
+          "extent": [
+            "1 score (9 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Originally for soprano and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 3:30.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "subjectLiteral_exploded": [
+            "Bertolino, James, 1942-",
+            "Bertolino, James, 1942- -- Musical settings",
+            "Songs (High voice) with instrumental ensemble",
+            "Songs (High voice) with instrumental ensemble -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "AdLar Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1994
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A wedding toast : for soprano and string quartet"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1994"
+          ],
+          "creatorLiteral": [
+            "Adaskin, Murray, 1906-2002"
+          ],
+          "idLccn": [
+            "M706002064"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1994
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9911624953506421"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocn666197888"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-2121535"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "M706002064"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(CStRLIN)NJPG97-C408"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)1162495-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocn666197888"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)37469199"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager1162495"
+            }
+          ],
+          "idOclc": [
+            "ocn666197888",
+            "SCSB-2121535"
+          ],
+          "uniformTitle": [
+            "Wedding toast; arr."
+          ],
+          "popularity": 0,
+          "updatedAt": 1723191638343,
+          "publicationStatement": [
+            "Victoria, British Columbia : AdLar Publications, c1994."
+          ],
+          "identifier": [
+            "urn:bnum:9911624953506421",
+            "urn:oclc:ocn666197888",
+            "urn:oclc:SCSB-2121535",
+            "urn:lccn:M706002064",
+            "urn:identifier:(CStRLIN)NJPG97-C408",
+            "urn:identifier:(NjP)1162495-princetondb",
+            "urn:identifier:(OCoLC)ocn666197888",
+            "urn:identifier:(OCoLC)37469199",
+            "urn:identifier:(NjP)Voyager1162495"
+          ],
+          "genreForm": [
+            "Scores.",
+            "Songs."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1994"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bertolino, James, 1942- -- Musical settings.",
+            "Songs (High voice) with instrumental ensemble -- Scores."
+          ],
+          "titleDisplay": [
+            "A wedding toast : for soprano and string quartet / Murray Adaskin ; poem by James Bertolino."
+          ],
+          "uri": "pb9911624953506421",
+          "lccClassification": [
+            "M1613.3.A32 W4 1994"
+          ],
+          "formatId": "c",
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "Victoria, British Columbia"
+          ],
+          "titleAlt": [
+            "Wedding toast;"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          362.5912,
+          "pb9911624953506421"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "pb9911624953506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:M1613.3.A32 W4 1994q Oversize",
+                      "urn:barcode:32101069496063"
+                    ],
+                    "physicalLocation": [
+                      "M1613.3.A32 W4 1994q Oversize"
+                    ],
+                    "shelfMark_sort": "aM1613.3.A32 W4 1994q Oversize",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "M1613.3.A32 W4 1994q Oversize"
+                    ],
+                    "uri": "pi23608241160006421",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "M1613.3.A32 W4 1994q Oversize"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32101069496063"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101069496063"
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-825e97f996b228583bbc960b9bec2b25.json
+++ b/test/fixtures/query-825e97f996b228583bbc960b9bec2b25.json
@@ -1,0 +1,12714 @@
+{
+  "took": 170,
+  "timed_out": false,
+  "_shards": {
+    "total": 2,
+    "successful": 2,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1462,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b20970375",
+        "_score": 3949.4294,
+        "_source": {
+          "extent": [
+            "119 pages : illustrations (color) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Toast (Bread)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Phaidon Press Limited"
+          ],
+          "description": [
+            "The ultimate canvas for sweet and savory culinary creativity. 50 seasonal recipes that reimagine the \"bread and butter\" of cuisine with simple ingredients in surprising ways. Easy enough for breakfast, yet suitable for brunch, lunch, dinner and even dessert, the possibilities of heaping beautiful seasonal ingredients on bread are limitless. Toast guides home chefs as they explore home cuisine's ultimate creative canvas. Organized by season, Toast features 50 recipes from savory to sweet that unleash the power of fresh ingredients and simple techniques guaranteed to impress and satisfy any kitchen audience on any occasion."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2015
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Toast"
+          ],
+          "shelfMark": [
+            "JFF 16-815"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2015"
+          ],
+          "creatorLiteral": [
+            "Pelzel, Raquel"
+          ],
+          "idLccn": [
+            "2015473840"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sung, Evan"
+          ],
+          "dateStartYear": [
+            2015
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 16-815"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "20970375"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780714869551"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0714869554"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "915941587"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2015473840"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)915941587"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)905521916"
+            }
+          ],
+          "idOclc": [
+            "915941587"
+          ],
+          "popularity": 4,
+          "updatedAt": 1722434139301,
+          "publicationStatement": [
+            "London : Phaidon Press Limited, 2015.",
+            "©2015"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFF 16-815",
+            "urn:bnum:20970375",
+            "urn:isbn:9780714869551",
+            "urn:isbn:0714869554",
+            "urn:oclc:915941587",
+            "urn:lccn:2015473840",
+            "urn:identifier:(OCoLC)915941587",
+            "urn:identifier:(OCoLC)905521916"
+          ],
+          "genreForm": [
+            "Cookbooks."
+          ],
+          "idIsbn": [
+            "9780714869551",
+            "0714869554"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2015"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Toast (Bread)"
+          ],
+          "titleDisplay": [
+            "Toast / by Raquel Pelzel ; photographs by Evan Sung."
+          ],
+          "uri": "b20970375",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "titleAlt": [
+            "Toast : the cookbook"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm"
+          ],
+          "idIsbn_clean": [
+            "9780714869551",
+            "0714869554"
+          ]
+        },
+        "sort": [
+          3949.4294,
+          "b20970375"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b20970375",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFF 16-815",
+                      "urn:barcode:33433118568447"
+                    ],
+                    "physicalLocation": [
+                      "JFF 16-815"
+                    ],
+                    "shelfMark_sort": "aJFF 16-000815",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFF 16-815"
+                    ],
+                    "uri": "i34162229",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFF 16-815"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433118568447"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433118568447"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b11361121",
+        "_score": 3588.9365,
+        "_source": {
+          "extent": [
+            "191 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wydawnictwo Literackie"
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "title": [
+            "Toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "*QPM 90-2088"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "creatorLiteral": [
+            "Hen, Józef"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "idOclc": [
+            "NYPG89-B29663"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*QPM 90-2088"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11361121"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG89-B29663"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1369053"
+            }
+          ],
+          "popularity": 6,
+          "updatedAt": 1752421819335,
+          "publicationStatement": [
+            "Krakow : Wydawnictwo Literackie, 1974."
+          ],
+          "identifier": [
+            "urn:shelfmark:*QPM 90-2088",
+            "urn:bnum:11361121",
+            "urn:oclc:NYPG89-B29663",
+            "urn:identifier:(WaOLN)nyp1369053"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Toast / Józef Hen."
+          ],
+          "uri": "b11361121",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Krakow"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          3588.9365,
+          "b11361121"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b11361121",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building - General Research Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433044323693"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*QPM 90-2088",
+                      "urn:barcode:33433044323693"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*QPM 90-2088",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433044323693",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "*QPM 90-2088"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "*QPM 90-2088"
+                    ],
+                    "shelfMark_sort": "a*QPM 90-002088",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i13172719"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b17982563",
+        "_score": 3588.9365,
+        "_source": {
+          "extent": [
+            "1 volume (unpaged) : all color illustrations ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title and publication information from Printed Matter website",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"A great flipbook portraying two slices of bread being toasted.\"--Printed Matter website (viewed May 14, 2025)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Local note",
+              "label": "Artists' Books Collection (NYPL, Print Collection)",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Artists' books"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "J. Featheringill"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            null
+          ],
+          "title": [
+            "Toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "MEMZ (Featheringill) 09-981"
+          ],
+          "createdString": [
+            "    "
+          ],
+          "creatorLiteral": [
+            "Featheringill, Julia"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "MEMZ (Featheringill) 09-981"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "17982563"
+            }
+          ],
+          "popularity": 0,
+          "updatedAt": 1753312482161,
+          "publicationStatement": [
+            "Ithaca, NY : J. Featheringill, 2001",
+            " ©2001 "
+          ],
+          "genreForm": [
+            "Artists' books"
+          ],
+          "identifier": [
+            "urn:shelfmark:MEMZ (Featheringill) 09-981",
+            "urn:bnum:17982563"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "    "
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Artists' books"
+          ],
+          "titleDisplay": [
+            "Toast / Julia Featheringill"
+          ],
+          "uri": "b17982563",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Ithaca, NY"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "7 x 14 cm"
+          ]
+        },
+        "sort": [
+          3588.9365,
+          "b17982563"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b17982563",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Featheringill%2C+Julia&CallNumber=MEMZ+%28Featheringill%29+09-981&Date=++++&Form=30&Genre=book+non-circ&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db17982563&ItemISxN=i174467412&ItemNumber=33433138142132&ItemPlace=Ithaca%2C+NY&ItemPublisher=+%C2%A92001+&Location=Schwarzman+Prints+and+Photographs+Division&ReferenceNumber=b17982563x&Site=SASPR&Title=Toast"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mauu2",
+                        "label": "Schwarzman Building - Print Collection Room 308"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mauu2||Schwarzman Building - Print Collection Room 308"
+                    ],
+                    "idBarcode": [
+                      "33433138142132"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:MEMZ (Featheringill) 09-981",
+                      "urn:barcode:33433138142132"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "MEMZ (Featheringill) 09-981",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433138142132",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1112",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Print Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1112||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Print Collection"
+                    ],
+                    "physicalLocation": [
+                      "MEMZ (Featheringill) 09-981"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "MEMZ (Featheringill) 09-981"
+                    ],
+                    "shelfMark_sort": "aMEMZ (Featheringill) 09-000981",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17446741"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b17759113",
+        "_score": 3587.9365,
+        "_source": {
+          "extent": [
+            "1 film reel (12 min.) : sd., col. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Originally released as a short film in 1974.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Narration, Michael Ryan ; music, Klaus Schulze, Achim Reichel, Kraftwerk.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Fuel",
+            "Energy conservation"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "[s.n.]"
+          ],
+          "description": [
+            "Focuses on the excessive use of fossil fuels in the preparation and marketing of food by tracing the production and distribution of a loaf of bread from the oil well to consumption. Also illustrates the concept of net energy profit."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "title": [
+            "Toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Hoffman, Daniel",
+            "Earth Chronicles (Firm)"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "17759113"
+            }
+          ],
+          "popularity": 0,
+          "updatedAt": 1753560730965,
+          "publicationStatement": [
+            "[S.l.] : [s.n.], 1974."
+          ],
+          "genreForm": [
+            "Short films.",
+            "Educational films."
+          ],
+          "identifier": [
+            "urn:bnum:17759113"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mov",
+              "label": "Moving image"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Fuel.",
+            "Energy conservation."
+          ],
+          "titleDisplay": [
+            "Toast [motion picture] / Earth Chronicles presents ; a film by Daniel Hoffman ... [et al.]."
+          ],
+          "uri": "b17759113",
+          "formatId": "g",
+          "recordTypeId": "g",
+          "placeOfPublication": [
+            "[S.l.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 mm."
+          ]
+        },
+        "sort": [
+          3587.9365,
+          "b17759113"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b17759113",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:a",
+                        "label": "By appointment only"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:a||By appointment only"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=M16+5213+T+C.1+REEL+1+OF+1&Date=1974&Form=30&Genre=rfvc+-+film&ItemInfo1=By+appointment+only&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db17759113&ItemISxN=i239658231&ItemNumber=33433081452009&ItemPlace=%5BS.l.%5D&ItemPublisher=%5Bs.n.%5D%2C+1974.&ItemVolume=C.1+REEL+1+OF+1&Location=ReCAP&ReferenceNumber=b177591134&Site=LPARF&SubLocation=rcpr8&Title=Toast"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:72",
+                        "label": "rfvc - film"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:72||rfvc - film"
+                    ],
+                    "enumerationChronology": [
+                      "C.1 REEL 1 OF 1"
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "formatLiteral": [
+                      "Film, Slide, etc."
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpr8",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpr8||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433081452009"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:M16 5213 T C.1 REEL 1 OF 1",
+                      "urn:barcode:33433081452009"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M16 5213 T C.1 REEL 1 OF 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433081452009",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "M16 5213 T C.1 REEL 1 OF 1"
+                    ],
+                    "recapCustomerCode": [
+                      "NN"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "M16 5213 T C.1 REEL 1 OF 1"
+                    ],
+                    "shelfMark_sort": "aM16 5213 T C.1 REEL 1 OF 000001",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i23965823",
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "pb9928178733506421",
+        "_score": 3581.1802,
+        "_source": {
+          "extent": [
+            "191 p. ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wydawn. Literackie"
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "title": [
+            "Toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "creatorLiteral": [
+            "Hen, Józef"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "idOclc": [
+            "ocm10101466",
+            "SCSB-944961"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9928178733506421"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm10101466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-944961"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)2817873-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm10101466"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager2817873"
+            }
+          ],
+          "popularity": 0,
+          "updatedAt": 1723162379105,
+          "publicationStatement": [
+            "Kraków : Wydawn. Literackie, 1967."
+          ],
+          "identifier": [
+            "urn:bnum:9928178733506421",
+            "urn:oclc:ocm10101466",
+            "urn:oclc:SCSB-944961",
+            "urn:identifier:(NjP)2817873-princetondb",
+            "urn:identifier:(OCoLC)ocm10101466",
+            "urn:identifier:(NjP)Voyager2817873"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Toast / Józef Hen."
+          ],
+          "uri": "pb9928178733506421",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Kraków"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          3581.1802,
+          "pb9928178733506421"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "pb9928178733506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PG7158.H43 T637 1967",
+                      "urn:barcode:32101075229904"
+                    ],
+                    "physicalLocation": [
+                      "PG7158.H43 T637 1967"
+                    ],
+                    "shelfMark_sort": "aPG7158.H43 T637 001967",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "PG7158.H43 T637 1967"
+                    ],
+                    "uri": "pi23546661110006421",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PG7158.H43 T637 1967"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32101075229904"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101075229904"
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "pb9928479343506421",
+        "_score": 3581.1802,
+        "_source": {
+          "extent": [
+            "103 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"First performed at the Royal Court Theatre Upstairs ... on 12th February 1999.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Oberon"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1999
+          ],
+          "title": [
+            "Toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1999"
+          ],
+          "creatorLiteral": [
+            "Bean, Richard, 1956-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1999
+          ],
+          "idOclc": [
+            "ocm53231811",
+            "SCSB-964143"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9928479343506421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1840021047"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm53231811"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-964143"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(CStRLIN)GAEGO42263032-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(GEU)(Sirsi)o42263032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)2847934-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm53231811"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager2847934"
+            }
+          ],
+          "popularity": 0,
+          "updatedAt": 1739836292936,
+          "publicationStatement": [
+            "London : Oberon, 1999."
+          ],
+          "idIsbn": [
+            "1840021047"
+          ],
+          "identifier": [
+            "urn:bnum:9928479343506421",
+            "urn:isbn:1840021047",
+            "urn:oclc:ocm53231811",
+            "urn:oclc:SCSB-964143",
+            "urn:identifier:(CStRLIN)GAEGO42263032-B",
+            "urn:identifier:(GEU)(Sirsi)o42263032",
+            "urn:identifier:(NjP)2847934-princetondb",
+            "urn:identifier:(OCoLC)ocm53231811",
+            "urn:identifier:(NjP)Voyager2847934"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Toast / by Richard Bean."
+          ],
+          "uri": "pb9928479343506421",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "1840021047"
+          ]
+        },
+        "sort": [
+          3581.1802,
+          "pb9928479343506421"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "pb9928479343506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR6052.E176 T627 1999",
+                      "urn:barcode:32101095377683"
+                    ],
+                    "physicalLocation": [
+                      "PR6052.E176 T627 1999"
+                    ],
+                    "shelfMark_sort": "aPR6052.E176 T627 001999",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "PR6052.E176 T627 1999"
+                    ],
+                    "uri": "pi23486469710006421",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PR6052.E176 T627 1999"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32101095377683"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101095377683"
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "hb990052336220203941",
+        "_score": 2035.5773,
+        "_source": {
+          "extent": [
+            "187 p."
+          ],
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wydawnictwo Literackie"
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1964
+          ],
+          "title": [
+            "Toast."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "creatorLiteral": [
+            "Hen, Józef"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "idOclc": [
+            "7224766",
+            "SCSB-10588391"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990052336220203941"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "7224766"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-10588391"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)7224766"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)977353017"
+            }
+          ],
+          "popularity": 0,
+          "updatedAt": 1740965556310,
+          "publicationStatement": [
+            "Kraków, Wydawnictwo Literackie [1964]"
+          ],
+          "genreForm": [
+            "Polish fiction"
+          ],
+          "identifier": [
+            "urn:bnum:990052336220203941",
+            "urn:oclc:7224766",
+            "urn:oclc:SCSB-10588391",
+            "urn:identifier:(OCoLC)7224766",
+            "urn:identifier:(OCoLC)977353017"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Toast."
+          ],
+          "uri": "hb990052336220203941",
+          "lccClassification": [
+            "PG7158.H43 T6"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Kraków"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          2035.5773,
+          "hb990052336220203941"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "hb990052336220203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Slav 7147.24.2110",
+                      "urn:barcode:HNAASE"
+                    ],
+                    "physicalLocation": [
+                      "Slav 7147.24.2110"
+                    ],
+                    "shelfMark_sort": "aSlav 7147.24.002110",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "Slav 7147.24.2110"
+                    ],
+                    "uri": "hi231942284890003941",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Slav 7147.24.2110"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "HNAASE"
+                      }
+                    ],
+                    "idBarcode": [
+                      "HNAASE"
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b21290385",
+        "_score": 551.25867,
+        "_source": {
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Compiled by The Billy Rose Theatre Division, The New York Public Library.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Four reviews of ToasT by Lemon Andersen. This prison drama starring Keith David and John Earl Jelks takes place in Attica just prior to the riots of 1971. Opened May 5, 2015, at Public Theater, 425 Lafayette Street, New York, N.Y.  Most of  the characters are African Americans.",
+              "type": "bf:Note"
+            }
+          ],
+          "partOf": [
+            "Collection of newspaper clippings of dramatic criticism, 2014/15."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Andersen, Lemon",
+            "Attica Correctional Facility",
+            "Attica Correctional Facility -- Drama",
+            "Public Theater (New York, N.Y.)",
+            "Theater",
+            "Theater -- New York (State)",
+            "Theater -- New York (State) -- New York",
+            "Theater -- New York (State) -- New York -- Reviews",
+            "Prisons",
+            "Prisons -- Drama"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            null
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "title": [
+            "ToasT (Andersen)"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*T-NBL+ Collection 2014/15 (ToasT)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "    "
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "New York Public Library for the Performing Arts. Billy Rose Theatre Division. com"
+          ],
+          "dateStartYear": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*T-NBL+ Collection 2014/15 (ToasT)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "21290385"
+            }
+          ],
+          "updatedAt": 1711659268085,
+          "genreForm": [
+            "Reviews (document genre)."
+          ],
+          "identifier": [
+            "urn:shelfmark:*T-NBL+ Collection 2014/15 (ToasT)",
+            "urn:bnum:21290385"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "    "
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Andersen, Lemon.",
+            "Attica Correctional Facility -- Drama.",
+            "Public Theater (New York, N.Y.)",
+            "Theater -- New York (State) -- New York -- Reviews.",
+            "Prisons -- Drama."
+          ],
+          "titleDisplay": [
+            "ToasT (Andersen), 2014/15 : reviews."
+          ],
+          "uri": "b21290385",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          551.25867,
+          "b21290385"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b21290385",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*T-NBL+ Collection 2014/15 (ToasT)"
+                    ],
+                    "physicalLocation": [
+                      "*T-NBL+ Collection 2014/15 (ToasT)"
+                    ],
+                    "shelfMark_sort": "a*T-NBL+ Collection 2014/15 (ToasT)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:22||clipping files"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*T-NBL+ Collection 2014/15 (ToasT)"
+                    ],
+                    "uri": "i37684790",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*T-NBL+ Collection 2014/15 (ToasT)"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pat11||Performing Arts Research Collections - Theatre - Reference"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:22",
+                        "label": "clipping files"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pat11",
+                        "label": "Performing Arts Research Collections - Theatre - Reference"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b21501833",
+        "_score": 551.25867,
+        "_source": {
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Compiled by The Billy Rose Theatre Division, The New York Public Library.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Four reviews of Toast by Richard Bean. This comedy about British factory life was reviewed May 19, 2016, when it was produced as part of Brits Off-Broadway festival at 59E59 Theaters, 59 East 59th Street, New York, N.Y.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Reviewed by Ben Brantley in The New York Times, Hilton Als in The New Yorker, Barry Bassis in The Epoch Times, and Elisabeth Vincentelli in New Yor Post.",
+              "type": "bf:Note"
+            }
+          ],
+          "partOf": [
+            "Collection of newspaper clippings of dramatic criticism, 2015/16."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bean, Richard, 1956-",
+            "59E59 Theaters (New York, N.Y.)",
+            "Brits Off-Broadway",
+            "Theater",
+            "Theater -- New York (State)",
+            "Theater -- New York (State) -- New York",
+            "Theater -- New York (State) -- New York -- Reviews",
+            "Factories",
+            "Factories -- England",
+            "Factories -- England -- Drama",
+            "Employees",
+            "Employees -- England",
+            "Employees -- England -- Drama"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            null
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "title": [
+            "Toast (Bean)"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*T-NBL+ Collection 2015/16 (Toast)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "    "
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "New York Public Library for the Performing Arts. Billy Rose Theatre Division. com"
+          ],
+          "dateStartYear": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*T-NBL+ Collection 2015/16 (Toast)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "21501833"
+            }
+          ],
+          "updatedAt": 1711659234093,
+          "genreForm": [
+            "Reviews (document genre)."
+          ],
+          "identifier": [
+            "urn:shelfmark:*T-NBL+ Collection 2015/16 (Toast)",
+            "urn:bnum:21501833"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "    "
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bean, Richard, 1956-",
+            "59E59 Theaters (New York, N.Y.)",
+            "Brits Off-Broadway.",
+            "Theater -- New York (State) -- New York -- Reviews.",
+            "Factories -- England -- Drama.",
+            "Employees -- England -- Drama."
+          ],
+          "titleDisplay": [
+            "Toast (Bean), 2015/16 : reviews."
+          ],
+          "uri": "b21501833",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          551.25867,
+          "b21501833"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b21501833",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*T-NBL+ Collection 2015/16 (Toast)"
+                    ],
+                    "physicalLocation": [
+                      "*T-NBL+ Collection 2015/16 (Toast)"
+                    ],
+                    "shelfMark_sort": "a*T-NBL+ Collection 2015/16 (Toast)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:22||clipping files"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*T-NBL+ Collection 2015/16 (Toast)"
+                    ],
+                    "uri": "i37685439",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*T-NBL+ Collection 2015/16 (Toast)"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pat11||Performing Arts Research Collections - Theatre - Reference"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:22",
+                        "label": "clipping files"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pat11",
+                        "label": "Performing Arts Research Collections - Theatre - Reference"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b14570561",
+        "_score": 550.25867,
+        "_source": {
+          "extent": [
+            "[97] p., ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Skeleton head cover.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Illustrated t.-p.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Toasts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "John C. Winston Co."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            1905
+          ],
+          "buildingLocationIds": [],
+          "title": [
+            "Toast book"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "Rare Books 18-3570"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1905"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Dwiggins, Clare Victor"
+          ],
+          "dateStartYear": [
+            1905
+          ],
+          "idOclc": [
+            "14233575"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Rare Books 18-3570"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "14570561"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "14233575"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)R250001642"
+            }
+          ],
+          "updatedAt": 1712866073540,
+          "publicationStatement": [
+            "Philadelphia : John C. Winston Co., c1905."
+          ],
+          "identifier": [
+            "urn:shelfmark:Rare Books 18-3570",
+            "urn:bnum:14570561",
+            "urn:oclc:14233575",
+            "urn:identifier:(WaOLN)R250001642"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1905"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Toasts."
+          ],
+          "titleDisplay": [
+            "Toast book / compiled and illustrated by Clare Victor Dwiggins."
+          ],
+          "uri": "b14570561",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Philadelphia"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          550.25867,
+          "b14570561"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b21965138",
+        "_score": 522.18475,
+        "_source": {
+          "extent": [
+            "1 folder. "
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Programs for productions of the play Toast by Henry Filloux-Bennett. Based on the book by Nigel Slater.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Filloux-Bennett, Henry",
+            "Slater, Nigel"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "title": [
+            "Toast (Filloux-Bennett)"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "*T-PRG (Toast (Filloux-Bennett))"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*T-PRG (Toast (Filloux-Bennett))"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "21965138"
+            }
+          ],
+          "popularity": 0,
+          "updatedAt": 1734635850344,
+          "genreForm": [
+            "Programs."
+          ],
+          "identifier": [
+            "urn:shelfmark:*T-PRG (Toast (Filloux-Bennett))",
+            "urn:bnum:21965138"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Filloux-Bennett, Henry.",
+            "Slater, Nigel."
+          ],
+          "titleDisplay": [
+            "Toast (Filloux-Bennett) : programs."
+          ],
+          "uri": "b21965138",
+          "formatId": "p",
+          "recordTypeId": " "
+        },
+        "sort": [
+          522.18475,
+          "b21965138"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b21965138",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*T-PRG (Toast (Filloux-Bennett))",
+                      "urn:barcode:33433120459403"
+                    ],
+                    "physicalLocation": [
+                      "*T-PRG (Toast (Filloux-Bennett))"
+                    ],
+                    "shelfMark_sort": "a*T-PRG (Toast (Filloux-Bennett))",
+                    "catalogItemType_packed": [
+                      "catalogItemType:21||archival material"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=*T-PRG+%28Toast+%28Filloux-Bennett%29%29&Form=30&Genre=archival+material&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db21965138&ItemISxN=i373192253&ItemNumber=33433120459403&Location=Performing+Arts+Theatre+Division&ReferenceNumber=b219651383&Site=LPATH&Title=Toast+%28Filloux-Bennett%29+%3A+programs."
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*T-PRG (Toast (Filloux-Bennett))"
+                    ],
+                    "uri": "i37319225",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*T-PRG (Toast (Filloux-Bennett))"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433120459403"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pat38||Performing Arts Research Collections - Theatre"
+                    ],
+                    "idBarcode": [
+                      "33433120459403"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:21",
+                        "label": "archival material"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pat38",
+                        "label": "Performing Arts Research Collections - Theatre"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Archival Mix"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b18576841",
+        "_score": 521.18475,
+        "_source": {
+          "extent": [
+            "386 pp."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "buildingLocationIds": [],
+          "title": [
+            "Toast za przodkow"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Gorecki, Wojciech"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "18576841"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9788373561940"
+            }
+          ],
+          "updatedAt": 1711654548895,
+          "publicationStatement": [
+            "Wolowiec : Czarne, 2010"
+          ],
+          "idIsbn": [
+            "9788373561940"
+          ],
+          "identifier": [
+            "urn:bnum:18576841",
+            "urn:isbn:9788373561940"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Toast za przodkow"
+          ],
+          "uri": "b18576841",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Wolowiec : Czarne, 2010"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "9788373561940"
+          ]
+        },
+        "sort": [
+          521.18475,
+          "b18576841"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b18806309",
+        "_score": 521.18475,
+        "_source": {
+          "extent": [
+            "386 p. : map ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. 383-[387])",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Polish.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Caucasus",
+            "Caucasus -- Civilization"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wydawn. Czarne"
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2010
+          ],
+          "title": [
+            "Toast za przodków"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "ReCAP 11-4380"
+          ],
+          "createdString": [
+            "2010"
+          ],
+          "creatorLiteral": [
+            "Górecki, Wojciech, 1970-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "seriesStatement": [
+            "Reportaż"
+          ],
+          "dateStartYear": [
+            2010
+          ],
+          "idOclc": [
+            "671293997"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "ReCAP 11-4380"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "18806309"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9788375361940 (pbk)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "8375361941 (pbk)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "671293997"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)671293997"
+            }
+          ],
+          "popularity": 2,
+          "uniformTitle": [
+            "Seria Reportaż."
+          ],
+          "updatedAt": 1746030521128,
+          "publicationStatement": [
+            "Wołowiec : Wydawn. Czarne, 2010."
+          ],
+          "idIsbn": [
+            "9788375361940 (pbk)",
+            "8375361941 (pbk)"
+          ],
+          "identifier": [
+            "urn:shelfmark:ReCAP 11-4380",
+            "urn:bnum:18806309",
+            "urn:isbn:9788375361940 (pbk)",
+            "urn:isbn:8375361941 (pbk)",
+            "urn:oclc:671293997",
+            "urn:identifier:(OCoLC)671293997"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2010"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Caucasus.",
+            "Caucasus -- Civilization."
+          ],
+          "titleDisplay": [
+            "Toast za przodków / Wojciech Górecki."
+          ],
+          "uri": "b18806309",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Wołowiec"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "9788375361940",
+            "8375361941"
+          ]
+        },
+        "sort": [
+          521.18475,
+          "b18806309"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b18806309",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433090460647"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:ReCAP 11-4380",
+                      "urn:barcode:33433090460647"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "ReCAP 11-4380",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433090460647",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "physicalLocation": [
+                      "ReCAP 11-4380"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "ReCAP 11-4380"
+                    ],
+                    "shelfMark_sort": "aReCAP 11-004380",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i26121731"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "hb990099650640203941",
+        "_score": 515.7138,
+        "_source": {
+          "extent": [
+            "247 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "subjectLiteral_exploded": [
+            "Short stories"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Cosmos Books"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2006
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "dateEndString": [
+            "2002"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Toast / Charles Stross."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Stross, Charles"
+          ],
+          "createdString": [
+            "2006"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2006
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990099650640203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0809556030 (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "69652590"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-12049344"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)69652590"
+            }
+          ],
+          "idOclc": [
+            "69652590",
+            "SCSB-12049344"
+          ],
+          "dateEndYear": [
+            2002
+          ],
+          "holdings": [],
+          "updatedAt": 1681081853656,
+          "publicationStatement": [
+            "Holicong, PA : Cosmos Books, c2006, c2002."
+          ],
+          "identifier": [
+            "urn:bnum:990099650640203941",
+            "urn:isbn:0809556030 (pbk.)",
+            "urn:oclc:69652590",
+            "urn:oclc:SCSB-12049344",
+            "urn:undefined:(OCoLC)69652590"
+          ],
+          "idIsbn": [
+            "0809556030 (pbk.)"
+          ],
+          "genreForm": [
+            "short stories.",
+            "Short stories",
+            "Science fiction",
+            "Nouvelles."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2006"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Short stories"
+          ],
+          "titleDisplay": [
+            "Toast / Charles Stross."
+          ],
+          "uri": "hb990099650640203941",
+          "lccClassification": [
+            "PR6119.T79 T63 2006"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Holicong, PA"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Antibodies -- Bear trap -- Extracts from the Club Diary -- A colder war -- Toast: a con report -- A boy and his God -- Ship of fools -- Dechlorinating the moderator -- Yellow snow -- Big Brother Iron."
+          ],
+          "idIsbn_clean": [
+            "0809556030"
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          515.7138,
+          "hb990099650640203941"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "hb990099650640203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:32044077499465"
+                    ],
+                    "physicalLocation": [
+                      "PR6119.T79 T63 2006"
+                    ],
+                    "shelfMark_sort": "aPR6119.T79 T63 002006",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "hi232106586300003941",
+                    "shelfMark": [
+                      "PR6119.T79 T63 2006"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PR6119.T79 T63 2006"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32044077499465"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32044077499465"
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "pb9969551973506421",
+        "_score": 515.7138,
+        "_source": {
+          "extent": [
+            "386 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wydawn. \"Czarne\""
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2010
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "title": [
+            "Toast za przodków"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2010"
+          ],
+          "creatorLiteral": [
+            "Górecki, Wojciech, 1970-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "seriesStatement": [
+            "Reportaż"
+          ],
+          "dateStartYear": [
+            2010
+          ],
+          "idOclc": [
+            "ocn671293997",
+            "SCSB-1622764"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9969551973506421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9788375361940"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocn671293997"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-1622764"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(PlWaKWL)lx2010024594"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)6955197-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocn671293997"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager6955197"
+            }
+          ],
+          "uniformTitle": [
+            "Reportaż"
+          ],
+          "updatedAt": 1719969925808,
+          "publicationStatement": [
+            "Wołowiec : Wydawn. \"Czarne\", 2010."
+          ],
+          "idIsbn": [
+            "9788375361940"
+          ],
+          "identifier": [
+            "urn:bnum:9969551973506421",
+            "urn:isbn:9788375361940",
+            "urn:oclc:ocn671293997",
+            "urn:oclc:SCSB-1622764",
+            "urn:identifier:(PlWaKWL)lx2010024594",
+            "urn:identifier:(NjP)6955197-princetondb",
+            "urn:identifier:(OCoLC)ocn671293997",
+            "urn:identifier:(NjP)Voyager6955197"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2010"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Toast za przodków / Wojciech Górecki."
+          ],
+          "uri": "pb9969551973506421",
+          "lccClassification": [
+            "PG7223.I78 T627 2010"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Wołowiec"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "9788375361940"
+          ]
+        },
+        "sort": [
+          515.7138,
+          "pb9969551973506421"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "pb9969551973506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PG7223.I78 T627 2010",
+                      "urn:barcode:32101072287822"
+                    ],
+                    "physicalLocation": [
+                      "PG7223.I78 T627 2010"
+                    ],
+                    "shelfMark_sort": "aPG7223.I78 T627 002010",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "PG7223.I78 T627 2010"
+                    ],
+                    "uri": "pi23652743930006421",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PG7223.I78 T627 2010"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32101072287822"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101072287822"
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b11373666",
+        "_score": 501.2587,
+        "_source": {
+          "extent": [
+            "1 ms. score (5 leaves) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Holograph signed, in ink and pencil.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For voice and orchestra; music for orchestra only (includes cue for voice).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Alternate musical setting from mss. of Mar. 6, 1918.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "At end: N.Y., March 15, 1918.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Title from caption (in pencil); other caption title information illegible.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sousa, John Philip, 1854-1932",
+            "Sousa, John Philip, 1854-1932 -- Manuscripts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1918
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "title": [
+            "The toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JPB 84-313"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1918"
+          ],
+          "creatorLiteral": [
+            "Sousa, John Philip, 1854-1932"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1918
+          ],
+          "idOclc": [
+            "NYPG004000623-C"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 84-313"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11373666"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG004000623-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405623"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1381622"
+            }
+          ],
+          "updatedAt": 1712854138515,
+          "publicationStatement": [
+            "1918 Mar. 15"
+          ],
+          "identifier": [
+            "urn:shelfmark:JPB 84-313",
+            "urn:bnum:11373666",
+            "urn:oclc:NYPG004000623-C",
+            "urn:identifier:NNSZ00405623",
+            "urn:identifier:(WaOLN)nyp1381622"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1918"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sousa, John Philip, 1854-1932 -- Manuscripts."
+          ],
+          "titleDisplay": [
+            "The toast / J.P.S. [John Philip Sousa]."
+          ],
+          "uri": "b11373666",
+          "formatId": "d",
+          "recordTypeId": "d",
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "34 cm."
+          ]
+        },
+        "sort": [
+          501.2587,
+          "b11373666"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b11373666",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JPB 84-313"
+                    ],
+                    "physicalLocation": [
+                      "JPB 84-313"
+                    ],
+                    "shelfMark_sort": "aJPB 84-000313",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Sousa%2C+John+Philip%2C+1854-1932.&CallNumber=JPB+84-313&Date=1918&Form=30&Genre=book+non-circ&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db11373666&ItemISxN=i15897007x&ItemPublisher=1918+Mar.+15&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b113736666&Site=LPAMR&Title=The+toast"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JPB 84-313"
+                    ],
+                    "uri": "i15897007",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JPB 84-313"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pam38||Performing Arts Research Collections - Music"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Manuscript notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pam38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b11373667",
+        "_score": 501.2587,
+        "_source": {
+          "extent": [
+            "1 ms. score (14 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Holograph signed, in ink.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For voice and orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Without the words.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Alternate musical setting from mss. of Mar. 15, 1918.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "At end: Port Washington, March 6th 1918.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sousa, John Philip, 1854-1932",
+            "Sousa, John Philip, 1854-1932 -- Manuscripts",
+            "Songs (Medium voice) with orchestra",
+            "Songs (Medium voice) with orchestra -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1918
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "title": [
+            "The toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JPB 84-314"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1918"
+          ],
+          "creatorLiteral": [
+            "Sousa, John Philip, 1854-1932"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Burnside, R. H. (Robert Hubberthorne), 1873-1952"
+          ],
+          "dateStartYear": [
+            1918
+          ],
+          "idOclc": [
+            "NYPG004000624-C"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 84-314"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11373667"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG004000624-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405624"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1381623"
+            }
+          ],
+          "updatedAt": 1712854138515,
+          "publicationStatement": [
+            "1918 Mar. 6"
+          ],
+          "identifier": [
+            "urn:shelfmark:JPB 84-314",
+            "urn:bnum:11373667",
+            "urn:oclc:NYPG004000624-C",
+            "urn:identifier:NNSZ00405624",
+            "urn:identifier:(WaOLN)nyp1381623"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1918"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sousa, John Philip, 1854-1932 -- Manuscripts.",
+            "Songs (Medium voice) with orchestra -- Scores."
+          ],
+          "titleDisplay": [
+            "The toast / words by Frank Warren & R.H. Burnside ; music by John Philip Sousa."
+          ],
+          "uri": "b11373667",
+          "formatId": "d",
+          "recordTypeId": "d",
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "34 cm."
+          ]
+        },
+        "sort": [
+          501.2587,
+          "b11373667"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b11373667",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JPB 84-314"
+                    ],
+                    "physicalLocation": [
+                      "JPB 84-314"
+                    ],
+                    "shelfMark_sort": "aJPB 84-000314",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Sousa%2C+John+Philip%2C+1854-1932.&CallNumber=JPB+84-314&Date=1918&Form=30&Genre=book+non-circ&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db11373667&ItemISxN=i158970081&ItemPublisher=1918+Mar.+6&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b113736678&Site=LPAMR&Title=The+toast"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JPB 84-314"
+                    ],
+                    "uri": "i15897008",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JPB 84-314"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pam38||Performing Arts Research Collections - Music"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Manuscript notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pam38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b15876151",
+        "_score": 501.2587,
+        "_source": {
+          "extent": [
+            "1 sound disc : analog, 33 1/3 rpm ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Program notes by \"Jonah\" Jones on container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded Oct. 8, 1954 and May 1955 in Paris.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jazz",
+            "Jazz -- France",
+            "Jazz -- France -- 1951-1960"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Angel Records"
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            195
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "dateEndString": [
+            "1954"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "French toast"
+          ],
+          "shelfMark": [
+            "*LZO 356"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "195"
+          ],
+          "creatorLiteral": [
+            "Persiany, André"
+          ],
+          "seriesStatement": [
+            "Jazz series ; vol. 1, no. 10"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Chevallier, Christian",
+            "Lafitte, Guy"
+          ],
+          "dateStartYear": [
+            195
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LZO 356"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15876151"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "53378691"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "ANG-60009 Angel Records"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A100000016"
+            }
+          ],
+          "idOclc": [
+            "53378691"
+          ],
+          "uniformTitle": [
+            "Jazz series (Angel Records) ; vol. 1, no. 10."
+          ],
+          "dateEndYear": [
+            1954
+          ],
+          "updatedAt": 1712867110813,
+          "publicationStatement": [
+            "New York, [N.Y.] : Angel Records, [195-]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LZO 356",
+            "urn:bnum:15876151",
+            "urn:oclc:53378691",
+            "urn:identifier:ANG-60009 Angel Records",
+            "urn:identifier:(WaOLN)A100000016"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "195"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jazz -- France -- 1951-1960."
+          ],
+          "titleDisplay": [
+            "French toast [sound recording]."
+          ],
+          "uri": "b15876151",
+          "formatId": "j",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "New York, [N.Y.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Nice joke -- Fiction -- Quartet mind -- Saxology -- Little story -- Halbe fünf -- Christmas song -- Two cats and a piece of lung."
+          ],
+          "dimensions": [
+            "10 in."
+          ]
+        },
+        "sort": [
+          501.2587,
+          "b15876151"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15876151",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LZO 356 [Disc]",
+                      "urn:barcode:33433035294234"
+                    ],
+                    "physicalLocation": [
+                      "*LZO 356 [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LZO 356 [Disc]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Persiany%2C+Andr%C3%A9.&CallNumber=*LZO+356+%5BDisc%5D&Date=195&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15876151&ItemISxN=i146601877&ItemNumber=33433035294234&ItemPlace=New+York%2C+%5BN.Y.%5D&ItemPublisher=Angel+Records%2C+%5B195-%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b158761510&Site=LPAMRAMI&Title=French+toast"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LZO 356 [Disc]"
+                    ],
+                    "uri": "i14660187",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LZO 356 [Disc]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433035294234"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433035294234"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b19650848",
+        "_score": 501.2587,
+        "_source": {
+          "extent": [
+            "256, 31 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Advertisements: p. [1]-31 (second group).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Metheun"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1916
+          ],
+          "title": [
+            "On toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "NCW (Ridge, W. P. On toast)"
+          ],
+          "createdString": [
+            "1916"
+          ],
+          "creatorLiteral": [
+            "Ridge, W. Pett (William Pett), -1930"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1916
+          ],
+          "idOclc": [
+            "26167955"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NCW (Ridge, W. P. On toast)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "19650848"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "26167955"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)26167955"
+            }
+          ],
+          "popularity": 6,
+          "updatedAt": 1751965649870,
+          "publicationStatement": [
+            "London : Metheun, 1916."
+          ],
+          "identifier": [
+            "urn:shelfmark:NCW (Ridge, W. P. On toast)",
+            "urn:bnum:19650848",
+            "urn:oclc:26167955",
+            "urn:identifier:(OCoLC)26167955"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1916"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "On toast / by W. Pett Ridge."
+          ],
+          "uri": "b19650848",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          501.2587,
+          "b19650848"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b19650848",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building - General Research Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433101440497"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NCW (Ridge, W. P. On toast)",
+                      "urn:barcode:33433101440497"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "NCW (Ridge, W. P. On toast)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433101440497",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "NCW (Ridge, W. P. On toast)"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "NCW (Ridge, W. P. On toast)"
+                    ],
+                    "shelfMark_sort": "aNCW (Ridge, W. P. On toast)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i28924660"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b22227752",
+        "_score": 501.2587,
+        "_source": {
+          "extent": [
+            "1 volume (unpaged) : colour illustrations ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"This is a first edition\"--Title page verso.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Multiracial people",
+            "Multiracial people -- Juvenile fiction",
+            "Grandmothers",
+            "Grandmothers -- Juvenile fiction",
+            "Blind people",
+            "Blind people -- Juvenile fiction",
+            "Human skin color",
+            "Human skin color -- Juvenile fiction",
+            "Self-esteem",
+            "Self-esteem -- Juvenile fiction",
+            "Picture books for children"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Pajama Press"
+          ],
+          "description": [
+            "While out on a walk with her blind grandmother, Phoebe tries to describe the skin color of members of her family by comparing them to various foods."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2016
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "French toast"
+          ],
+          "shelfMark": [
+            "JFF 17-1945"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2016"
+          ],
+          "creatorLiteral": [
+            "Winters, Kari-Lynn, 1969-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Thisdale, François, 1964-"
+          ],
+          "dateStartYear": [
+            2016
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 17-1945"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22227752"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781772780062"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1772780065"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "943594881"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)943594881"
+            }
+          ],
+          "idOclc": [
+            "943594881"
+          ],
+          "popularity": 0,
+          "updatedAt": 1729183707636,
+          "publicationStatement": [
+            "Toronto, Ontario, Canada : Pajama Press, 2016."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFF 17-1945",
+            "urn:bnum:22227752",
+            "urn:isbn:9781772780062",
+            "urn:isbn:1772780065",
+            "urn:oclc:943594881",
+            "urn:identifier:(OCoLC)943594881"
+          ],
+          "genreForm": [
+            "Fiction.",
+            "Juvenile works."
+          ],
+          "idIsbn": [
+            "9781772780062",
+            "1772780065"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2016"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Multiracial people -- Juvenile fiction.",
+            "Grandmothers -- Juvenile fiction.",
+            "Blind people -- Juvenile fiction.",
+            "Human skin color -- Juvenile fiction.",
+            "Self-esteem -- Juvenile fiction.",
+            "Picture books for children.",
+            "Blind people.",
+            "Grandmothers.",
+            "Human skin color.",
+            "Self-esteem."
+          ],
+          "titleDisplay": [
+            "French toast / written by Kari-Lynn Winters ; illustrated by François Thisdale."
+          ],
+          "uri": "b22227752",
+          "lccClassification": [
+            "PZ7.W7674 Fr 2016"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Toronto, Ontario, Canada"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 x 27 cm"
+          ],
+          "idIsbn_clean": [
+            "9781772780062",
+            "1772780065"
+          ]
+        },
+        "sort": [
+          501.2587,
+          "b22227752"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b22227752",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFF 17-1945",
+                      "urn:barcode:33433122276318"
+                    ],
+                    "physicalLocation": [
+                      "JFF 17-1945"
+                    ],
+                    "shelfMark_sort": "aJFF 17-001945",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFF 17-1945"
+                    ],
+                    "uri": "i37949151",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFF 17-1945"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433122276318"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433122276318"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b12269299",
+        "_score": 500.2587,
+        "_source": {
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Directions and music.",
+              "type": "bf:Note"
+            }
+          ],
+          "partOf": [
+            "Pedersen, Dagny. Folk games of Denmark and Sweden. Chicago [c1915] p 24. illus, diagr"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Gustafs skål (Dance)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            1915
+          ],
+          "buildingLocationIds": [],
+          "title": [
+            "Gustaf's toast."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*MGS (Scandinavian)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1915"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1915
+          ],
+          "idOclc": [
+            "NYPY710236921-B"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*MGS (Scandinavian)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12269299"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPY710236921-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NN-PD)710236921"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp2256094"
+            }
+          ],
+          "updatedAt": 1711057241809,
+          "identifier": [
+            "urn:shelfmark:*MGS (Scandinavian)",
+            "urn:bnum:12269299",
+            "urn:oclc:NYPY710236921-B",
+            "urn:identifier:(NN-PD)710236921",
+            "urn:identifier:(WaOLN)nyp2256094"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1915"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Gustafs skål (Dance)"
+          ],
+          "titleDisplay": [
+            "Gustaf's toast."
+          ],
+          "uri": "b12269299",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "issuance": [
+            {
+              "id": "urn:biblevel:a",
+              "label": "monograph component part"
+            }
+          ]
+        },
+        "sort": [
+          500.2587,
+          "b12269299"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b23469693",
+        "_score": 500.2587,
+        "_source": {
+          "extent": [
+            "101 pages : illustrations ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ritter Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            2024
+          ],
+          "title": [
+            "Tiger Toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2024"
+          ],
+          "creatorLiteral": [
+            "Pfeifer, Nika"
+          ],
+          "idLccn": [
+            "9783854156796"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "seriesStatement": [
+            "Ritter Literatur"
+          ],
+          "dateStartYear": [
+            2024
+          ],
+          "idOclc": [
+            "har240149450"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "23469693"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9783854156796"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "har240149450"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9783854156796"
+            }
+          ],
+          "popularity": 0,
+          "updatedAt": 1735052019777,
+          "publicationStatement": [
+            "Klagenfurt : Ritter Verlag, [2024]",
+            "©2024"
+          ],
+          "idIsbn": [
+            "9783854156796"
+          ],
+          "identifier": [
+            "urn:bnum:23469693",
+            "urn:isbn:9783854156796",
+            "urn:oclc:har240149450",
+            "urn:lccn:9783854156796"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2024"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Tiger Toast / Nika Pfeifer."
+          ],
+          "uri": "b23469693",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Klagenfurt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm"
+          ],
+          "idIsbn_clean": [
+            "9783854156796"
+          ]
+        },
+        "sort": [
+          500.2587,
+          "b23469693"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b11302028",
+        "_score": 499.89853,
+        "_source": {
+          "extent": [
+            "vi, 301 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cooking, American",
+            "Cooking, American -- California",
+            "Cooking, American -- California -- Los Angeles"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Women's Auxiliary of the California Babies' and Children's Hospital"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1950
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "Burnt toast."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 89-9691"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1950"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "California Babies' and Children's Hospital. Women's Auxiliary"
+          ],
+          "dateStartYear": [
+            1950
+          ],
+          "idOclc": [
+            "4365987",
+            "NYPG90-B62543"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 89-9691"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11302028"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "4365987"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG90-B62543"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1309761"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)4365987"
+            }
+          ],
+          "updatedAt": 1711595109405,
+          "publicationStatement": [
+            "Los Angeles, Calif. : Women's Auxiliary of the California Babies' and Children's Hospital, 1950."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 89-9691",
+            "urn:bnum:11302028",
+            "urn:oclc:4365987",
+            "urn:oclc:NYPG90-B62543",
+            "urn:identifier:(WaOLN)nyp1309761",
+            "urn:identifier:(OCoLC)4365987"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1950"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cooking, American -- California -- Los Angeles."
+          ],
+          "titleDisplay": [
+            "Burnt toast."
+          ],
+          "uri": "b11302028",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Los Angeles, Calif."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          499.89853,
+          "b11302028"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b11302028",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 89-9691",
+                      "urn:barcode:33433040618625"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "JFD 89-9691"
+                    ],
+                    "shelfMark_sort": "aJFD 89-009691",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFD 89-9691"
+                    ],
+                    "uri": "i13162098",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFD 89-9691"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433040618625"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433040618625"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b11373665",
+        "_score": 499.89853,
+        "_source": {
+          "extent": [
+            "1 ms. score (6 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Copyist's ms., in ink.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For voice and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Stamp on pp. [1] & 6: Fred P. Champlin, Autographing and Copying.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Songs (Medium voice) with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1918
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "title": [
+            "The toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JPB 84-312"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1918"
+          ],
+          "creatorLiteral": [
+            "Sousa, John Philip, 1854-1932"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Burnside, R. H. (Robert Hubberthorne), 1873-1952",
+            "Champlin, Fred P"
+          ],
+          "dateStartYear": [
+            1918
+          ],
+          "idOclc": [
+            "NYPG004000622-C"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 84-312"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11373665"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG004000622-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405622"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1381621"
+            }
+          ],
+          "updatedAt": 1712854138515,
+          "publicationStatement": [
+            "[ca. 1918]"
+          ],
+          "identifier": [
+            "urn:shelfmark:JPB 84-312",
+            "urn:bnum:11373665",
+            "urn:oclc:NYPG004000622-C",
+            "urn:identifier:NNSZ00405622",
+            "urn:identifier:(WaOLN)nyp1381621"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1918"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Songs (Medium voice) with piano."
+          ],
+          "titleDisplay": [
+            "The toast / words by R.J. Burnside ; music by John Philip Sousa."
+          ],
+          "uri": "b11373665",
+          "formatId": "d",
+          "recordTypeId": "d",
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "34 cm."
+          ]
+        },
+        "sort": [
+          499.89853,
+          "b11373665"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b11373665",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JPB 84-312"
+                    ],
+                    "physicalLocation": [
+                      "JPB 84-312"
+                    ],
+                    "shelfMark_sort": "aJPB 84-000312",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Sousa%2C+John+Philip%2C+1854-1932.&CallNumber=JPB+84-312&Date=1918&Form=30&Genre=book+non-circ&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db11373665&ItemISxN=i158970068&ItemPublisher=%5Bca.+1918%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b113736654&Site=LPAMR&Title=The+toast"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JPB 84-312"
+                    ],
+                    "uri": "i15897006",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JPB 84-312"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pam38||Performing Arts Research Collections - Music"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Manuscript notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pam38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b18054582",
+        "_score": 499.89853,
+        "_source": {
+          "extent": [
+            "1 videodisc (approximately 52 min.) : sound, color ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Original comic opera.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Larry Weinstein, director; Jessica Daniel, Matthew Hornburg, Larry Weinstein, producers; David Franco, director of photography.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "DVD-R format.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Love",
+            "Love -- Drama",
+            "Television operas",
+            "Vignettes",
+            "Vignettes -- Drama"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Bullfrog Films"
+          ],
+          "description": [
+            "\"Comprised of a series of eight comedic mini-operas, each depicting a different stage of a romantic relationship set in contemporary settings. With original music and libretti, each vignette is a self-contained story, but together they work as a cohesive single piece\"--Container."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            2005
+          ],
+          "title": [
+            "Burnt toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2005"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Weinstein, Larry",
+            "Louie, Alexina, 1949-",
+            "Redican, Dan",
+            "Daniel, Jessica",
+            "Hornburg, Matthew",
+            "Franco, David, 1963-",
+            "Gross, Paul, 1959-",
+            "Szabó, Krisztina (Mezzo-soprano)",
+            "Houtman, Martin",
+            "McGillivray, Peter",
+            "Mercer, Shannon",
+            "Stilwell, Jean, 1955-",
+            "Butterfield, Benjamin",
+            "Bayrakdarian, Isabel",
+            "Martin, Bob, 1962-",
+            "Balaban, Liane, 1980-",
+            "Colvin, Michael (Tenor)",
+            "Sadiq, Zorana",
+            "Braun, Russell, 1968-",
+            "Monoyios, Ann, 1949-",
+            "McNaughton, Doug",
+            "Hannigan, Barbara",
+            "Pauk, Alex, 1945-",
+            "Esprit Orchestra. prf",
+            "Bullfrog Films. pmn",
+            "Rhombus Media (Firm) pmn",
+            "Canadian Television Fund",
+            "Canadian Broadcasting Corporation",
+            "Channel Four Films (Firm)",
+            "Zweites Deutsches Fernsehen",
+            "Association relative à la télévision européenne"
+          ],
+          "dateStartYear": [
+            2005
+          ],
+          "idOclc": [
+            "191872445"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "18054582"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1594583560"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781594583568"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "191872445"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)191872445"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1053113461"
+            }
+          ],
+          "popularity": 2,
+          "updatedAt": 1753724219799,
+          "publicationStatement": [
+            "Oley, PA : Bullfrog Films, [2005]"
+          ],
+          "genreForm": [
+            "Drama.",
+            "Feature films.",
+            "Musical films."
+          ],
+          "idIsbn": [
+            "1594583560",
+            "9781594583568"
+          ],
+          "identifier": [
+            "urn:bnum:18054582",
+            "urn:isbn:1594583560",
+            "urn:isbn:9781594583568",
+            "urn:oclc:191872445",
+            "urn:identifier:(OCoLC)191872445",
+            "urn:identifier:(OCoLC)1053113461"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mov",
+              "label": "Moving image"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2005"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Love -- Drama.",
+            "Television operas.",
+            "Vignettes -- Drama.",
+            "Love.",
+            "Television operas.",
+            "Vignettes."
+          ],
+          "titleDisplay": [
+            "Burnt toast / Bullfrog Films presents Rhombus Media and marblemedia present a film by Larry Weinstein ; music by Alexina Louie ; words by Dan Redican ; produced with the participation of the Canadian Television Fund ; produced in association with the Canadian Broadcasting Corporation ; Channel Four Television Corporation ; ZDF in cooperation with ARTE."
+          ],
+          "uri": "b18054582",
+          "lccClassification": [
+            "PN1997.2 .B87 2005"
+          ],
+          "formatId": "v",
+          "recordTypeId": "g",
+          "placeOfPublication": [
+            "Oley, PA"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "The 8 stages of love. Stage 1: Attraction ; Stage 2: Connection ; Stage 3: Commitment ; Stage 4: Marriage ; Stage 5: Consummation ; Stage 6: Perseverance ; Stage 7: Disintegration ; Stage 8: Starting over."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ],
+          "idIsbn_clean": [
+            "1594583560",
+            "9781594583568"
+          ]
+        },
+        "sort": [
+          499.89853,
+          "b18054582"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b18054582",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:a",
+                        "label": "By appointment only"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:a||By appointment only"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=DVDR+1348+B++&Date=2005&Form=30&Genre=rfvc+-+dvd&ItemInfo1=By+appointment+only&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db18054582&ItemISxN=i246011543&ItemNumber=33333225144951&ItemPlace=Oley%2C+PA&ItemPublisher=Bullfrog+Films%2C+%5B2005%5D&ItemVolume=C.1&Location=Performing+Arts+Reserve+Film+and+Video+Collection&ReferenceNumber=b180545826&Site=LPARF&Title=Burnt+toast"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:75",
+                        "label": "dvd"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:75||dvd"
+                    ],
+                    "enumerationChronology": [
+                      "C.1"
+                    ],
+                    "formatLiteral": [
+                      "DVD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pav28",
+                        "label": "Performing Arts Research Collections - Reserve Film and Video"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pav28||Performing Arts Research Collections - Reserve Film and Video"
+                    ],
+                    "idBarcode": [
+                      "33333225144951"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:DVDR 1348 B  ",
+                      "urn:barcode:33333225144951"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "DVDR 1348 B  ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33333225144951",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "DVDR 1348 B  "
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "DVDR 1348 B  "
+                    ],
+                    "shelfMark_sort": "aDVDR 1348 B ",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i24601154"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b14264413",
+        "_score": 498.89853,
+        "_source": {
+          "extent": [
+            "2 p.l., 7-73 p., 2 l."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "At head of title: G.C. Baravelli.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Stalin, Joseph, 1878-1953",
+            "Communism",
+            "Communism -- Soviet Union",
+            "Soviet Union",
+            "Soviet Union -- Economic conditions",
+            "Soviet Union -- Economic conditions -- 1917-1945"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Edizioni di Novissima"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            1937
+          ],
+          "buildingLocationIds": [],
+          "title": [
+            "Stalin's toast."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "SB p.v. 443"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1937"
+          ],
+          "creatorLiteral": [
+            "Baravelli, G. C. (Giulio Cesare)"
+          ],
+          "idLccn": [
+            "38006165"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1937
+          ],
+          "idOclc": [
+            "10504920"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "SB p.v. 443"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "14264413"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "10504920"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "38006165"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)R020000041"
+            }
+          ],
+          "updatedAt": 1711486550968,
+          "publicationStatement": [
+            "Roma, Edizioni di Novissima [1937]"
+          ],
+          "identifier": [
+            "urn:shelfmark:SB p.v. 443",
+            "urn:bnum:14264413",
+            "urn:oclc:10504920",
+            "urn:lccn:38006165",
+            "urn:identifier:(WaOLN)R020000041"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1937"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Stalin, Joseph, 1878-1953.",
+            "Communism -- Soviet Union.",
+            "Soviet Union -- Economic conditions -- 1917-1945."
+          ],
+          "titleDisplay": [
+            "Stalin's toast."
+          ],
+          "uri": "b14264413",
+          "lccClassification": [
+            "DK267 .B27"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Roma"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "A class which refuses to die.--Fighting the party.--Rifle shots in Moscow.--The lowest wages in the world.--Sordid housing.--Yagoda: a name and a symbol.--Six million convicts.--The revenge of militarism.--Bolshevism paramount to supercapitalism."
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          498.89853,
+          "b14264413"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b15868157",
+        "_score": 498.63147,
+        "_source": {
+          "extent": [
+            "64 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Conduct of life",
+            "Conduct of life -- Poetry",
+            "Nigeria",
+            "Nigeria -- Poetry",
+            "Black author"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Hope Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "sc"
+          ],
+          "createdYear": [
+            2002
+          ],
+          "title": [
+            "Toast to life & vision"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "Sc D 13-57 no. 1"
+          ],
+          "createdString": [
+            "2002"
+          ],
+          "creatorLiteral": [
+            "Odeleye, Biodun"
+          ],
+          "idLccn": [
+            "2004352407"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2002
+          ],
+          "idOclc": [
+            "54955577"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 13-57 no. 1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15868157"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9783654845 (pbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9789783654846 (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "54955577"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2004352407"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)54955577"
+            }
+          ],
+          "popularity": 2,
+          "updatedAt": 1752439851912,
+          "publicationStatement": [
+            "Ibadan, Nigeria : Hope Publications, 2002."
+          ],
+          "idIsbn": [
+            "9783654845 (pbk.)",
+            "9789783654846 (pbk.)"
+          ],
+          "identifier": [
+            "urn:shelfmark:Sc D 13-57 no. 1",
+            "urn:bnum:15868157",
+            "urn:isbn:9783654845 (pbk.)",
+            "urn:isbn:9789783654846 (pbk.)",
+            "urn:oclc:54955577",
+            "urn:lccn:2004352407",
+            "urn:identifier:(OCoLC)54955577"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2002"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Conduct of life -- Poetry.",
+            "Nigeria -- Poetry.",
+            "Black author."
+          ],
+          "titleDisplay": [
+            "Toast to life & vision / Biodun Odeleye."
+          ],
+          "uri": "b15868157",
+          "lccClassification": [
+            "PR9387.9.O3115 T63 2002"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Ibadan, Nigeria"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Toast to life and vision"
+          ],
+          "tableOfContents": [
+            "Moon among stars -- Vampires on rampage -- The dangling visionary saw -- Much to a name -- Dear mother -- La Rambla -- Personifying death -- Success turns albatross in the hall of nobility."
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "9783654845",
+            "9789783654846"
+          ]
+        },
+        "sort": [
+          498.63147,
+          "b15868157"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15868157",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:61",
+                        "label": "pamphlet volumes, bound with"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:61||pamphlet volumes, bound with"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "idBarcode": [
+                      "33433089426146"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc D 13-57",
+                      "urn:barcode:33433089426146"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 13-57",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433089426146",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "physicalLocation": [
+                      "Sc D 13-57"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "Sc D 13-57"
+                    ],
+                    "shelfMark_sort": "aSc D 13-000057",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i29987107"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b19635190",
+        "_score": 497.42587,
+        "_source": {
+          "extent": [
+            "1 sound disc (46 min.) : digital, mono. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Audio portion of CBS Television broadcast.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Transfer to compact disc incomplete due to damage to the original lacquer discs; side one is completely delaminated, and other sides have minor damage.  Original program ran 60 min.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access to original items restricted.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Marlo Lewis and Ed Sullivan (producers) ; John Wray (direction) ; Ray Bloch (musical direction)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Forms part of the Oscar Hammerstein collection of noncommercial sound recordings, 1942-1955.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Local note",
+              "label": "Archival original: (7 sound discs : analog, aluminum based lacquer, 78 rpm, mono. ; 12 in.) in *LJ-12 5896.",
+              "type": "bf:Note"
+            }
+          ],
+          "partOf": [
+            "Oscar Hammerstein collection of noncommercial sound recordings, 1942-1955."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hammerstein, Oscar, II, 1895-1960",
+            "Hammerstein, Oscar, II, 1895-1960 -- Interviews",
+            "Lyricists",
+            "Lyricists -- United States",
+            "Lyricists -- United States -- Biography",
+            "Musicals",
+            "Musicals -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1951
+          ],
+          "dateEndString": [
+            "0909"
+          ],
+          "title": [
+            "Toast of the town."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "*LDC 37733"
+          ],
+          "createdString": [
+            "1951"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sullivan, Ed, 1901-1974",
+            "Hammerstein, Oscar, II, 1895-1960",
+            "Horne, Lena",
+            "Merrill, Robert, 1917-2004",
+            "Benzell, Mimi",
+            "Tabbert, William, 1919-1974",
+            "Hall, George, 1916-2002",
+            "Cox, Wally, 1924-1973"
+          ],
+          "dateStartYear": [
+            1951
+          ],
+          "idOclc": [
+            "794597226"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 37733"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "19635190"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "794597226"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)794597226"
+            }
+          ],
+          "popularity": 0,
+          "uniformTitle": [
+            "Ed Sullivan show (Television program)"
+          ],
+          "dateEndYear": [
+            909
+          ],
+          "updatedAt": 1751556623575,
+          "publicationStatement": [
+            "1951."
+          ],
+          "genreForm": [
+            "Variety shows (Television programs)",
+            "Television commercials."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 37733",
+            "urn:bnum:19635190",
+            "urn:oclc:794597226",
+            "urn:identifier:(OCoLC)794597226"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1951"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hammerstein, Oscar, II, 1895-1960 -- Interviews.",
+            "Lyricists -- United States -- Biography.",
+            "Musicals -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Toast of the town. 1951-09-09, the Oscar Hammerstein story, pt. 1 [sound recording] / CBS-TV ; written by Ed Sullivan."
+          ],
+          "uri": "b19635190",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Oscar Hammerstein story, pt. 1",
+            "Oscar Hammerstein collection of noncommercial sound recordings."
+          ],
+          "tableOfContents": [
+            "Opening commentary and early biography of Oscar Hammerstein II -- Indian love call (Mimi Benzell and Robert Merrill) -- Biography continued (incomplete) -- One alone (Bill Tabbert) (incomplete) -- Biography continued -- Can't help lovin' that man (Lena Horne) -- Biography continued (incomplete) -- Old man river (Robert Merrill) -- Biography continued (incomplete) -- Lover come back to me (Mimi Benzell) -- Comedy skit (incomplete) / George Hall ; Wally Cox -- Interview with Oscar Hammerstein II -- Ending commentary & sponsor's advertisements (Lincoln automobiles) -- Announcement for the next show."
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          497.42587,
+          "b19635190"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b19635190",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=*LDC+37733&Date=1951&Form=30&Genre=archival+sound+recording&ItemInfo1=Use+in+library&ItemInfo2=Access+to+original+items+restricted.&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db19635190&ItemISxN=i288025581&ItemNumber=33433099082954&ItemPublisher=1951.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b19635190x&Site=LPAMRAMI&Title=Toast+of+the+town.&Transaction.CustomFields.MapsLocationNote=%5BCD%5D"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:23",
+                        "label": "archival sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:23||archival sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433099082954"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 37733",
+                      "urn:barcode:33433099082954"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LDC 37733",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433099082954",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LDC 37733"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LDC 37733"
+                    ],
+                    "shelfMark_sort": "a*LDC 037733",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i28802558"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b19635203",
+        "_score": 497.42587,
+        "_source": {
+          "extent": [
+            "1 sound disc (46 min.) : digital, mono. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Audio portion of CBS Television broadcast.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Audio distortion from original source. Transfer to compact disc incomplete due to damage to the original lacquer discs; side one, two, five, and seven are completely delaminated, and other sides have minor damage.  Original program ran 60 min.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access to original items restricted.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Marlo Lewis and Ed Sullivan (producers) ; John Wray (direction) ; Ray Bloch (musical direction)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Forms part of the Oscar Hammerstein collection of noncommercial sound recordings, 1942-1955.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Local note",
+              "label": "Archival original: (7 sound discs : analog, aluminum based lacquer, 78 rpm, mono. ; 12 in.) in *LJ-12 5909.",
+              "type": "bf:Note"
+            }
+          ],
+          "partOf": [
+            "Oscar Hammerstein collection of noncommercial sound recordings, 1942-1955."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hammerstein, Oscar, II, 1895-1960",
+            "Hammerstein, Oscar, II, 1895-1960 -- Interviews",
+            "Rodgers, Richard, 1902-1979",
+            "Rodgers, Richard, 1902-1979 -- Interviews",
+            "Lyricists",
+            "Lyricists -- United States",
+            "Lyricists -- United States -- Biography",
+            "Musicals",
+            "Musicals -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1951
+          ],
+          "dateEndString": [
+            "0916"
+          ],
+          "title": [
+            "Toast of the town."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "*LDC 50447"
+          ],
+          "createdString": [
+            "1951"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sullivan, Ed, 1901-1974",
+            "Hammerstein, Oscar, II, 1895-1960",
+            "Rodgers, Richard, 1902-1979",
+            "Rodgers, Richard, 1902-1979",
+            "Deel, Sandra",
+            "Merrill, Robert, 1917-2004",
+            "Rahn, Muriel",
+            "Tabbert, William, 1919-1974",
+            "Lawrence, Gertrude"
+          ],
+          "dateStartYear": [
+            1951
+          ],
+          "idOclc": [
+            "794597454"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 50447"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "19635203"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "794597454"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)794597454"
+            }
+          ],
+          "popularity": 0,
+          "uniformTitle": [
+            "Ed Sullivan show (Television program)"
+          ],
+          "dateEndYear": [
+            916
+          ],
+          "updatedAt": 1751556623575,
+          "publicationStatement": [
+            "1951."
+          ],
+          "genreForm": [
+            "Variety shows (Television programs)",
+            "Television commercials."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 50447",
+            "urn:bnum:19635203",
+            "urn:oclc:794597454",
+            "urn:identifier:(OCoLC)794597454"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1951"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hammerstein, Oscar, II, 1895-1960 -- Interviews.",
+            "Rodgers, Richard, 1902-1979 -- Interviews.",
+            "Lyricists -- United States -- Biography.",
+            "Musicals -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Toast of the town. 1951-09-16, the Oscar Hammerstein story, pt. 2 [sound recording] / CBS-TV ; written by Ed Sullivan."
+          ],
+          "uri": "b19635203",
+          "formatId": "y",
+          "recordTypeId": "j",
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Oscar Hammerstein story, pt. 2",
+            "Oscar Hammerstein collection of noncommercial sound recordings."
+          ],
+          "tableOfContents": [
+            "[Sides 1 & 2 unplayable] -- Commentary on Oklahoma (Ed Sullivan, incomplete) -- People will say we're in love (Robert Merrill & Sandra Deel) -- Habanera from Carmen Jones (Murial Rahn, incomplete) -- [Side 5 unplayable] -- Some Enchanted Evening (Robert Merrill) -- You've Got To Be Carefully Taught (Bill Tabbert) -- Sullivan speaks with Hammerstein and Richard Rodgers about their partnership -- Whistle A Happy Tune & Getting To Know You (Gertrude Lawrence & Richard Rodgers, piano) -- You'll never walk alone (Merrill) -- Commercial announcement for Lincoln automobiles -- Concluding announcements (incomplete)"
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          497.42587,
+          "b19635203"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b19635203",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=*LDC+50447&Date=1951&Form=30&Genre=archival+sound+recording&ItemInfo1=Use+in+library&ItemInfo2=Access+to+original+items+restricted.&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db19635203&ItemISxN=i288025854&ItemNumber=33433099082962&ItemPublisher=1951.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b196352034&Site=LPAMRAMI&Title=Toast+of+the+town.&Transaction.CustomFields.MapsLocationNote=%5BCD%5D"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:23",
+                        "label": "archival sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:23||archival sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433099082962"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 50447",
+                      "urn:barcode:33433099082962"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LDC 50447",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433099082962",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LDC 50447"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LDC 50447"
+                    ],
+                    "shelfMark_sort": "a*LDC 050447",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i28802585"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "pb99131303145606421",
+        "_score": 492.14212,
+        "_source": {
+          "extent": [
+            "101 pages : illustrations ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ritter Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2024
+          ],
+          "dateEndString": [
+            "2024"
+          ],
+          "title": [
+            "Tiger Toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2024"
+          ],
+          "creatorLiteral": [
+            "Pfeifer, Judith, 1975-"
+          ],
+          "idLccn": [
+            "9783854156796"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "seriesStatement": [
+            "Ritter Literatur"
+          ],
+          "dateStartYear": [
+            2024
+          ],
+          "idOclc": [
+            "on1463809188",
+            "SCSB-15114298"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "99131303145606421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9783854156796"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3854156790"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "on1463809188"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-15114298"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9783854156796"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)on1463809188"
+            }
+          ],
+          "popularity": 0,
+          "uniformTitle": [
+            "Ritter Literatur"
+          ],
+          "dateEndYear": [
+            2024
+          ],
+          "updatedAt": 1753829373697,
+          "publicationStatement": [
+            "Klagenfurt : Ritter Verlag, [2024]",
+            "©2024"
+          ],
+          "genreForm": [
+            "poetry.",
+            "Poetry.",
+            "Poésie."
+          ],
+          "idIsbn": [
+            "9783854156796",
+            "3854156790"
+          ],
+          "identifier": [
+            "urn:bnum:99131303145606421",
+            "urn:isbn:9783854156796",
+            "urn:isbn:3854156790",
+            "urn:oclc:on1463809188",
+            "urn:oclc:SCSB-15114298",
+            "urn:lccn:9783854156796",
+            "urn:identifier:(OCoLC)on1463809188"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2024"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Tiger Toast / Nika Pfeifer."
+          ],
+          "uri": "pb99131303145606421",
+          "lccClassification": [
+            "PT2716.F474 T54 2024"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Klagenfurt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "9783854156796",
+            "3854156790"
+          ]
+        },
+        "sort": [
+          492.14212,
+          "pb99131303145606421"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "pb99131303145606421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "idBarcode": [
+                      "32101115835132"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PT2716.F474 T54 2024",
+                      "urn:barcode:32101115835132"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PT2716.F474 T54 2024",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101115835132",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PT2716.F474 T54 2024"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PT2716.F474 T54 2024"
+                    ],
+                    "shelfMark_sort": "aPT2716.F474 T54 002024",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi231033210850006421"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b12004445",
+        "_score": 477.55127,
+        "_source": {
+          "extent": [
+            "124 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kneipp"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1993
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "Mein Lieblings-Toast : 300 heisse Tips für Toast-Fans"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 94-21395"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1993"
+          ],
+          "creatorLiteral": [
+            "Heindel, Gabriele"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1993
+          ],
+          "idOclc": [
+            "31256373",
+            "NYPGR31256373-B"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 94-21395"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12004445"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3900696349"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "31256373"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGR31256373-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)31256373"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "LC 199410"
+            }
+          ],
+          "updatedAt": 1711150297035,
+          "publicationStatement": [
+            "Leoben : Kneipp, 1993."
+          ],
+          "idIsbn": [
+            "3900696349"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 94-21395",
+            "urn:bnum:12004445",
+            "urn:isbn:3900696349",
+            "urn:oclc:31256373",
+            "urn:oclc:NYPGR31256373-B",
+            "urn:identifier:(OCoLC)31256373",
+            "urn:identifier:LC 199410"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1993"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Mein Lieblings-Toast : 300 heisse Tips für Toast-Fans / Gabriele Heindel."
+          ],
+          "uri": "b12004445",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Leoben"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "3900696349"
+          ]
+        },
+        "sort": [
+          477.55127,
+          "b12004445"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b12004445",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 94-21395",
+                      "urn:barcode:33433041530118"
+                    ],
+                    "physicalLocation": [
+                      "JFD 94-21395"
+                    ],
+                    "shelfMark_sort": "aJFD 94-021395",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFD 94-21395"
+                    ],
+                    "uri": "i13317173",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFD 94-21395"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433041530118"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433041530118"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b11294632",
+        "_score": 473.463,
+        "_source": {
+          "extent": [
+            "xxi, 273 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Originally published ... by Charles Scribner's Sons ... in 1940\"--T.p. verso.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Vintage Books"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1990
+          ],
+          "dateEndString": [
+            "1940"
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "Angels on toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 90-6303"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1990"
+          ],
+          "creatorLiteral": [
+            "Powell, Dawn"
+          ],
+          "idLccn": [
+            "89040281"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1990
+          ],
+          "idOclc": [
+            "70304237",
+            "NYPG90-B53168"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 90-6303"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11294632"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0679726861"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "70304237"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG90-B53168"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "89040281"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1302350"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)70304237"
+            }
+          ],
+          "dateEndYear": [
+            1940
+          ],
+          "updatedAt": 1711585322970,
+          "publicationStatement": [
+            "New York : Vintage Books, 1990, c1940."
+          ],
+          "idIsbn": [
+            "0679726861"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 90-6303",
+            "urn:bnum:11294632",
+            "urn:isbn:0679726861",
+            "urn:oclc:70304237",
+            "urn:oclc:NYPG90-B53168",
+            "urn:lccn:89040281",
+            "urn:identifier:(WaOLN)nyp1302350",
+            "urn:identifier:(OCoLC)70304237"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1990"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Angels on toast / Dawn Powell ; with an introduction by Gore Vidal."
+          ],
+          "uri": "b11294632",
+          "lccClassification": [
+            "PS3531.O936 A83 1989"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "0679726861"
+          ]
+        },
+        "sort": [
+          473.463,
+          "b11294632"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b11294632",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 90-6303",
+                      "urn:barcode:33433040606604"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "JFD 90-6303"
+                    ],
+                    "shelfMark_sort": "aJFD 90-006303",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFD 90-6303"
+                    ],
+                    "uri": "i13160245",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFD 90-6303"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433040606604"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433040606604"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b13060795",
+        "_score": 473.463,
+        "_source": {
+          "extent": [
+            "29 p. col. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Grades 1-3.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Coward-McCann, inc."
+          ],
+          "description": [
+            "Thomas always pretended his favorite menu was creamed angleworms on toast. Then one day when he also pretended he was sick enough to miss school, his family thought he deserved whatever he wanted for lunch."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1942
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "Angleworms on toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "NAS (Kantor, M. Angleworms on toast)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1942"
+          ],
+          "creatorLiteral": [
+            "Kantor, MacKinlay, 1904-1977"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Wiese, Kurt, 1887-"
+          ],
+          "dateStartYear": [
+            1942
+          ],
+          "idOclc": [
+            "26982453"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NAS (Kantor, M. Angleworms on toast)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13060795"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "26982453"
+            }
+          ],
+          "updatedAt": 1715610080517,
+          "publicationStatement": [
+            "New York, Coward-McCann, inc., c1942."
+          ],
+          "identifier": [
+            "urn:shelfmark:NAS (Kantor, M. Angleworms on toast)",
+            "urn:bnum:13060795",
+            "urn:oclc:26982453"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1942"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Angleworms on toast, by MacKinlay Kantor. Illustrated by Kurt Wiese."
+          ],
+          "uri": "b13060795",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 x 25 cm."
+          ]
+        },
+        "sort": [
+          473.463,
+          "b13060795"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b13060795",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NAS (Kantor, M. Angleworms on toast)",
+                      "urn:barcode:33433084609134"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "NAS (Kantor, M. Angleworms on toast)"
+                    ],
+                    "shelfMark_sort": "aNAS (Kantor, M. Angleworms on toast)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:66||book, poor condition, non-MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "NAS (Kantor, M. Angleworms on toast)"
+                    ],
+                    "uri": "i16222433",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "NAS (Kantor, M. Angleworms on toast)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084609134"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433084609134"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:66",
+                        "label": "book, poor condition, non-MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16436832",
+        "_score": 473.463,
+        "_source": {
+          "extent": [
+            "on 1 side of 1 sound disc : analog, 78 rpm, mono. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Victor: 4074; matrix no.: B1105.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in French.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Victor"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1908
+          ],
+          "dateEndString": [
+            "1913"
+          ],
+          "title": [
+            "Carmen. [Votre toast]"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "*LO 338"
+          ],
+          "createdString": [
+            "1908"
+          ],
+          "creatorLiteral": [
+            "Bizet, Georges, 1838-1875"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Gogorza, Emilio de, 1872-1949",
+            "Victor Orchestra. prf"
+          ],
+          "dateStartYear": [
+            1908
+          ],
+          "idOclc": [
+            "71232236"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LO 338"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16436832"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "71232236"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "4074 Victor"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "B1105 Victor"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M010000216"
+            }
+          ],
+          "popularity": 0,
+          "uniformTitle": [
+            "Carmen. Chanson du toréador"
+          ],
+          "dateEndYear": [
+            1913
+          ],
+          "updatedAt": 1752109037490,
+          "publicationStatement": [
+            "Camden, NJ : Victor, [between 1908 and 1913]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LO 338",
+            "urn:bnum:16436832",
+            "urn:oclc:71232236",
+            "urn:identifier:4074 Victor",
+            "urn:identifier:B1105 Victor",
+            "urn:identifier:(WaOLN)M010000216"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1908"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "titleDisplay": [
+            "Carmen. Toreador song [sound recording] = [Votre toast] / Bizet."
+          ],
+          "uri": "b16436832",
+          "formatId": "j",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Camden, NJ"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Carmen. Chanson du toréador",
+            "Toreador song",
+            "Votre toast"
+          ],
+          "dimensions": [
+            "10 in."
+          ]
+        },
+        "sort": [
+          473.463,
+          "b16436832"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16436832",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=Bizet%2C+Georges%2C+1838-1875&CallNumber=*LO+338+%5BDisc%5D&Date=1908&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16436832&ItemISxN=i172397315&ItemNumber=33433070578319&ItemPlace=Camden%2C+NJ&ItemPublisher=Victor%2C+%5Bbetween+1908+and+1913%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b164368322&Site=LPAMRAMI&Title=Carmen.+%5BVotre+toast%5D"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433070578319"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LO 338 [Disc]",
+                      "urn:barcode:33433070578319"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LO 338 [Disc]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433070578319",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LO 338 [Disc]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LO 338 [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LO 338 [Disc]",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17239731"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b10981311",
+        "_score": 472.463,
+        "_source": {
+          "extent": [
+            "1 miniature score (12 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: H.P.S. 976.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Fondly dedicated to the memory of André Kostelanetz.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 2:30.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Jalni Publications : Boosey & Hawkes, sole selling agent"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "dateEndString": [
+            "1980"
+          ],
+          "title": [
+            "A musical toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "JNF 87-27"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [
+            "Bernstein, Leonard, 1918-1990"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Kostelanetz, Andre, 1901-1980"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "idOclc": [
+            "11578466",
+            "NYPG85-C1260"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNF 87-27"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10981311"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11578466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG85-C1260"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "HPS 976. Boosey & Hawkes"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0988546"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)11578466"
+            }
+          ],
+          "popularity": 2,
+          "dateEndYear": [
+            1980
+          ],
+          "updatedAt": 1752422485670,
+          "publicationStatement": [
+            "[United States] : Jalni Publications : Boosey & Hawkes, sole selling agent, 1984, c1980."
+          ],
+          "identifier": [
+            "urn:shelfmark:JNF 87-27",
+            "urn:bnum:10981311",
+            "urn:oclc:11578466",
+            "urn:oclc:NYPG85-C1260",
+            "urn:identifier:HPS 976. Boosey & Hawkes",
+            "urn:identifier:(WaOLN)nyp0988546",
+            "urn:identifier:(OCoLC)11578466"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "titleDisplay": [
+            "A musical toast / Leonard Bernstein."
+          ],
+          "uri": "b10981311",
+          "formatId": "c",
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "[United States]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          472.463,
+          "b10981311"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b10981311",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:57",
+                        "label": "printed music limited circ MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:57||printed music limited circ MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433047232982"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JNF 87-27",
+                      "urn:barcode:33433047232982"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JNF 87-27",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433047232982",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "physicalLocation": [
+                      "JNF 87-27"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JNF 87-27"
+                    ],
+                    "shelfMark_sort": "aJNF 87-000027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i13956002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b16671423",
+        "_score": 472.18475,
+        "_source": {
+          "extent": [
+            "1 folder"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Clippings from the Music Division clippings files",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Roma's Toast (song)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            null
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "title": [
+            "Roma's Toast (song)"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "M-Clippings (Subjects)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "    "
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            null
+          ],
+          "idOclc": [
+            "Local - CLIP Music Clippings"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "M-Clippings (Subjects)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16671423"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "Local - CLIP Music Clippings"
+            }
+          ],
+          "updatedAt": 1711605836419,
+          "genreForm": [
+            "Clippings."
+          ],
+          "identifier": [
+            "urn:shelfmark:M-Clippings (Subjects)",
+            "urn:bnum:16671423",
+            "urn:oclc:Local - CLIP Music Clippings"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "    "
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Roma's Toast (song)"
+          ],
+          "titleDisplay": [
+            "Roma's Toast (song) : clippings"
+          ],
+          "uri": "b16671423",
+          "formatId": "p",
+          "recordTypeId": "a",
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          472.18475,
+          "b16671423"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b16671423",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:M-Clippings (Subjects)",
+                      "urn:barcode:33433087491175"
+                    ],
+                    "physicalLocation": [
+                      "M-Clippings (Subjects)"
+                    ],
+                    "shelfMark_sort": "aM-Clippings (Subjects)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:22||clipping files"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=M-Clippings+%28Subjects%29&Date=++++&Form=30&Genre=clipping+files&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16671423&ItemISxN=i17393514x&ItemNumber=33433087491175&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b166714239&Site=LPAMR&Title=Roma%27s+Toast+%28song%29+%3A+clippings"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "M-Clippings (Subjects)"
+                    ],
+                    "uri": "i17393514",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "M-Clippings (Subjects)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433087491175"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pam38||Performing Arts Research Collections - Music"
+                    ],
+                    "idBarcode": [
+                      "33433087491175"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:22",
+                        "label": "clipping files"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Archival Mix"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pam38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b13131869",
+        "_score": 471.18475,
+        "_source": {
+          "extent": [
+            "242 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kingston Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1920
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "title": [
+            "The royal toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "NCM (Back, K. J. Royal toast)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1920"
+          ],
+          "creatorLiteral": [
+            "Australianus"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1920
+          ],
+          "idOclc": [
+            "18297389"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NCM (Back, K. J. Royal toast)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13131869"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "18297389"
+            }
+          ],
+          "updatedAt": 1711048347990,
+          "publicationStatement": [
+            "Sydney [N.S.W.] : Kingston Press, 1920."
+          ],
+          "identifier": [
+            "urn:shelfmark:NCM (Back, K. J. Royal toast)",
+            "urn:bnum:13131869",
+            "urn:oclc:18297389"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1920"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "The royal toast / by \"Australianus\"."
+          ],
+          "uri": "b13131869",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Sydney [N.S.W.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          471.18475,
+          "b13131869"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b13131869",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NCM (Back, K. J. Royal toast)",
+                      "urn:barcode:33433112057363"
+                    ],
+                    "physicalLocation": [
+                      "NCM (Back, K. J. Royal toast)"
+                    ],
+                    "shelfMark_sort": "aNCM (Back, K. J. Royal toast)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "NCM (Back, K. J. Royal toast)"
+                    ],
+                    "uri": "i16274064",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "NCM (Back, K. J. Royal toast)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433112057363"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433112057363"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b17174971",
+        "_score": 471.18475,
+        "_source": {
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Putnam"
+          ],
+          "description": [
+            "Thomas always pretended his favorite menu was creamed angleworms on toast. Then one day when he also pretended he was sick enough to miss school, his family thought he deserved whatever he wanted for lunch."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "dateEndString": [
+            "1942"
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "title": [
+            "Angleworms on toast."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "creatorLiteral": [
+            "Kantor, MacKinlay, 1904-1977"
+          ],
+          "idLccn": [
+            "68024523"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Wiese, Kurt, 1887-"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "17174971"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "68024523"
+            }
+          ],
+          "dateEndYear": [
+            1942
+          ],
+          "updatedAt": 1711655200426,
+          "publicationStatement": [
+            "New York : Putnam, [1969, c1942]"
+          ],
+          "identifier": [
+            "urn:bnum:17174971",
+            "urn:lccn:68024523"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Angleworms on toast. Illustrated by Kurt Wiese."
+          ],
+          "uri": "b17174971",
+          "lccClassification": [
+            "PZ7.K128 An5"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          471.18475,
+          "b17174971"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b17174971",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:J FIC K",
+                      "urn:barcode:33333059683314"
+                    ],
+                    "physicalLocation": [
+                      "J FIC K"
+                    ],
+                    "shelfMark_sort": "aJ FIC K",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "J FIC K"
+                    ],
+                    "uri": "i22474239",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "J FIC K"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33333059683314"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33333059683314"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NH"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "cb15861113",
+        "_score": 465.7138,
+        "_source": {
+          "extent": [
+            "288 pages ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Parthian"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2022
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "title": [
+            "Sex on toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2022"
+          ],
+          "creatorLiteral": [
+            "Mills, Tôpher"
+          ],
+          "idLccn": [
+            "60002450032"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Edwards, Jonathan"
+          ],
+          "dateStartYear": [
+            2022
+          ],
+          "idOclc": [
+            "on1263812851",
+            "SCSB-13992812"
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "15861113"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781912681877"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1912681870"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "on1263812851"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-13992812"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "60002450032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)on1263812851"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "15861113"
+            }
+          ],
+          "updatedAt": 1719566189606,
+          "publicationStatement": [
+            "Cardigan : Parthian, 2022."
+          ],
+          "idIsbn": [
+            "9781912681877",
+            "1912681870"
+          ],
+          "identifier": [
+            "urn:bnum:15861113",
+            "urn:isbn:9781912681877",
+            "urn:isbn:1912681870",
+            "urn:oclc:on1263812851",
+            "urn:oclc:SCSB-13992812",
+            "urn:lccn:60002450032",
+            "urn:identifier:(OCoLC)on1263812851",
+            "urn:identifier:15861113"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2022"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Sex on toast / Tôpher Mills ; [editor, Jonathan Edwards]."
+          ],
+          "uri": "cb15861113",
+          "lccClassification": [
+            "PR6113.I5865 S39 2022"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Cardigan"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm"
+          ],
+          "idIsbn_clean": [
+            "9781912681877",
+            "1912681870"
+          ]
+        },
+        "sort": [
+          465.7138,
+          "cb15861113"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "cb15861113",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR6113.I5865 S39 2022g",
+                      "urn:barcode:CU27972887"
+                    ],
+                    "physicalLocation": [
+                      "PR6113.I5865 S39 2022g"
+                    ],
+                    "shelfMark_sort": "aPR6113.I5865 S39 2022g",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "PR6113.I5865 S39 2022g"
+                    ],
+                    "uri": "ci10035633",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "PR6113.I5865 S39 2022g"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "CU27972887"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU27972887"
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "cb1869694",
+        "_score": 465.7138,
+        "_source": {
+          "extent": [
+            "2 volumes ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "publisherLiteral": [
+            "J.B. Lyon Company, Printers"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1908
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Verse and toast"
+          ],
+          "creatorLiteral": [
+            "Rowe, William H., Jr"
+          ],
+          "createdString": [
+            "1908"
+          ],
+          "idLccn": [
+            "   08036390 "
+          ],
+          "dateStartYear": [
+            1908
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "1869694"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "   08036390 "
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm18495675"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm18495675"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "1869694"
+            }
+          ],
+          "idOclc": [
+            "ocm18495675"
+          ],
+          "holdings": [],
+          "updatedAt": 1654915295034,
+          "publicationStatement": [
+            "Albany : J.B. Lyon Company, Printers, 1908."
+          ],
+          "identifier": [
+            "urn:bnum:1869694",
+            "urn:lccn:   08036390 ",
+            "urn:oclc:ocm18495675",
+            "urn:undefined:(OCoLC)ocm18495675",
+            "urn:undefined:1869694"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1908"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Verse and toast / by Col. William H. Rowe, Jr."
+          ],
+          "uri": "cb1869694",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Albany"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm"
+          ]
+        },
+        "sort": [
+          465.7138,
+          "cb1869694"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "cb1869694",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:1002217392"
+                    ],
+                    "physicalLocation": [
+                      "812R79 Y"
+                    ],
+                    "shelfMark_sort": "a812R79 Y v.000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "ci2345977",
+                    "shelfMark": [
+                      "812R79 Y v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "812R79 Y v.1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "1002217392"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "idBarcode": [
+                      "1002217392"
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "cb1869694",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:1002217449"
+                    ],
+                    "physicalLocation": [
+                      "812R79 Y"
+                    ],
+                    "shelfMark_sort": "a812R79 Y v.000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "ci2345976",
+                    "shelfMark": [
+                      "812R79 Y v.2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "812R79 Y v.2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "1002217449"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v.2"
+                    ],
+                    "idBarcode": [
+                      "1002217449"
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "cb1808514",
+        "_score": 464.42834,
+        "_source": {
+          "extent": [
+            "1 score (3 unnumbered pages, 12 pages) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes by Jack Gottlieb.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 2:30.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Recorded by the Israel Philharmonic, the composer conducting, on Deutsche Grammophon 2532 052.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Also available in a version for symphonic band.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "publisherLiteral": [
+            "Jalni Publications ; Boosey & Hawkes, sole selling agent"
+          ],
+          "dateEndString": [
+            "1980"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A musical toast"
+          ],
+          "creatorLiteral": [
+            "Bernstein, Leonard, 1918-1990"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "Hawkes pocket scores"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "1808514"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm11578466"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "H.P.S. 976 Boosey & Hawkes"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm11578466"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)1808514"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "1808514"
+            }
+          ],
+          "idOclc": [
+            "ocm11578466"
+          ],
+          "uniformTitle": [
+            "Musical toast",
+            "Hawkes pocket scores."
+          ],
+          "dateEndYear": [
+            1980
+          ],
+          "holdings": [],
+          "updatedAt": 1664590433971,
+          "publicationStatement": [
+            "[Place of publication not identified] : Jalni Publications ; New York, N.Y. : Boosey & Hawkes, sole selling agent, 1984, ©1980."
+          ],
+          "identifier": [
+            "urn:bnum:1808514",
+            "urn:oclc:ocm11578466",
+            "urn:undefined:H.P.S. 976 Boosey & Hawkes",
+            "urn:undefined:(OCoLC)ocm11578466",
+            "urn:undefined:(NNC)1808514",
+            "urn:undefined:1808514"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "titleDisplay": [
+            "A musical toast / Leonard Bernstein."
+          ],
+          "uri": "cb1808514",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "formatId": "c",
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "[Place of publication not identified] : New York, N.Y."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Musical toast"
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          464.42834,
+          "cb1808514"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "cb1808514",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:MR61509485"
+                    ],
+                    "physicalLocation": [
+                      "61 B458 M9"
+                    ],
+                    "shelfMark_sort": "a61 B458 M000009",
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "ci2278358",
+                    "shelfMark": [
+                      "61 B458 M9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "61 B458 M9"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "MR61509485"
+                      }
+                    ],
+                    "idBarcode": [
+                      "MR61509485"
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "MR"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b22067378",
+        "_score": 456.14685,
+        "_source": {
+          "extent": [
+            "<1> envelope (photographic prints) : b&w ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Publicity photographs for the television program Toast of the Town. Photographs include images of Mimi Benzell, Gertrude Lawrence, Dorothy Sarnoff, Lena Horne, Richard Rodgers, Oscar Hammerstein II, Ed Sullivan, Harriet Talbot, Georgine Darcy, Betty Lorraine, Rae McGregor, Janet Gaylord, Franca Baldwin, Norma Thornton, Joan Lowe and Jean Goodall.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Local note",
+              "label": "Theatre Photo Cataloging",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Benzell, Mimi",
+            "Lawrence, Gertrude",
+            "Sarnoff, Dorothy",
+            "Horne, Lena",
+            "Rodgers, Richard, 1902-1979",
+            "Hammerstein, Oscar, II, 1895-1960",
+            "Sullivan, Ed, 1901-1974",
+            "Talbot, Harriet",
+            "Darcy, Georgine",
+            "Lorraine, Betty",
+            "McGregor, Rae",
+            "Gaylord, Janet",
+            "Baldwin, Franca",
+            "Thornton, Norma",
+            "Lowe, Joan",
+            "Goodall, Jean"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "title": [
+            "Toast of the town (Television program)"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "*T-Pho B (Toast of the town (Television program))"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*T-Pho B (Toast of the town (Television program))"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22067378"
+            }
+          ],
+          "popularity": 0,
+          "updatedAt": 1751560516109,
+          "genreForm": [
+            "Photographic prints."
+          ],
+          "identifier": [
+            "urn:shelfmark:*T-Pho B (Toast of the town (Television program))",
+            "urn:bnum:22067378"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:img",
+              "label": "Still image"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Benzell, Mimi.",
+            "Lawrence, Gertrude.",
+            "Sarnoff, Dorothy.",
+            "Horne, Lena.",
+            "Rodgers, Richard, 1902-1979.",
+            "Hammerstein, Oscar, II, 1895-1960.",
+            "Sullivan, Ed, 1901-1974.",
+            "Talbot, Harriet.",
+            "Darcy, Georgine.",
+            "Lorraine, Betty.",
+            "McGregor, Rae.",
+            "Gaylord, Janet.",
+            "Baldwin, Franca.",
+            "Thornton, Norma.",
+            "Lowe, Joan.",
+            "Goodall, Jean."
+          ],
+          "titleDisplay": [
+            "Toast of the town (Television program) : photographs, 1951-1953."
+          ],
+          "uri": "b22067378",
+          "formatId": "k",
+          "recordTypeId": "k",
+          "issuance": [
+            {
+              "id": "urn:biblevel:c",
+              "label": "collection"
+            }
+          ],
+          "dimensions": [
+            "25 x 20 cm. or smaller."
+          ]
+        },
+        "sort": [
+          456.14685,
+          "b22067378"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b22067378",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=*T-Pho+B+%28Toast+of+the+town+%28Television+program%29%29&Form=30&Genre=flat+graphic&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db22067378&ItemISxN=i377321837&ItemNumber=33433117780357&Location=Performing+Arts+Theatre+Division&ReferenceNumber=b220673780&Site=LPATH&Title=Toast+of+the+town+%28Television+program%29+%3A+photographs%2C+1951-1953."
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:15",
+                        "label": "flat graphic"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:15||flat graphic"
+                    ],
+                    "formatLiteral": [
+                      "Picture"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pat38",
+                        "label": "Performing Arts Research Collections - Theatre"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pat38||Performing Arts Research Collections - Theatre"
+                    ],
+                    "idBarcode": [
+                      "33433117780357"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*T-Pho B (Toast of the town (Television program))",
+                      "urn:barcode:33433117780357"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*T-Pho B (Toast of the town (Television program))",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433117780357",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*T-Pho B (Toast of the town (Television program))"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*T-Pho B (Toast of the town (Television program))"
+                    ],
+                    "shelfMark_sort": "a*T-Pho B (Toast of the town (Television program))",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i37732183"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b10038245",
+        "_score": 448.63147,
+        "_source": {
+          "extent": [
+            "176 p. illus."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Knopf"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "Burnt toast; a novel."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 71-3298"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "creatorLiteral": [
+            "Gould, Peter"
+          ],
+          "idLccn": [
+            "70147880"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "idOclc": [
+            "NYPG710603184-B"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 71-3298"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10038245"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG710603184-B"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "70147880"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NN710603184"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0038376"
+            }
+          ],
+          "updatedAt": 1711114284571,
+          "publicationStatement": [
+            "New York, Knopf, 1971."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 71-3298",
+            "urn:bnum:10038245",
+            "urn:oclc:NYPG710603184-B",
+            "urn:lccn:70147880",
+            "urn:identifier:NN710603184",
+            "urn:identifier:(WaOLN)nyp0038376"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Burnt toast; a novel."
+          ],
+          "uri": "b10038245",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          448.63147,
+          "b10038245"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b10038245",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 71-3298",
+                      "urn:barcode:33433038923789"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "JFD 71-3298"
+                    ],
+                    "shelfMark_sort": "aJFD 71-003298",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFD 71-3298"
+                    ],
+                    "uri": "i12867982",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFD 71-3298"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433038923789"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433038923789"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b12435314",
+        "_score": 448.63147,
+        "_source": {
+          "extent": [
+            "xiv p., 1 l., 17-327 p. front., plates, ports."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"First edition.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "The Bobbs-Merrill company"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1935
+          ],
+          "title": [
+            "A toast to rebellion"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "AN (Garibaldi) (Garibaldi, G. Toast to rebellion)"
+          ],
+          "createdString": [
+            "1935"
+          ],
+          "creatorLiteral": [
+            "Garibaldi, Giuseppe, 1879-"
+          ],
+          "idLccn": [
+            "35025393"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1935
+          ],
+          "idOclc": [
+            "1526251"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "AN (Garibaldi) (Garibaldi, G. Toast to rebellion)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12435314"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1526251"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "35025393"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp2419632"
+            }
+          ],
+          "popularity": 2,
+          "updatedAt": 1753499321383,
+          "publicationStatement": [
+            "Indianapolis, New York, The Bobbs-Merrill company [c1935]"
+          ],
+          "identifier": [
+            "urn:shelfmark:AN (Garibaldi) (Garibaldi, G. Toast to rebellion)",
+            "urn:bnum:12435314",
+            "urn:oclc:1526251",
+            "urn:lccn:35025393",
+            "urn:identifier:(WaOLN)nyp2419632"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1935"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "A toast to rebellion, by Giuseppe Garibaldi."
+          ],
+          "uri": "b12435314",
+          "lccClassification": [
+            "D413.G3 A35"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Indianapolis, New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          448.63147,
+          "b12435314"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b12435314",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building - General Research Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433090984489"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:AN (Garibaldi) (Garibaldi, G. Toast to rebellion)",
+                      "urn:barcode:33433090984489"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "AN (Garibaldi) (Garibaldi, G. Toast to rebellion)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433090984489",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "AN (Garibaldi) (Garibaldi, G. Toast to rebellion)"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "AN (Garibaldi) (Garibaldi, G. Toast to rebellion)"
+                    ],
+                    "shelfMark_sort": "aAN (Garibaldi) (Garibaldi, G. Toast to rebellion)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i16027411"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b13147602",
+        "_score": 448.63147,
+        "_source": {
+          "extent": [
+            "310 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"First edition.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Doubleday"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1941
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "A toast to tomorrow."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "NCW (Coles, M. Toast to tomorrow)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1941"
+          ],
+          "creatorLiteral": [
+            "Coles, Manning"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1941
+          ],
+          "idOclc": [
+            "48802346",
+            "1370631"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NCW (Coles, M. Toast to tomorrow)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13147602"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "48802346"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1370631"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3125942"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)48802346"
+            }
+          ],
+          "updatedAt": 1711302779644,
+          "publicationStatement": [
+            "Garden City, N.Y. Doubleday [1941]"
+          ],
+          "identifier": [
+            "urn:shelfmark:NCW (Coles, M. Toast to tomorrow)",
+            "urn:bnum:13147602",
+            "urn:oclc:48802346",
+            "urn:oclc:1370631",
+            "urn:identifier:(WaOLN)nyp3125942",
+            "urn:identifier:(OCoLC)48802346"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1941"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "A toast to tomorrow."
+          ],
+          "uri": "b13147602",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Garden City, N.Y."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21cm."
+          ]
+        },
+        "sort": [
+          448.63147,
+          "b13147602"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b13147602",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NCW (Coles, M. Toast to tomorrow)",
+                      "urn:barcode:33433114070448"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "NCW (Coles, M. Toast to tomorrow)"
+                    ],
+                    "shelfMark_sort": "aNCW (Coles, M. Toast to tomorrow)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "NCW (Coles, M. Toast to tomorrow)"
+                    ],
+                    "uri": "i16287071",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "NCW (Coles, M. Toast to tomorrow)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433114070448"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433114070448"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b15877453",
+        "_score": 448.63147,
+        "_source": {
+          "extent": [
+            "1 sound disc : analog, 33 1/3 rpm, stereo. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Alshire: ST-5074 (on container: S-5074).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Selections from musicals arranged for orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes on container.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Musicals",
+            "Musicals -- Excerpts, Arranged",
+            "Orchestral music, Arranged"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Alshire"
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1966
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "title": [
+            "A toast to Broadway"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LZR 9189"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1966"
+          ],
+          "creatorLiteral": [
+            "101 Strings. prf"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1966
+          ],
+          "idOclc": [
+            "13323483"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LZR 9189"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15877453"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "13323483"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "ST-5074 Alshire"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "S-5074 Alshire"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A310000041"
+            }
+          ],
+          "updatedAt": 1712867127337,
+          "publicationStatement": [
+            "Burbank, Calif. : Alshire, [1966?]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LZR 9189",
+            "urn:bnum:15877453",
+            "urn:oclc:13323483",
+            "urn:identifier:ST-5074 Alshire",
+            "urn:identifier:S-5074 Alshire",
+            "urn:identifier:(WaOLN)A310000041"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1966"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Musicals -- Excerpts, Arranged.",
+            "Orchestral music, Arranged."
+          ],
+          "titleDisplay": [
+            "A toast to Broadway [sound recording] / 101 Strings."
+          ],
+          "uri": "b15877453",
+          "formatId": "j",
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Burbank, Calif."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "8:40 curtain.",
+            "Small world.",
+            "Till there was you.",
+            "Just in time.",
+            "Promise me a rose.",
+            "Til tomorrow.",
+            "Hey there.",
+            "Climb every mountain.",
+            "I enjoy being a girl.",
+            "Tonight.",
+            "Aisle talk."
+          ],
+          "tableOfContents": [
+            "8:40 curtain -- Small world -- Till there was you -- Just in time -- Promise me a rose -- Til tomorrow -- Hey there -- Climb every mountan -- I enjoy being a girl -- Tonight -- Aisle talk."
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          448.63147,
+          "b15877453"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b15877453",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LZR 9189 [Disc]",
+                      "urn:barcode:33433035395361"
+                    ],
+                    "physicalLocation": [
+                      "*LZR 9189 [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LZR 9189 [Disc]",
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Author=101+Strings.+prf&CallNumber=*LZR+9189+%5BDisc%5D&Date=1966&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15877453&ItemISxN=i14661544x&ItemNumber=33433035395361&ItemPlace=Burbank%2C+Calif.&ItemPublisher=Alshire%2C+%5B1966%3F%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b15877453x&Site=LPAMRAMI&Title=A+toast+to+Broadway"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "*LZR 9189 [Disc]"
+                    ],
+                    "uri": "i14661544",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*LZR 9189 [Disc]"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433035395361"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "idBarcode": [
+                      "33433035395361"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Audio"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b21766784",
+        "_score": 448.63147,
+        "_source": {
+          "extent": [
+            "75 pages ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Quattro Poetry"
+          ],
+          "description": [
+            "\"This new poetry collection by Corrado Paina explores the induced meditations and considerations that illness imposes upon a body and mind.\"--"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2018
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "A toast to illness"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 19-3255"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2018"
+          ],
+          "creatorLiteral": [
+            "Paina, Corrado, 1954-"
+          ],
+          "idLccn": [
+            "2018487509"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2018
+          ],
+          "idOclc": [
+            "1030339564"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 19-3255"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "21766784"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781988254616"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1988254612"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1030339564"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2018487509"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1030339564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1030484899"
+            }
+          ],
+          "updatedAt": 1711251518653,
+          "publicationStatement": [
+            "Toronto, Canada : Quattro Poetry, 2018."
+          ],
+          "genreForm": [
+            "Poetry."
+          ],
+          "idIsbn": [
+            "9781988254616",
+            "1988254612"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 19-3255",
+            "urn:bnum:21766784",
+            "urn:isbn:9781988254616",
+            "urn:isbn:1988254612",
+            "urn:oclc:1030339564",
+            "urn:lccn:2018487509",
+            "urn:identifier:(OCoLC)1030339564",
+            "urn:identifier:(OCoLC)1030484899"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2018"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "A toast to illness / Corrado Paina."
+          ],
+          "uri": "b21766784",
+          "lccClassification": [
+            "PR9199.4.P34 T63 2018"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Toronto, Canada"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm"
+          ],
+          "idIsbn_clean": [
+            "9781988254616",
+            "1988254612"
+          ]
+        },
+        "sort": [
+          448.63147,
+          "b21766784"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b21766784",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 19-3255",
+                      "urn:barcode:33433129000943"
+                    ],
+                    "physicalLocation": [
+                      "JFD 19-3255"
+                    ],
+                    "shelfMark_sort": "aJFD 19-003255",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "JFD 19-3255"
+                    ],
+                    "uri": "i37241733",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFD 19-3255"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433129000943"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433129000943"
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b12114589",
+        "_score": 447.63147,
+        "_source": {
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Music only.",
+              "type": "bf:Note"
+            }
+          ],
+          "partOf": [
+            "Burchenal, Elizabeth. Folk-dance music. New York, c1908. p 46"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Gustafs skål (Dance)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            1908
+          ],
+          "buildingLocationIds": [],
+          "title": [
+            "Gustafs skål (Gustave's toast)."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*MGS (General)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1908"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1908
+          ],
+          "idOclc": [
+            "NYPY710261847-C"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*MGS (General)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12114589"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPY710261847-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NN-PD)710261847"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp2101171"
+            }
+          ],
+          "updatedAt": 1711037894806,
+          "identifier": [
+            "urn:shelfmark:*MGS (General)",
+            "urn:bnum:12114589",
+            "urn:oclc:NYPY710261847-C",
+            "urn:identifier:(NN-PD)710261847",
+            "urn:identifier:(WaOLN)nyp2101171"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1908"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Gustafs skål (Dance)"
+          ],
+          "titleDisplay": [
+            "Gustafs skål (Gustave's toast)."
+          ],
+          "uri": "b12114589",
+          "formatId": "c",
+          "recordTypeId": "c",
+          "issuance": [
+            {
+              "id": "urn:biblevel:a",
+              "label": "monograph component part"
+            }
+          ]
+        },
+        "sort": [
+          447.63147,
+          "b12114589"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b12471757",
+        "_score": 447.42587,
+        "_source": {
+          "extent": [
+            "188 p., 13 leaves of plates : front., ill., ports. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Willis, Frederick"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Phoenix House"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1950
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "Peace and dripping toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "AN (Willis) (Willis, F. Peace and dripping toast)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1950"
+          ],
+          "creatorLiteral": [
+            "Willis, Frederick"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1950
+          ],
+          "idOclc": [
+            "2275721"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "AN (Willis) (Willis, F. Peace and dripping toast)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12471757"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "2275721"
+            }
+          ],
+          "updatedAt": 1711046734330,
+          "publicationStatement": [
+            "London : Phoenix House, 1950."
+          ],
+          "identifier": [
+            "urn:shelfmark:AN (Willis) (Willis, F. Peace and dripping toast)",
+            "urn:bnum:12471757",
+            "urn:oclc:2275721"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1950"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Willis, Frederick."
+          ],
+          "titleDisplay": [
+            "Peace and dripping toast / by Frederick Willis."
+          ],
+          "uri": "b12471757",
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          447.42587,
+          "b12471757"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b12471757",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:AN (Willis) (Willis, F. Peace and dripping toast)",
+                      "urn:barcode:33433103600973"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "AN (Willis) (Willis, F. Peace and dripping toast)"
+                    ],
+                    "shelfMark_sort": "aAN (Willis) (Willis, F. Peace and dripping toast)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "AN (Willis) (Willis, F. Peace and dripping toast)"
+                    ],
+                    "uri": "i16049510",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "AN (Willis) (Willis, F. Peace and dripping toast)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433103600973"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433103600973"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2025-07-16",
+        "_id": "b13279082",
+        "_score": 447.42587,
+        "_source": {
+          "extent": [
+            "41 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"An address delivered on January 16, 1936 before the Municipal art society of Baltimore city and now published under its auspices. Some of the ideas expressed were further developed in lectures given ... at the Rice institute of Houston, Texas, in January, 1937.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Horace"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Harvard university press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1937
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "title": [
+            "A toast to Horace"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "NTRW (Rand, E. K. Toast to Horace)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1937"
+          ],
+          "creatorLiteral": [
+            "Rand, Edward Kennard, 1871-1945"
+          ],
+          "idLccn": [
+            "38001889"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1937
+          ],
+          "idOclc": [
+            "5581153"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NTRW (Rand, E. K. Toast to Horace)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13279082"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "5581153"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "38001889"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3256542"
+            }
+          ],
+          "updatedAt": 1711302787483,
+          "publicationStatement": [
+            "Cambridge, Harvard university press, 1937."
+          ],
+          "identifier": [
+            "urn:shelfmark:NTRW (Rand, E. K. Toast to Horace)",
+            "urn:bnum:13279082",
+            "urn:oclc:5581153",
+            "urn:lccn:38001889",
+            "urn:identifier:(WaOLN)nyp3256542"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1937"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Horace."
+          ],
+          "titleDisplay": [
+            "A toast to Horace, by Edward Kennard Rand."
+          ],
+          "uri": "b13279082",
+          "lccClassification": [
+            "PA6411.Z5 R3"
+          ],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Cambridge"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          447.42587,
+          "b13279082"
+        ],
+        "matched_queries": [
+          "on-site"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-2025-07-16",
+                  "_id": "b13279082",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NTRW (Rand, E. K. Toast to Horace)",
+                      "urn:barcode:33433097996379"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "NTRW (Rand, E. K. Toast to Horace)"
+                    ],
+                    "shelfMark_sort": "aNTRW (Rand, E. K. Toast to Horace)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "shelfMark": [
+                      "NTRW (Rand, E. K. Toast to Horace)"
+                    ],
+                    "uri": "i16397426",
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "NTRW (Rand, E. K. Toast to Horace)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433097996379"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433097996379"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "formatLiteral": [
+                      "Book/Text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/scsb-by-barcode-6b2b7b2c5c697022451121eeedc508ad.json
+++ b/test/fixtures/scsb-by-barcode-6b2b7b2c5c697022451121eeedc508ad.json
@@ -1,0 +1,242 @@
+[
+  {
+    "itemBarcode": "33433118568447",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32101095377683",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433090460647",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32044077499465",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32101072287822",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433122276318",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33333225144951",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433089426146",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32101115835132",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433041530118",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433040606604",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433047232982",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "CU27972887",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "MR61509485",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433129000943",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433074287149",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32044089630495",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32101069223301",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433087759761",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433089279883",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433139820116",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433066644109",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433066644091",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33333113836635",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "AR02401576",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433114669116",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433135837288",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33333120986738",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "CU24576484",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "HXSKRU",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076591738",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433073344230",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433083720965",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "HNGRR7",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "HXL53Z",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "CU71435093",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32044105914865",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32101085641676",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059013072",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433089303840",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433083328249",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433120132745",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "CU68848080",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32101041878081",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059013205",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433069269284",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32101106490491",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32101069496063",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-7187853f2b28ac791fa747c18aec93a0.json
+++ b/test/fixtures/scsb-by-barcode-7187853f2b28ac791fa747c18aec93a0.json
@@ -1,0 +1,302 @@
+[
+  {
+    "itemBarcode": "33433040606604",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433047232982",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "MR61509485",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433066644109",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433066644091",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433110534520",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433110534512",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433086370503",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036090011",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036090755",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036090730",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433137385237",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433119383762",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433079269134",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "CU63297698",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32044042656827",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433070901354",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433064016748",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433063602100",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124442363",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002566952",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093051658",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433016013462",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433068003650",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433047707090",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433067981898",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433035629520",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433016107595",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433016107603",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433047678341",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433068925019",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085960031",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085960023",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015996212",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015996220",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433087273144",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433087273151",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433068004625",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433035869852",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062962687",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062962695",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433067801856",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433067801609",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085449688",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085449696",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433101197964",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433031368065",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433031368057",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062945013",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062945377",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433067801666",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433067801419",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433079152835",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433079152843",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433047665371",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433067822563",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433067822555",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433125489173",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433047750496",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433047772151",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-b3e68d433424fdcdbe2831c2fc61d2be.json
+++ b/test/fixtures/scsb-by-barcode-b3e68d433424fdcdbe2831c2fc61d2be.json
@@ -1,0 +1,202 @@
+[
+  {
+    "itemBarcode": "33433118568447",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433044323693",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433138142132",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433081452009",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32101075229904",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32101095377683",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "HNAASE",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433120459403",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433090460647",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32044077499465",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32101072287822",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433035294234",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433101440497",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433122276318",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433040618625",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33333225144951",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433089426146",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099082954",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099082962",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "32101115835132",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433041530118",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433040606604",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084609134",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433070578319",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433047232982",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433087491175",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433112057363",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33333059683314",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "CU27972887",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "1002217392",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "1002217449",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "MR61509485",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433117780357",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433038923789",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433090984489",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433114070448",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433035395361",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433129000943",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433103600973",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433097996379",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]


### PR DESCRIPTION
This ticket [SCC-4742](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4742)

The search `folkstsaytung varshe` should return results, but it doesn't because the `cross_fields` query still only accepts `placeOfPublication` as a match if it includes the entire phrase. To fix this, the mapping needs to add a folding analyzer to `placeOfPublication`

Once we update the ElasticSearch mappings and reindex relevant bibs, we need to update DiscoveryAPI to use the folded version of `placeOfPublication`.

[SCC-4742]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ