### PR TITLE
Noref/wildcard search tweaks

### DIFF
--- a/lib/elasticsearch/cql_query_builder.js
+++ b/lib/elasticsearch/cql_query_builder.js
@@ -530,10 +530,6 @@ function basicMatch (fields, term, type) {
   const shelfMarkFields = fields.filter(field => field.includes('shelfMark'))
   const otherFields = fields.filter(field => !field.includes('shelfMark'))
 
-  if (!shelfMarkFields.length) {
-    return queryStringQuery(otherFields, term, type)
-  }
-
   return [
     ...queryStringQuery(otherFields, term, type),
     ...multiMatch(shelfMarkFields, term, type)

--- a/lib/elasticsearch/cql_query_builder.js
+++ b/lib/elasticsearch/cql_query_builder.js
@@ -342,7 +342,7 @@ function matchTermWithFields (fields, term, type) {
   const selector = selectFields(queryType, fields)
 
   const queries = [
-    ...multiMatch(selector('multi_match'), term, type),
+    ...basicMatch(selector('multi_match'), term, type),
     ...(selector('term').map(termField => termQuery(termField, term))),
     ...(selector('prefix').map(prefixField => prefixQuery(prefixField, term)))
   ]
@@ -501,17 +501,43 @@ function multiMatch (fields, term, type) {
     type
   }
 
-  if (term.includes('*')) {
-    query.analyze_wildcard = true
-    query.default_operator = 'AND'
-    return [{
-      query_string: query
-    }]
-  }
-
   return [{
     multi_match: query
   }]
+}
+
+function queryStringQuery (fields, term, type) {
+  if (!fields || !fields.length) return []
+
+  return [{
+    query_string: {
+      query: term,
+      fields,
+      type,
+      analyze_wildcard: true,
+      default_operator: 'AND'
+    }
+  }]
+}
+
+function basicMatch (fields, term, type) {
+  if (!fields || !fields.length) return []
+
+  if (!term.includes('*')) {
+    return multiMatch(fields, term, type)
+  }
+
+  const shelfMarkFields = fields.filter(field => field.includes('shelfMark'))
+  const otherFields = fields.filter(field => !field.includes('shelfMark'))
+
+  if (!shelfMarkFields.length) {
+    return queryStringQuery(otherFields, term, type)
+  }
+
+  return [
+    ...queryStringQuery(otherFields, term, type),
+    ...multiMatch(shelfMarkFields, term, type)
+  ]
 }
 
 module.exports = {

--- a/lib/elasticsearch/cql_query_builder.js
+++ b/lib/elasticsearch/cql_query_builder.js
@@ -502,6 +502,8 @@ function multiMatch (fields, term, type) {
   }
 
   if (term.includes('*')) {
+    query.analyze_wildcard = true
+    query.default_operator = 'AND'
     return [{
       query_string: query
     }]

--- a/test/cql_es_queries.js
+++ b/test/cql_es_queries.js
@@ -1567,6 +1567,127 @@ const divisionExact = {
   }
 }
 
+const wildcardQueryNoShelfMark = {
+  bool: {
+    must: [
+      {
+        bool: {
+          should: [
+            {
+              bool: {
+                should: [
+                  {
+                    query_string: {
+                      query: 'Ham*let',
+                      fields: [
+                        'title',
+                        'title.folded',
+                        'titleAlt.folded',
+                        'uniformTitle.folded',
+                        'titleDisplay.folded',
+                        'seriesStatement.folded',
+                        'contentsTitle.folded',
+                        'donor.folded',
+                        'parallelTitle.folded',
+                        'parallelTitleDisplay.folded',
+                        'parallelSeriesStatement.folded',
+                        'parallelTitleAlt.folded',
+                        'parallelCreatorLiteral.folded',
+                        'parallelUniformTitle',
+                        'formerTitle',
+                        'addedAuthorTitle'
+                      ],
+                      type: 'phrase',
+                      analyze_wildcard: true,
+                      default_operator: 'AND'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+const wildcardQueryWithShelfMark = {
+  bool: {
+    must: [
+      {
+        bool: {
+          should: [
+            {
+              bool: {
+                should: [
+                  {
+                    query_string: {
+                      query: 'B 12*',
+                      fields: [
+                        'title',
+                        'title.folded',
+                        'description.foldedStemmed',
+                        'subjectLiteral',
+                        'subjectLiteral.folded',
+                        'creatorLiteral',
+                        'creatorLiteral.folded',
+                        'contributorLiteral.folded',
+                        'note.label.foldedStemmed',
+                        'publisherLiteral.folded',
+                        'seriesStatement.folded',
+                        'titleAlt.folded',
+                        'titleDisplay.folded',
+                        'contentsTitle.folded',
+                        'tableOfContents.folded',
+                        'genreForm',
+                        'donor.folded',
+                        'parallelTitle.folded',
+                        'parallelTitleDisplay.folded',
+                        'parallelTitleAlt.folded',
+                        'parallelSeriesStatement.folded',
+                        'parallelCreatorLiteral.folded',
+                        'parallelPublisher',
+                        'parallelPublisherLiteral',
+                        'uniformTitle.folded',
+                        'parallelUniformTitle',
+                        'formerTitle',
+                        'addedAuthorTitle',
+                        'placeOfPublication.folded'
+                      ],
+                      type: 'phrase',
+                      analyze_wildcard: true,
+                      default_operator: 'AND'
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              nested: {
+                path: 'items',
+                query: {
+                  bool: {
+                    should: [
+                      {
+                        multi_match: {
+                          query: 'B 12*',
+                          fields: ['items.shelfMark'],
+                          type: 'phrase'
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
 module.exports = {
   simpleAdjQuery,
   simpleAnyQuery,
@@ -1593,5 +1714,7 @@ module.exports = {
   divisionAdj,
   divisionAll,
   divisionAny,
-  divisionExact
+  divisionExact,
+  wildcardQueryNoShelfMark,
+  wildcardQueryWithShelfMark
 }

--- a/test/cql_query_builder.test.js
+++ b/test/cql_query_builder.test.js
@@ -31,7 +31,9 @@ const {
   divisionAdj,
   divisionAll,
   divisionAny,
-  divisionExact
+  divisionExact,
+  wildcardQueryNoShelfMark,
+  wildcardQueryWithShelfMark
 } = require('./cql_es_queries')
 
 describe('CQL Query Builder', function () {
@@ -239,6 +241,20 @@ describe('CQL Query Builder', function () {
     expect(new CqlQuery('AuThOr = "Shakespeare" aNd LaNgUaGe = "English"').buildEsQuery())
       .to.deep.equal(
         binaryBooleanQuery
+      )
+  })
+
+  it('Wildcard query without shelfMark fields', function () {
+    expect(new CqlQuery('title="Ham*let"').buildEsQuery())
+      .to.deep.equal(
+        wildcardQueryNoShelfMark
+      )
+  })
+
+  it('Wildcard query with shelfMark fields', function () {
+    expect(new CqlQuery('keyword="B 12*"').buildEsQuery())
+      .to.deep.equal(
+        wildcardQueryWithShelfMark
       )
   })
 


### PR DESCRIPTION
We're still working on the wildcard queries but this adds some support for the current requirements:

- Use a `query_string` query in case `*` is present
- Except for shelfMark fields
- Some minor refactoring to make this a little easier
- Also a couple of tests