### PR TITLE
Scc 3442/connect to bug

### DIFF
--- a/lib/annotated-marc-serializer.js
+++ b/lib/annotated-marc-serializer.js
@@ -175,7 +175,7 @@ const prefixForSubfield = (marcTag, subfield, previousSubfield = null) => {
   if (subfield === '4' && previousSubfield === '4') {
     prefix = '. '
 
-  // Otherwise determine prefix by marcTag/subfield
+    // Otherwise determine prefix by marcTag/subfield
   } else {
     switch (parseInt(marcTag)) {
       // Subject fields:
@@ -233,15 +233,14 @@ AnnotatedMarcSerializer.formatVarFieldMatch = function (matchingVarField, rule) 
     return false
   })
 
+  if (!matchedSubfields.length) return
   const content = matchingVarField.content || matchedSubfields
     .map((subfield, ind) => {
       const previousSubfield = matchedSubfields[ind - 1]
       // Construct prefix based on subfield & prev. subfield:
       const prefix = prefixForSubfield(matchingVarField.marcTag, subfield.tag, previousSubfield ? previousSubfield.tag : null)
-
       return prefix + extractContent(subfield)
     }).join('')
-
   // Collect other field values apart from primary value:
   const additionalFields = {}
 

--- a/lib/annotated-marc-serializer.js
+++ b/lib/annotated-marc-serializer.js
@@ -233,7 +233,6 @@ AnnotatedMarcSerializer.formatVarFieldMatch = function (matchingVarField, rule) 
     return false
   })
 
-  if (!matchedSubfields.length) return
   const content = matchingVarField.content || matchedSubfields
     .map((subfield, ind) => {
       const previousSubfield = matchedSubfields[ind - 1]
@@ -246,6 +245,7 @@ AnnotatedMarcSerializer.formatVarFieldMatch = function (matchingVarField, rule) 
 
   // For "Connect to:" mapped blocks, extract label:
   if (rule.label === 'Connect to:') {
+    if (!matchedSubfields.length) return
     const labelSubfields = ['z', 'y', '3']
     additionalFields.label = (matchingVarField.subfields || [])
       .filter((s) => labelSubfields.indexOf(s.tag) >= 0)

--- a/test/annotated-marc-rules.test.js
+++ b/test/annotated-marc-rules.test.js
@@ -625,7 +625,8 @@ describe('Annotated Marc Rules', function () {
         varFields: [
           { fieldTag: 'y', marcTag: '856', subfields: [{ tag: 'u', content: 'http://example.com#0' }, { tag: 'z', content: 'Label 1' }] },
           { fieldTag: 'y', marcTag: '856', subfields: [{ tag: 'u', content: 'http://example.com#1' }, { tag: 'y', content: 'Label 2' }, { tag: '3', content: 'This additional lable is ignored because we found $y first' }] },
-          { fieldTag: 'y', marcTag: '856', subfields: [{ tag: 'a', content: 'Ignore tag' }, { tag: 'u', content: 'http://example.com#2' }, { tag: '3', content: 'Label 3' }] }
+          { fieldTag: 'y', marcTag: '856', subfields: [{ tag: 'a', content: 'Ignore tag' }, { tag: 'u', content: 'http://example.com#2' }, { tag: '3', content: 'Label 3' }] },
+          { fieldTag: 'y', marcTag: '856', subfields: [{ tag: 'x', content: '[redacted]' }] }
         ]
       }
 
@@ -639,6 +640,7 @@ describe('Annotated Marc Rules', function () {
       expect(serialized.bib.fields[0].values[0].label).to.equal('Label 1')
       expect(serialized.bib.fields[0].values[1].label).to.equal('Label 2')
       expect(serialized.bib.fields[0].values[2].label).to.equal('Label 3')
+      expect(serialized.bib.fields[0].values[3]).to.equal(undefined)
     })
 
     it('should use default label when none specified', function () {


### PR DESCRIPTION
[This ticket](https://newyorkpubliclibrary.atlassian.net/browse/SCC-3342) seems to be caused by some inadvertent including of excluded fields in the special handling of "Connect to" fields. I think this should do the trick! Basically, there are fields being filtered out, but in the "Connect to" parsing, the (perhaps misnamed) `matchingVarField`'s subfields are mapped over without care to whether any of that varfields subfields are valid by the annotated marc rules. The content of any subfield is then returned as a default value, regardless of if the subfield is one we want. 
For this case called out in the ticket, the subfield x is the only subfield, so there are no matched subfields, so returning early when `!matchedSubfields.length` works.