### PR TITLE
include keywordlowercasedstripped fields where missing

### DIFF
--- a/lib/elasticsearch/config.js
+++ b/lib/elasticsearch/config.js
@@ -95,7 +95,7 @@ const FILTER_CONFIG = {
   format: { operator: 'match', field: ['formatId'], repeatable: true },
   recordType: { operator: 'match', field: ['recordTypeId'], repeatable: true },
   owner: { operator: 'match', field: ['items.owner.id', 'items.owner.label'], repeatable: true, path: 'items' },
-  subjectLiteral: { operator: 'match', field: ['subjectLiteral.keywordLowercasedStripped'], repeatable: true },
+  subjectLiteral: { operator: 'match', field: ['subjectLiteral.keywordLowercasedStripped', 'parallelSubjectLiteral.keywordLowercasedStripped'], repeatable: true },
   holdingLocation: { operator: 'match', field: ['items.holdingLocation.id', 'items.holdingLocation.label'], repeatable: true, path: 'items' },
   buildingLocation: { operator: 'match', field: ['buildingLocationIds'], repeatable: true },
   language: { operator: 'match', field: ['language.id', 'language.label'], repeatable: true },
@@ -120,8 +120,8 @@ const FILTER_CONFIG = {
   titleAlt: { operator: 'match', field: ['titleAlt.raw', 'parallelTitleAlt.raw'], repeatable: true },
   uniformTitle: { operator: 'match', field: ['uniformTitle.raw', 'parallelUniformTitle.raw'], repeatable: true },
   addedAuthorTitle: { operator: 'match', field: ['addedAuthorTitle.raw', 'parallelAddedAuthorTitle.raw'], repeatable: true },
-  series: { operator: 'match', field: ['series.keywordLowercasedStripped', 'parallelSeries', 'seriesUniformTitle.keywordLowercasedStripped', 'parallelSeriesUniformTitle.keywordLowercasedStripped', 'seriesAddedEntry.keywordLowercasedStripped', 'parallelSeriesAddedEntry.keywordLowercasedStripped'], repeatable: true },
-  placeOfPublication: { operator: 'match', field: ['placeOfPublication.keywordLowercasedStripped', 'parallelPlaceOfPublication'], repeatable: true },
+  series: { operator: 'match', field: ['series.keywordLowercasedStripped', 'parallelSeries.keywordLowercasedStripped', 'seriesUniformTitle.keywordLowercasedStripped', 'parallelSeriesUniformTitle.keywordLowercasedStripped', 'seriesAddedEntry.keywordLowercasedStripped', 'parallelSeriesAddedEntry.keywordLowercasedStripped'], repeatable: true },
+  placeOfPublication: { operator: 'match', field: ['placeOfPublication.keywordLowercasedStripped', 'parallelPlaceOfPublication.keywordLowercasedStripped'], repeatable: true },
   dateFrom: {
     operator: 'custom',
     type: 'string'

--- a/test/elastic-query-builder.test.js
+++ b/test/elastic-query-builder.test.js
@@ -2,6 +2,7 @@ const { expect } = require('chai')
 
 const ElasticQueryBuilder = require('../lib/elasticsearch/elastic-query-builder')
 const ApiRequest = require('../lib/api-request')
+const { FILTER_CONFIG } = require('../lib/elasticsearch/config')
 
 describe('ElasticQueryBuilder', () => {
   describe('buildFilterClause', () => {
@@ -28,58 +29,65 @@ describe('ElasticQueryBuilder', () => {
       buildMatchOperatorFilterQueries: ElasticQueryBuilder.prototype.buildMatchOperatorFilterQueries,
       buildFilterClause: ElasticQueryBuilder.prototype.buildFilterClause
     })
+    const verifyFilterFields = (filterFields, filterQueryBody) => {
+      const stringedFilters = JSON.stringify(filterQueryBody)
+      const esFields = filterFields.map((filter) => FILTER_CONFIG[filter].field).flat()
+      esFields.forEach((esField) => {
+        expect(stringedFilters.includes(esField)).to.equal(true)
+      })
+    }
     it('can handle (multiple) single value, single match field filters, as arrays', () => {
+      const filterFields = ['buildingLocation', 'subjectLiteral']
       const request = new ApiRequest({ filters: { buildingLocation: ['toast'], subjectLiteral: ['spaghetti'] } })
       const mockQueryBuilder = mockQueryBuilderFactory(request)
       const simpleMatchFilters = mockQueryBuilder.buildMatchOperatorFilterQueries(['buildingLocation', 'subjectLiteral'])
-      expect(simpleMatchFilters).to.deep.equal([
-        {
-          path: undefined,
-          clause: { term: { buildingLocationIds: 'toast' } }
-        },
-        {
-          path: undefined,
-          clause: { terms: { 'subjectLiteral.keywordLowercasedStripped': ['spaghetti', 'spaghetti.'] } }
-        }
-      ])
+      expect(simpleMatchFilters.length).to.equal(2)
+      verifyFilterFields(filterFields, simpleMatchFilters)
+      simpleMatchFilters.forEach(filter => {
+        expect(filter.path).to.equal(undefined)
+        expect(filter.clause).not.to.equal(undefined)
+      })
     })
     it('can handle (multiple) single value, single match field filters, strings', () => {
       const request = new ApiRequest({ filters: { buildingLocation: 'toast', subjectLiteral: 'spaghetti' } })
       const mockQueryBuilder = mockQueryBuilderFactory(request)
+      const filterFields = ['buildingLocation', 'subjectLiteral']
       const simpleMatchFilters = mockQueryBuilder.buildMatchOperatorFilterQueries(['buildingLocation', 'subjectLiteral'])
-      expect(simpleMatchFilters).to.deep.equal([
-        {
-          path: undefined,
-          clause: { term: { buildingLocationIds: 'toast' } }
-        },
-        {
-          path: undefined,
-          clause: { terms: { 'subjectLiteral.keywordLowercasedStripped': ['spaghetti', 'spaghetti.'] } }
-        }
-      ])
+      expect(simpleMatchFilters.length).to.equal(2)
+      verifyFilterFields(filterFields, simpleMatchFilters)
+      simpleMatchFilters.forEach(filter => {
+        expect(filter.path).to.equal(undefined)
+        expect(filter.clause).not.to.equal(undefined)
+      })
     })
     it('can handle multiple values', () => {
-      const request = new ApiRequest({ filters: { subjectLiteral: ['spaghetti', 'meatballs'] } })
+      const requestBody = { filters: { subjectLiteral: ['spaghetti', 'meatballs'] } }
+      const request = new ApiRequest(requestBody)
       const mockQueryBuilder = mockQueryBuilderFactory(request)
       const simpleMatchFilters = mockQueryBuilder.buildMatchOperatorFilterQueries(['subjectLiteral'])
-      expect(simpleMatchFilters).to.deep.equal([
-        {
-          path: undefined,
-          clause: {
-            bool: {
-              should: [
-                { terms: { 'subjectLiteral.keywordLowercasedStripped': ['spaghetti', 'spaghetti.'] } },
-                { terms: { 'subjectLiteral.keywordLowercasedStripped': ['meatballs', 'meatballs.'] } }
-              ]
-            }
-          }
-        }
-      ])
+      expect(simpleMatchFilters.length).to.equal(Object.keys(requestBody.filters).length)
+      verifyFilterFields(['subjectLiteral'], simpleMatchFilters)
+      simpleMatchFilters.forEach(filter => {
+        expect(filter.path).to.equal(undefined)
+        expect(filter.clause).not.to.equal(undefined)
+        expect(filter.clause.bool.should.length).to.equal(requestBody.filters.subjectLiteral.length)
+      })
     })
     it('can handle packed values', () => {
-      const request = new ApiRequest({ filters: { language: ['spanish', 'finnish'] } })
+      const requestBody = { filters: { language: ['spanish', 'finnish'] } }
+      const request = new ApiRequest(requestBody)
       const mockQueryBuilder = mockQueryBuilderFactory(request)
       const simpleMatchFilters = mockQueryBuilder.buildMatchOperatorFilterQueries(['language'])
+      expect(simpleMatchFilters.length).to.equal(Object.keys(requestBody.filters).length)
+      verifyFilterFields(['language'], simpleMatchFilters)
+      simpleMatchFilters.forEach(filter => {
+        expect(filter.path).to.equal(undefined)
+        expect(filter.clause).not.to.equal(undefined)
+        expect(filter.clause.bool.should.length).to.equal(requestBody.filters.language.length)
+        for (const packedValueShouldTerms in filter.clause.bool.should.bool) {
+          expect(packedValueShouldTerms.length).to.equal(2)
+        }
+      })
       expect(simpleMatchFilters).to.deep.equal([
         {
           path: undefined,

--- a/test/elastic-query-builder.test.js
+++ b/test/elastic-query-builder.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 
 const ElasticQueryBuilder = require('../lib/elasticsearch/elastic-query-builder')
 const ApiRequest = require('../lib/api-request')
-const { FILTER_CONFIG } = require('../lib/elasticsearch/config')
+const { verifyFilterFields } = require('./utils.js')
 
 describe('ElasticQueryBuilder', () => {
   describe('buildFilterClause', () => {
@@ -29,13 +29,6 @@ describe('ElasticQueryBuilder', () => {
       buildMatchOperatorFilterQueries: ElasticQueryBuilder.prototype.buildMatchOperatorFilterQueries,
       buildFilterClause: ElasticQueryBuilder.prototype.buildFilterClause
     })
-    const verifyFilterFields = (filterFields, filterQueryBody) => {
-      const stringedFilters = JSON.stringify(filterQueryBody)
-      const esFields = filterFields.map((filter) => FILTER_CONFIG[filter].field).flat()
-      esFields.forEach((esField) => {
-        expect(stringedFilters.includes(esField)).to.equal(true)
-      })
-    }
     it('can handle (multiple) single value, single match field filters, as arrays', () => {
       const filterFields = ['buildingLocation', 'subjectLiteral']
       const request = new ApiRequest({ filters: { buildingLocation: ['toast'], subjectLiteral: ['spaghetti'] } })

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -237,7 +237,11 @@ describe('Resources query', function () {
       // Expect one agg query for all the properties not involved in a filter:
       expect(Object.keys(queries[0].aggregations)).to.have.lengthOf.at.least(numAggregations - 1)
       expect(queries[0].query.bool.filter).to.be.a('array')
-      expect(queries[0].query.bool.filter[0].terms['subjectLiteral.keywordLowercasedStripped']).to.deep.equal(['S1', 'S1.'])
+      for (const term in queries[0].query.bool.filter[0].terms) {
+        for (const termField in term) {
+          expect(term[termField]).to.deep.equal(['S1', 'S1.'])
+        }
+      }
 
       // Expect second agg query for subjectLiteral - w/out the filter:
       expect(Object.keys(queries[1].aggregations)).to.have.lengthOf(1)

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -3,10 +3,11 @@ const fs = require('fs')
 const sinon = require('sinon')
 const scsbClient = require('../lib/scsb-client')
 const errors = require('../lib/errors')
-const { AGGREGATIONS_SPEC, FILTER_CONFIG } = require('../lib/elasticsearch/config')
+const { AGGREGATIONS_SPEC } = require('../lib/elasticsearch/config')
 const numAggregations = Object.keys(AGGREGATIONS_SPEC).length
 
 const fixtures = require('./fixtures')
+const { verifyFilterFields } = require('./utils')
 
 describe('Resources query', function () {
   const resourcesPrivMethods = {}
@@ -141,10 +142,7 @@ describe('Resources query', function () {
       expect(body.query.bool).to.be.a('object')
       expect(body.query.bool.filter).to.be.a('array')
       expect(body.query.bool.filter[0]).to.be.a('object')
-      expect(body.query.bool.filter[0].terms).to.be.a('object')
-      const elasticProperty = FILTER_CONFIG.subjectLiteral.field
-      expect(body.query.bool.filter[0].terms[elasticProperty][0]).to.equal('United States -- History')
-      expect(body.query.bool.filter[0].terms[elasticProperty][1]).to.equal('United States -- History.')
+      verifyFilterFields(['subjectLiteral'], JSON.stringify(body))
     })
 
     describe('nyplSource filtering', function () {
@@ -212,22 +210,6 @@ describe('Resources query', function () {
       resourcesPrivMethods.buildElasticBody(params)
 
       expect(JSON.stringify(params)).to.equal(paramsSnapshot)
-    })
-
-    it('injects period matching for *Literal filters', () => {
-      const params = resourcesPrivMethods.parseSearchParams({
-        filters: {
-          subjectLiteral: ['S1'],
-          contributorLiteral: ['C1', 'C2']
-        }
-      })
-
-      const body = resourcesPrivMethods.buildElasticBody(params)
-
-      expect(body.query.bool.filter[0].terms['subjectLiteral.keywordLowercasedStripped']).to.deep.equal(['S1', 'S1.'])
-
-      expect(body.query.bool.filter[1].bool.should[0].bool.should[0].terms['contributorLiteral.keywordLowercased']).to.deep.equal(['C1', 'C1.'])
-      expect(body.query.bool.filter[1].bool.should[1].bool.should[0].terms['contributorLiteral.keywordLowercased']).to.deep.equal(['C2', 'C2.'])
     })
   })
 

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -259,8 +259,8 @@ describe('Resources query', function () {
       // Expect first agg query to include all filters:
       expect(Object.keys(queries[0].aggregations)).to.have.lengthOf(numAggregations - 2)
       expect(queries[0].query.bool.filter).to.be.a('array')
-      // Expect the subjectLiteral filter:
-      expect(queries[0].query.bool.filter[1].terms['subjectLiteral.keywordLowercasedStripped']).to.deep.equal(['S1', 'S1.'])
+      // Expect correct es fields are included in query
+      verifyFilterFields(['collection', 'subjectLiteral'], JSON.stringify(queries))
       // .. And the collection filters:
       expect(queries[0]).to.nested.include({ 'query.bool.filter[0].bool.should[0].term.collectionIds': 'C1' })
       expect(queries[0]).to.nested.include({ 'query.bool.filter[0].bool.should[1].term.collectionIds': 'C2' })

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,8 @@
+const { FILTER_CONFIG } = require('../lib/elasticsearch/config.js')
+exports.verifyFilterFields = (filterFields, filterQueryBody) => {
+  const stringedFilters = JSON.stringify(filterQueryBody)
+  const esFields = filterFields.map((filter) => FILTER_CONFIG[filter].field).flat()
+  esFields.forEach((esField) => {
+    expect(stringedFilters.includes(esField)).to.equal(true)
+  })
+}


### PR DESCRIPTION
Caught thanks to the ever-useful debug query response! 
- added keywordLowercasedStripped to filter and exact match configs
- a bunch of test refactoring that makes the tests harder to read but also hopefully less brittle when we continue to iterate on es field names and filter mappings etc. 