### PR TITLE
Force ENV=production when updating fixtures

### DIFF
--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -22,6 +22,11 @@ before(async () => {
     })
   }
 
+  if (process.env.UPDATE_FIXTURES) {
+    // Specify the environment from which to initialize config:
+    process.env.ENV = 'production'
+  }
+
   await app.init()
 
   // Establish base url for local queries:


### PR DESCRIPTION
Fix bug creating fixtures via `UPDATE_FIXTURES=if-missing npm test`, etc.