### PR TITLE
Change "sort" parameter to termLabel not preferredTerm

### DIFF
--- a/lib/subjects.js
+++ b/lib/subjects.js
@@ -11,7 +11,7 @@ const SEARCH_SCOPES = [
 ]
 
 const SORT_FIELDS = [
-  'preferredTerm',
+  'termLabel',
   'count',
   'relevance'
 ]
@@ -19,7 +19,7 @@ const SORT_FIELDS = [
 // Default sort orders for different search scopes
 const SEARCH_SCOPE_SORT_ORDER = {
   has: 'count',
-  starts_with: 'preferredTerm'
+  starts_with: 'termLabel'
 }
 
 // Define painless scripts that will let us respect order for results in a variant list
@@ -64,7 +64,7 @@ const parseBrowseParams = function (params) {
     q: { type: 'string' },
     page: { type: 'int', default: 1 },
     per_page: { type: 'int', default: 50, range: [0, 100] },
-    sort: { type: 'string', range: SORT_FIELDS, default: SEARCH_SCOPE_SORT_ORDER[params.search_scope] || 'preferredTerm' },
+    sort: { type: 'string', range: SORT_FIELDS, default: SEARCH_SCOPE_SORT_ORDER[params.search_scope] || 'termLabel' },
     sort_direction: { type: 'string', range: ['asc', 'desc'] },
     search_scope: { type: 'string', range: SEARCH_SCOPES, default: '' }
   })
@@ -154,7 +154,7 @@ const buildElasticSubjectsBody = function (params) {
   body.query = builder.query.toJson()
 
   // sort is done different for different search scopes due to how we manage variants
-  if (params.search_scope === 'starts_with') {
+  if (params.sort === 'termLabel') {
     // When doing startsWith alphabetical sorting, we might get hits inside the "variants" array.
     // The way ES deals with sorting matches in an array is it looks at the lowest/highest lexicographical
     // entry in the array and uses that- *not* the entry that caused the match. So we use simple painless scripts

--- a/test/subjects.test.js
+++ b/test/subjects.test.js
@@ -118,7 +118,7 @@ describe('Subjects query', function () {
       expect(params.search_scope).to.equal('')
       expect(params.page).to.equal(1)
       expect(params.per_page).to.equal(50)
-      expect(params.sort).to.equal('preferredTerm')
+      expect(params.sort).to.equal('termLabel')
     })
 
     it('parses params, using search_scope has', function () {
@@ -138,7 +138,7 @@ describe('Subjects query', function () {
       expect(params.search_scope).to.equal('starts_with')
       expect(params.page).to.equal(1)
       expect(params.per_page).to.equal(50)
-      expect(params.sort).to.equal('preferredTerm')
+      expect(params.sort).to.equal('termLabel')
     })
   })
 


### PR DESCRIPTION
* Tiny PR to use "termLabel" as the sort argument instead of "preferredTerm" since we're supporting variants in this as well.