### PR TITLE
skip addition when no content returned

### DIFF
--- a/lib/annotated-marc-serializer.js
+++ b/lib/annotated-marc-serializer.js
@@ -305,7 +305,7 @@ AnnotatedMarcSerializer.addStatementsToDoc = function (doc, rule, values) {
 AnnotatedMarcSerializer.addStatementsForVarFieldForRule = function (doc, bib, varField, rule) {
   const content = AnnotatedMarcSerializer.formatVarFieldMatch(varField, rule)
   //
-  doc = AnnotatedMarcSerializer.addStatementsToDoc(doc, rule, [content])
+  if (content) doc = AnnotatedMarcSerializer.addStatementsToDoc(doc, rule, [content])
 
   const parallelNumbers = (varField.subfields || [])
     .filter((s) => s.tag === '6')

--- a/test/annotated-marc-rules.test.js
+++ b/test/annotated-marc-rules.test.js
@@ -640,7 +640,8 @@ describe('Annotated Marc Rules', function () {
       expect(serialized.bib.fields[0].values[0].label).to.equal('Label 1')
       expect(serialized.bib.fields[0].values[1].label).to.equal('Label 2')
       expect(serialized.bib.fields[0].values[2].label).to.equal('Label 3')
-      expect(serialized.bib.fields[0].values[3]).to.equal(undefined)
+      // field tag x should not be included
+      expect(serialized.bib.fields[0].values.length).to.equal(3)
     })
 
     it('should use default label when none specified', function () {


### PR DESCRIPTION
prior code was returning null values for invalid connect to fields. this is to make sure that we are not including null content in the annotated marc document