### PR TITLE
Light normalization preprocessing for browse terms

### DIFF
--- a/lib/elasticsearch/elastic-query-browse-builder.js
+++ b/lib/elasticsearch/elastic-query-browse-builder.js
@@ -4,6 +4,7 @@ class ElasticQueryBrowseBuilder {
   constructor (apiRequest) {
     this.request = apiRequest
     this.query = new ElasticQuery()
+    this.normalizedQuery = this.request.querySansQuotes().normalize('NFC')
 
     switch (this.request.params.search_scope) {
       case 'has':
@@ -24,8 +25,8 @@ class ElasticQueryBrowseBuilder {
     this.query.addMust({
       bool: {
         should: [
-          { prefix: { 'preferredTerm.keyword_normalized': { value: this.request.querySansQuotes(), _name: 'preferredTerm' } } },
-          { nested: { path: 'variants', query: { prefix: { 'variants.variant.keyword_normalized': this.request.querySansQuotes() } }, inner_hits: {} } }
+          { prefix: { 'preferredTerm.keyword_normalized': { value: this.normalizedQuery, _name: 'preferredTerm' } } },
+          { nested: { path: 'variants', query: { prefix: { 'variants.variant.keyword_normalized': this.normalizedQuery } }, inner_hits: {} } }
         ]
       }
     })
@@ -38,8 +39,8 @@ class ElasticQueryBrowseBuilder {
     this.query.addMust({
       bool: {
         should: [
-          { term: { 'preferredTerm.keyword': { value: this.request.querySansQuotes(), _name: 'preferredTerm' } } },
-          { nested: { path: 'variants', query: { term: { 'variants.variant.keyword': this.request.querySansQuotes() } }, inner_hits: {} } }
+          { term: { 'preferredTerm.keyword': { value: this.normalizedQuery, _name: 'preferredTerm' } } },
+          { nested: { path: 'variants', query: { term: { 'variants.variant.keyword': this.normalizedQuery } }, inner_hits: {} } }
         ]
       }
     })
@@ -52,9 +53,9 @@ class ElasticQueryBrowseBuilder {
     this.query.addMust({
       bool: {
         should: [
-          { prefix: { 'preferredTerm.keyword_normalized': { value: this.request.querySansQuotes(), _name: 'preferredTermPrefix' } } },
-          { match: { preferredTerm: { query: this.request.querySansQuotes(), operator: 'and', _name: 'preferredTerm' } } },
-          { nested: { path: 'variants', query: { match: { 'variants.variant': { query: this.request.querySansQuotes(), operator: 'and' } } }, inner_hits: {} } }
+          { prefix: { 'preferredTerm.keyword_normalized': { value: this.normalizedQuery, _name: 'preferredTermPrefix' } } },
+          { match: { preferredTerm: { query: this.normalizedQuery, operator: 'and', _name: 'preferredTerm' } } },
+          { nested: { path: 'variants', query: { match: { 'variants.variant': { query: this.normalizedQuery, operator: 'and' } } }, inner_hits: {} } }
         ]
       }
     })


### PR DESCRIPTION
* As pointed out by Nora, our Elasticsearch folding analyzers don't seem to account for certain characters, hence we see things like this which look identical but have an invisible character difference:
  * Has results: https://www.nypl.org/research/research-catalog/browse/authors?q=Ki%C5%A1%2C%20Danilo%2C%201935-1989&search_scope=starts_with&sort=termLabel&sort_direction=asc
  * No results: https://www.nypl.org/research/research-catalog/browse/authors?q=Kis%CC%8C%2C%20Danilo%2C%201935-1989&search_scope=starts_with
* This change adds extremely light normalization into the preprocessing for the query which addresses the above discrepancy.