### PR TITLE
SCC-4914: Fix single aggregation route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ config/local*
 
 # rank-eval report:
 out.html
+
+.vscode*

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -79,7 +79,7 @@ const parseSearchParams = function (params) {
   return parseParams(params, {
     q: { type: 'string' },
     page: { type: 'int', default: 1 },
-    per_page: { type: 'int', default: 50, range: [0, 1000] },
+    per_page: { type: 'int', default: 50, range: [0, 100] },
     field: { type: 'string', range: Object.keys(AGGREGATIONS_SPEC) },
     sort: { type: 'string', range: Object.keys(SORT_FIELDS), default: 'relevance' },
     sort_direction: { type: 'string', range: ['asc', 'desc'] },
@@ -745,7 +745,7 @@ module.exports = function (app, _private = null) {
             }, {})
           // Add response aggs to combined aggs:
           return Object.assign(allAggs, respAggs)
-        }, { })
+        }, {})
     }
   }
 
@@ -771,9 +771,20 @@ module.exports = function (app, _private = null) {
 
   // Get a single aggregation:
   app.resources.aggregation = (params, opts) => {
+    // Save per_page if it exceeds 100
+    let perPage
+    if (params.per_page > 100) {
+      perPage = Number(params.per_page)
+    }
     params = parseSearchParams(params)
 
-    if (Object.keys(AGGREGATIONS_SPEC).indexOf(params.field) < 0) return Promise.reject(new Error('Invalid aggregation field'))
+    // Restore per_page if user requested > 100
+    if (perPage) {
+      params.per_page = perPage
+    }
+    if (Object.keys(AGGREGATIONS_SPEC).indexOf(params.field) < 0) {
+      return Promise.reject(new Error('Invalid aggregation field'))
+    }
 
     const body = buildElasticBody(params)
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -79,7 +79,7 @@ const parseSearchParams = function (params) {
   return parseParams(params, {
     q: { type: 'string' },
     page: { type: 'int', default: 1 },
-    per_page: { type: 'int', default: 50, range: [0, 100] },
+    per_page: { type: 'int', default: 50, range: [0, 500] },
     field: { type: 'string', range: Object.keys(AGGREGATIONS_SPEC) },
     sort: { type: 'string', range: Object.keys(SORT_FIELDS), default: 'relevance' },
     sort_direction: { type: 'string', range: ['asc', 'desc'] },

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -79,7 +79,7 @@ const parseSearchParams = function (params) {
   return parseParams(params, {
     q: { type: 'string' },
     page: { type: 'int', default: 1 },
-    per_page: { type: 'int', default: 50, range: [0, 500] },
+    per_page: { type: 'int', default: 50, range: [0, 1000] },
     field: { type: 'string', range: Object.keys(AGGREGATIONS_SPEC) },
     sort: { type: 'string', range: Object.keys(SORT_FIELDS), default: 'relevance' },
     sort_direction: { type: 'string', range: ['asc', 'desc'] },

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -59,8 +59,8 @@ module.exports = function (app) {
       .catch((error) => handleError(res, error, params))
   })
 
-  app.get(`/api/v${VER}/discovery/resources/aggregation/:field`, function (req, res) {
-    const params = req.query
+  app.get(`/api/v${VER}/discovery/resources/aggregations/:field`, function (req, res) {
+    const params = Object.assign({}, req.query, req.params)
 
     return app.resources.aggregation(params, { baseUrl: app.baseUrl })
       .then((resp) => respond(res, resp, params))


### PR DESCRIPTION
- Added `/api/v0.1/discovery/resources/aggregations/{field}` to [API gateway](https://946183545209-nbu5l6pe.us-east-1.console.aws.amazon.com/apigateway/main/apis/ggmsmw0dql/resources?api=ggmsmw0dql&region=us-east-1) as authenticated route (previously did not exist)
- Updates route handler to use `aggregationS` and capture params object correctly
- Overrides the `per_page` limit in ` app.resources.aggregation` so it's possible to request any number of values rather than limiting to 100