### PR TITLE
Fix parsing exception detection

### DIFF
--- a/lib/elasticsearch/client.js
+++ b/lib/elasticsearch/client.js
@@ -58,13 +58,17 @@ clientWrapper.search = function (body, index = process.env.RESOURCES_INDEX) {
     body
   })
     .catch((e) => {
+      // Collect failure types (to detect parsing error):
+      const failureTypes = e.body?.error?.failed_shards
+        ?.map((failure) => failure?.reason?.caused_by?.type) || []
+
       if (e.statusCode === 403) {
         logger.error(`Error connecting to index: ${e.statusCode}: ${JSON.stringify(e.body)}`)
         throw new IndexConnectionError('Error connecting to index')
       } else if (
         e.statusCode === 400 &&
         e.body?.error?.type === 'search_phase_execution_exception' &&
-        e.body.error.caused_by?.type === 'token_mgr_error'
+        failureTypes.includes('parse_exception')
       ) {
         // This kind of error appears to indicate structural problems in the
         // user's query, which we should specially handle downstream:

--- a/test/elasticsearch-client.test.js
+++ b/test/elasticsearch-client.test.js
@@ -57,7 +57,16 @@ describe('Elasticsearch Client', () => {
       error.body = {
         error: {
           type: 'search_phase_execution_exception',
-          caused_by: { type: 'token_mgr_error' }
+          failed_shards: [
+            {
+              reason: {
+                type: 'query_shard_exception',
+                caused_by: {
+                  type: 'parse_exception'
+                }
+              }
+            }
+          ]
         }
       }
 


### PR DESCRIPTION
Previous check didn't catch all parse errors. This appears to be the safer check.

https://newyorkpubliclibrary.atlassian.net/browse/SCC-4907