### PR TITLE
collapse cql and filter/search config

### DIFF
--- a/lib/elasticsearch/config.js
+++ b/lib/elasticsearch/config.js
@@ -96,7 +96,7 @@ const FILTER_CONFIG = {
     field: [
       'title.keywordLowercasedStripped',
       'series.keywordLowercasedStripped',
-      'titleAlt.raw',
+      'titleAlt.keywordLowercasedStripped',
       'titleDisplay.keywordLowercasedStripped',
       'contentsTitle.keywordLowercasedStripped',
       // tableOfContents missing

--- a/lib/elasticsearch/config.js
+++ b/lib/elasticsearch/config.js
@@ -91,6 +91,28 @@ const SEARCH_SCOPES = {
 }
 
 const FILTER_CONFIG = {
+  // not an actual filter, this is here to centralize config for CQL
+  title: {
+    field: [
+      'title.keywordLowercasedStripped',
+      'series.keywordLowercasedStripped',
+      'titleAlt.raw',
+      'titleDisplay.keywordLowercasedStripped',
+      'contentsTitle.keywordLowercasedStripped',
+      // tableOfContents missing
+      'donor.keywordLowercasedStripped',
+      'parallelTitle.keywordLowercasedStripped',
+      'parallelTitleDisplay.keywordLowercasedStripped',
+      'parallelTitleAlt.keywordLowercasedStripped',
+      'parallelSeries.keywordLowercasedStripped',
+      'parallelCreatorLiteral.keywordLowercasedStripped',
+      'uniformTitle.keywordLowercasedStripped',
+      'parallelUniformTitle.keywordLowercasedStripped',
+      'formerTitle.keywordLowercasedStripped',
+      'addedAuthorTitle.keywordLowercasedStripped',
+      'placeOfPublication.keywordLowercasedStripped'
+    ]
+  },
   collection: { operator: 'match', field: ['collectionIds'], repeatable: true },
   format: { operator: 'match', field: ['formatId'], repeatable: true },
   recordType: { operator: 'match', field: ['recordTypeId'], repeatable: true },
@@ -102,9 +124,9 @@ const FILTER_CONFIG = {
   materialType: { operator: 'match', field: ['materialType.id', 'materialType.label'], repeatable: true },
   mediaType: { operator: 'match', field: ['mediaType.id', 'mediaType.label'], repeatable: true },
   carrierType: { operator: 'match', field: ['carrierType.id', 'carrierType.label'], repeatable: true },
-  publisher: { operator: 'match', field: ['publisherLiteral.raw'], repeatable: true },
-  contributorLiteral: { operator: 'match', field: ['contributorLiteral.keywordLowercased', 'parallelContributorLiteral.raw', 'creatorLiteral.keywordLowercased', 'parallelCreatorLiteral.raw'], repeatable: true },
-  creatorLiteral: { operator: 'match', field: ['creatorLiteral.raw', 'parallelCreatorLiteral.raw'], repeatable: true },
+  publisher: { operator: 'match', field: ['publisherLiteral.keywordLowercasedStripped'], repeatable: true },
+  contributorLiteral: { operator: 'match', field: ['contributorLiteral.keywordLowercasedStripped', 'parallelContributorLiteral.keywordLowercasedStripped', 'creatorLiteral.keywordLowercasedStripped', 'parallelCreatorLiteral.keywordLowercasedStripped'], repeatable: true },
+  creatorLiteral: { operator: 'match', field: ['creatorLiteral.keywordLowercasedStripped', 'parallelCreatorLiteral.keywordLowercasedStripped'], repeatable: true },
   issuance: { operator: 'match', field: ['issuance.id', 'issuance.label'], repeatable: true },
   createdYear: { operator: 'match', field: ['createdYear'], repeatable: true },
   dateAfter: {
@@ -115,11 +137,11 @@ const FILTER_CONFIG = {
     operator: 'custom',
     type: 'int'
   },
-  genreForm: { operator: 'match', field: ['genreForm.raw'], repeatable: true },
-  donor: { operator: 'match', field: ['donor.raw'], repeatable: true },
-  titleAlt: { operator: 'match', field: ['titleAlt.raw', 'parallelTitleAlt.raw'], repeatable: true },
-  uniformTitle: { operator: 'match', field: ['uniformTitle.raw', 'parallelUniformTitle.raw'], repeatable: true },
-  addedAuthorTitle: { operator: 'match', field: ['addedAuthorTitle.raw', 'parallelAddedAuthorTitle.raw'], repeatable: true },
+  genreForm: { operator: 'match', field: ['genreForm.keywordLowercasedStripped'], repeatable: true },
+  donor: { operator: 'match', field: ['donor.keywordLowercasedStripped'], repeatable: true },
+  titleAlt: { operator: 'match', field: ['titleAlt.keywordLowercasedStripped', 'parallelTitleAlt.keywordLowercasedStripped'], repeatable: true },
+  uniformTitle: { operator: 'match', field: ['uniformTitle.keywordLowercasedStripped', 'parallelUniformTitle.keywordLowercasedStripped'], repeatable: true },
+  addedAuthorTitle: { operator: 'match', field: ['addedAuthorTitle.keywordLowercasedStripped', 'parallelAddedAuthorTitle.keywordLowercasedStripped'], repeatable: true },
   series: { operator: 'match', field: ['series.keywordLowercasedStripped', 'parallelSeries.keywordLowercasedStripped', 'seriesUniformTitle.keywordLowercasedStripped', 'parallelSeriesUniformTitle.keywordLowercasedStripped', 'seriesAddedEntry.keywordLowercasedStripped', 'parallelSeriesAddedEntry.keywordLowercasedStripped'], repeatable: true },
   placeOfPublication: { operator: 'match', field: ['placeOfPublication.keywordLowercasedStripped', 'parallelPlaceOfPublication.keywordLowercasedStripped'], repeatable: true },
   dateFrom: {

--- a/lib/elasticsearch/config.js
+++ b/lib/elasticsearch/config.js
@@ -4,7 +4,8 @@ const SEARCH_SCOPES = {
     fields: [
       'title^20',
       'title.folded^10',
-      'description.foldedStemmed',
+      'summary.foldedStemmed',
+      'parallelSummary.foldedStemmed',
       'subjectLiteral^2',
       'subjectLiteral.folded',
       'creatorLiteral^2',

--- a/lib/elasticsearch/cql/index-mapping.js
+++ b/lib/elasticsearch/cql/index-mapping.js
@@ -1,115 +1,26 @@
+const { FILTER_CONFIG, SEARCH_SCOPES } = require('../config')
+
+const combinedFilterFields = (fields) => {
+  fields.map((filterName) => FILTER_CONFIG[filterName].field).flat()]
+}
+
 const indexMapping = {
   keyword: {
-    fields: [
-      'title',
-      'title.folded',
-      'description.foldedStemmed',
-      'subjectLiteral',
-      'subjectLiteral.folded',
-      'creatorLiteral',
-      'creatorLiteral.folded',
-      'contributorLiteral.folded',
-      'note.label.foldedStemmed',
-      'publisherLiteral.folded',
-      'series.folded',
-      'titleAlt.folded',
-      'titleDisplay.folded',
-      'contentsTitle.folded',
-      'tableOfContents.folded',
-      'genreForm',
-      'donor.folded',
-      'parallelTitle.folded',
-      'parallelTitleDisplay.folded',
-      'parallelTitleAlt.folded',
-      'parallelSeries.folded',
-      'parallelCreatorLiteral.folded',
-      'parallelPublisher',
-      'parallelPublisherLiteral',
-      'uniformTitle.folded',
-      'parallelUniformTitle',
-      'formerTitle',
-      'addedAuthorTitle',
-      'placeOfPublication.folded',
-      // Try to detect shelfmark searches (e.g. JFD 16-5143)
-      { field: 'items.shelfMark', on: (q) => /^[A-Z]{1,3} \d{2,}/.test(q) }
-    ],
-    exact_fields: [
-      'title.keywordLowercasedStripped',
-      // missing description
-      'subjectLiteral.keywordLowercasedStripped',
-      'creatorLiteral.keywordLowercased',
-      'contributorLiteral.keywordLowercased',
-      // note.label is missing
-      'publisherLiteral.raw',
-      'series.keywordLowercasedStripped',
-      'titleAlt.raw',
-      // titleDisplay missing
-      // contentsTitle missing
-      // tableOfContents missing
-      'genreForm.raw',
-      'donor.raw',
-      // parallelTitle missing
-      // parallelTitleDisplay missing
-      'parallelTitleAlt.raw',
-      'parallelSeries.keywordLowercasedStripped',
-      'parallelCreatorLiteral.raw',
-      // parallelPublisher/parallelPublisherLiteral missing
-      'uniformTitle.raw',
-      'parallelUniformTitle.raw',
-      // formerTitle missing
-      'addedAuthorTitle.raw',
-      'placeOfPublication.keywordLowercasedStripped',
-      { field: 'items.shelfMark.raw', on: (q) => /^[A-Z]{1,3} \d{2,}/.test(q) }
-    ],
+    fields: SEARCH_SCOPES.all.fields,
+    exact_fields:
+      [{ field: 'items.shelfMark.raw', on: (q) => /^[A-Z]{1,3} \d{2,}/.test(q) },
+      ...combinedFilterFields(['title', 'subjectLiteral', 'publisher', 'genreForm', 'series', 'placeOfPublication', 'donor', 'contributorLiteral'])],
     term: [
       { field: 'items.idBarcode', on: (q) => /\d{6,}/.test(q) }
     ]
   },
   title: {
-    fields: [
-      'title',
-      'title.folded',
-      'titleAlt.folded',
-      'uniformTitle.folded',
-      'titleDisplay.folded',
-      'series.folded',
-      'contentsTitle.folded',
-      'donor.folded',
-      'parallelTitle.folded',
-      'parallelTitleDisplay.folded',
-      'parallelSeries.folded',
-      'parallelTitleAlt.folded',
-      'parallelCreatorLiteral.folded',
-      'parallelUniformTitle',
-      'formerTitle',
-      'addedAuthorTitle'
-    ],
-    exact_fields: [
-      'title.keywordLowercasedStripped',
-      'series.keywordLowercasedStripped',
-      'titleAlt.raw',
-      // titleDisplay missing
-      // contentsTitle missing
-      // tableOfContents missing
-      'donor.raw',
-      // parallelTitle missing
-      // parallelTitleDisplay missing
-      'parallelTitleAlt.raw',
-      'parallelSeries.keywordLowercasedStripped',
-      'parallelCreatorLiteral.raw',
-      'uniformTitle.raw',
-      'parallelUniformTitle.raw',
-      // formerTitle missing
-      'addedAuthorTitle.raw',
-      'placeOfPublication.keywordLowercasedStripped'
-    ]
+    fields: SEARCH_SCOPES.title.fields,
+    exact_fields: FILTER_CONFIG.title.field
   },
   author: {
-    fields: ['creatorLiteral', 'creatorLiteral.folded', 'contributorLiteral.folded', 'parallelCreatorLiteral.folded', 'parallelContributorLiteral.folded'],
-    exact_fields: [
-      'creatorLiteral.keywordLowercased', 'contributorLiteral.keywordLowercased',
-      'parallelCreatorLiteral.raw', 'parallelContributorLiteral.raw'
-    ]
+    fields: SEARCH_SCOPES.contributor.fields,
+    exact_fields: FILTER_CONFIG.contributorLiteral.field
   },
   callnumber: {
     fields: ['shelfMark', 'items.shelfMark'],
@@ -120,28 +31,16 @@ const indexMapping = {
     term: ['uri', 'items.idBarcode', 'idIsbn.clean', 'idIssn.clean']
   },
   subject: {
-    fields: ['subjectLiteral', 'subjectLiteral.folded', 'parallelSubjectLiteral.folded'],
-    exact_fields: ['subjectLiteral.raw']
+    fields: SEARCH_SCOPES.subject.fields,
+    exact_fields: FILTER_CONFIG.subjectLiteral.field
   },
   language: { term: ['language.id', 'language.label'] },
   date: { fields: ['dates.range'] },
   series: {
-    fields: [
-      'series.folded',
-      'parallelSeries.folded',
-      'parallelSeriesUniformTitle.folded',
-      'parallelSeriesAddedEntry.folded'
-    ],
-    exact_fields: [
-      'series',
-      'parallelSeries',
-      'seriesUniformTitle',
-      'parallelSeriesUniformTitle',
-      'seriesAddedEntry',
-      'parallelSeriesAddedEntry'
-    ]
+    fields: SEARCH_SCOPES.series.fields,
+    exact_fields: FILTER_CONFIG.series.field
   },
-  genre: { fields: ['genreForm', 'genreForm.folded'], exact_fields: ['genreForm.raw'] },
+  genre: { fields: SEARCH_SCOPES.genre.fields, exact_fields: FILTER_CONFIG.genreForm.field },
   center: { term: ['buildingLocationIds'] },
   division: { term: ['collectionIds'] },
   format: { term: ['formatId'] }

--- a/lib/elasticsearch/cql/index-mapping.js
+++ b/lib/elasticsearch/cql/index-mapping.js
@@ -1,7 +1,7 @@
 const { FILTER_CONFIG, SEARCH_SCOPES } = require('../config')
 
 const combinedFilterFields = (fields) => {
-  fields.map((filterName) => FILTER_CONFIG[filterName].field).flat()]
+  return fields.map((filterName) => FILTER_CONFIG[filterName].field).flat()
 }
 
 const indexMapping = {
@@ -9,7 +9,7 @@ const indexMapping = {
     fields: SEARCH_SCOPES.all.fields,
     exact_fields:
       [{ field: 'items.shelfMark.raw', on: (q) => /^[A-Z]{1,3} \d{2,}/.test(q) },
-      ...combinedFilterFields(['title', 'subjectLiteral', 'publisher', 'genreForm', 'series', 'placeOfPublication', 'donor', 'contributorLiteral'])],
+        ...combinedFilterFields(['title', 'subjectLiteral', 'publisher', 'genreForm', 'series', 'placeOfPublication', 'donor', 'contributorLiteral'])],
     term: [
       { field: 'items.idBarcode', on: (q) => /\d{6,}/.test(q) }
     ]

--- a/test/cql_es_queries.js
+++ b/test/cql_es_queries.js
@@ -383,7 +383,16 @@ const keywordQueryForBarcode = {
                 path: 'items',
                 query: {
                   bool: {
-                    should: [{ term: { 'items.idBarcode': '123456' } }]
+                    should: [
+                      {
+                        multi_match: {
+                          fields: [
+                            'items.idBarcode'
+                          ],
+                          query: '123456',
+                          type: 'phrase'
+                        }
+                      }, { term: { 'items.idBarcode': '123456' } }]
                   }
                 }
               }
@@ -1134,13 +1143,7 @@ const filterQuery = {
                   {
                     multi_match: {
                       query: 'Shakespeare',
-                      fields: [
-                        'creatorLiteral',
-                        'creatorLiteral.folded',
-                        'contributorLiteral.folded',
-                        'parallelCreatorLiteral.folded',
-                        'parallelContributorLiteral.folded'
-                      ],
+                      fields: SEARCH_SCOPES.contributor.fields,
                       type: 'phrase'
                     }
                   }

--- a/test/cql_es_queries.js
+++ b/test/cql_es_queries.js
@@ -1,3 +1,5 @@
+const { SEARCH_SCOPES } = require('../lib/elasticsearch/config')
+
 const simpleAdjQuery = {
   bool: {
     must: [
@@ -10,24 +12,7 @@ const simpleAdjQuery = {
                   {
                     multi_match: {
                       query: 'Hamlet',
-                      fields: [
-                        'title',
-                        'title.folded',
-                        'titleAlt.folded',
-                        'uniformTitle.folded',
-                        'titleDisplay.folded',
-                        'series.folded',
-                        'contentsTitle.folded',
-                        'donor.folded',
-                        'parallelTitle.folded',
-                        'parallelTitleDisplay.folded',
-                        'parallelSeries.folded',
-                        'parallelTitleAlt.folded',
-                        'parallelCreatorLiteral.folded',
-                        'parallelUniformTitle',
-                        'formerTitle',
-                        'addedAuthorTitle'
-                      ],
+                      fields: SEARCH_SCOPES.title.fields,
                       type: 'phrase'
                     }
                   }
@@ -53,24 +38,7 @@ const multiAdjQuery = {
                   {
                     multi_match: {
                       query: 'Hamlet, Prince',
-                      fields: [
-                        'title',
-                        'title.folded',
-                        'titleAlt.folded',
-                        'uniformTitle.folded',
-                        'titleDisplay.folded',
-                        'series.folded',
-                        'contentsTitle.folded',
-                        'donor.folded',
-                        'parallelTitle.folded',
-                        'parallelTitleDisplay.folded',
-                        'parallelSeries.folded',
-                        'parallelTitleAlt.folded',
-                        'parallelCreatorLiteral.folded',
-                        'parallelUniformTitle',
-                        'formerTitle',
-                        'addedAuthorTitle'
-                      ],
+                      fields: SEARCH_SCOPES.title.fields,
                       type: 'phrase'
                     }
                   }
@@ -173,24 +141,7 @@ const simpleAnyQuery = {
                         {
                           multi_match: {
                             query: 'Hamlet',
-                            fields: [
-                              'title',
-                              'title.folded',
-                              'titleAlt.folded',
-                              'uniformTitle.folded',
-                              'titleDisplay.folded',
-                              'series.folded',
-                              'contentsTitle.folded',
-                              'donor.folded',
-                              'parallelTitle.folded',
-                              'parallelTitleDisplay.folded',
-                              'parallelSeries.folded',
-                              'parallelTitleAlt.folded',
-                              'parallelCreatorLiteral.folded',
-                              'parallelUniformTitle',
-                              'formerTitle',
-                              'addedAuthorTitle'
-                            ],
+                            fields: SEARCH_SCOPES.title.fields,
                             type: 'cross_fields'
                           }
                         }
@@ -203,24 +154,7 @@ const simpleAnyQuery = {
                         {
                           multi_match: {
                             query: 'Othello',
-                            fields: [
-                              'title',
-                              'title.folded',
-                              'titleAlt.folded',
-                              'uniformTitle.folded',
-                              'titleDisplay.folded',
-                              'series.folded',
-                              'contentsTitle.folded',
-                              'donor.folded',
-                              'parallelTitle.folded',
-                              'parallelTitleDisplay.folded',
-                              'parallelSeries.folded',
-                              'parallelTitleAlt.folded',
-                              'parallelCreatorLiteral.folded',
-                              'parallelUniformTitle',
-                              'formerTitle',
-                              'addedAuthorTitle'
-                            ],
+                            fields: SEARCH_SCOPES.title.fields,
                             type: 'cross_fields'
                           }
                         }
@@ -395,24 +329,7 @@ const simpleAllQuery = {
                         {
                           multi_match: {
                             query: 'Hamlet',
-                            fields: [
-                              'title',
-                              'title.folded',
-                              'titleAlt.folded',
-                              'uniformTitle.folded',
-                              'titleDisplay.folded',
-                              'series.folded',
-                              'contentsTitle.folded',
-                              'donor.folded',
-                              'parallelTitle.folded',
-                              'parallelTitleDisplay.folded',
-                              'parallelSeries.folded',
-                              'parallelTitleAlt.folded',
-                              'parallelCreatorLiteral.folded',
-                              'parallelUniformTitle',
-                              'formerTitle',
-                              'addedAuthorTitle'
-                            ],
+                            fields: SEARCH_SCOPES.title.fields,
                             type: 'cross_fields'
                           }
                         }
@@ -425,24 +342,7 @@ const simpleAllQuery = {
                         {
                           multi_match: {
                             query: 'Othello',
-                            fields: [
-                              'title',
-                              'title.folded',
-                              'titleAlt.folded',
-                              'uniformTitle.folded',
-                              'titleDisplay.folded',
-                              'series.folded',
-                              'contentsTitle.folded',
-                              'donor.folded',
-                              'parallelTitle.folded',
-                              'parallelTitleDisplay.folded',
-                              'parallelSeries.folded',
-                              'parallelTitleAlt.folded',
-                              'parallelCreatorLiteral.folded',
-                              'parallelUniformTitle',
-                              'formerTitle',
-                              'addedAuthorTitle'
-                            ],
+                            fields: SEARCH_SCOPES.title.fields,
                             type: 'cross_fields'
                           }
                         }
@@ -471,37 +371,7 @@ const keywordQueryForBarcode = {
                   {
                     multi_match: {
                       query: '123456',
-                      fields: [
-                        'title',
-                        'title.folded',
-                        'description.foldedStemmed',
-                        'subjectLiteral',
-                        'subjectLiteral.folded',
-                        'creatorLiteral',
-                        'creatorLiteral.folded',
-                        'contributorLiteral.folded',
-                        'note.label.foldedStemmed',
-                        'publisherLiteral.folded',
-                        'series.folded',
-                        'titleAlt.folded',
-                        'titleDisplay.folded',
-                        'contentsTitle.folded',
-                        'tableOfContents.folded',
-                        'genreForm',
-                        'donor.folded',
-                        'parallelTitle.folded',
-                        'parallelTitleDisplay.folded',
-                        'parallelTitleAlt.folded',
-                        'parallelSeries.folded',
-                        'parallelCreatorLiteral.folded',
-                        'parallelPublisher',
-                        'parallelPublisherLiteral',
-                        'uniformTitle.folded',
-                        'parallelUniformTitle',
-                        'formerTitle',
-                        'addedAuthorTitle',
-                        'placeOfPublication.folded'
-                      ],
+                      fields: SEARCH_SCOPES.all.fields.filter(field => typeof field === 'string'),
                       type: 'phrase'
                     }
                   }
@@ -537,37 +407,7 @@ const keywordQueryForShelfMark = {
                   {
                     multi_match: {
                       query: 'B 12',
-                      fields: [
-                        'title',
-                        'title.folded',
-                        'description.foldedStemmed',
-                        'subjectLiteral',
-                        'subjectLiteral.folded',
-                        'creatorLiteral',
-                        'creatorLiteral.folded',
-                        'contributorLiteral.folded',
-                        'note.label.foldedStemmed',
-                        'publisherLiteral.folded',
-                        'series.folded',
-                        'titleAlt.folded',
-                        'titleDisplay.folded',
-                        'contentsTitle.folded',
-                        'tableOfContents.folded',
-                        'genreForm',
-                        'donor.folded',
-                        'parallelTitle.folded',
-                        'parallelTitleDisplay.folded',
-                        'parallelTitleAlt.folded',
-                        'parallelSeries.folded',
-                        'parallelCreatorLiteral.folded',
-                        'parallelPublisher',
-                        'parallelPublisherLiteral',
-                        'uniformTitle.folded',
-                        'parallelUniformTitle',
-                        'formerTitle',
-                        'addedAuthorTitle',
-                        'placeOfPublication.folded'
-                      ],
+                      fields: SEARCH_SCOPES.all.fields.filter(field => typeof field === 'string'),
                       type: 'phrase'
                     }
                   }
@@ -611,37 +451,7 @@ const keywordQueryForGeneralTerm = {
                   {
                     multi_match: {
                       query: 'Hamlet',
-                      fields: [
-                        'title',
-                        'title.folded',
-                        'description.foldedStemmed',
-                        'subjectLiteral',
-                        'subjectLiteral.folded',
-                        'creatorLiteral',
-                        'creatorLiteral.folded',
-                        'contributorLiteral.folded',
-                        'note.label.foldedStemmed',
-                        'publisherLiteral.folded',
-                        'series.folded',
-                        'titleAlt.folded',
-                        'titleDisplay.folded',
-                        'contentsTitle.folded',
-                        'tableOfContents.folded',
-                        'genreForm',
-                        'donor.folded',
-                        'parallelTitle.folded',
-                        'parallelTitleDisplay.folded',
-                        'parallelTitleAlt.folded',
-                        'parallelSeries.folded',
-                        'parallelCreatorLiteral.folded',
-                        'parallelPublisher',
-                        'parallelPublisherLiteral',
-                        'uniformTitle.folded',
-                        'parallelUniformTitle',
-                        'formerTitle',
-                        'addedAuthorTitle',
-                        'placeOfPublication.folded'
-                      ],
+                      fields: SEARCH_SCOPES.all.fields.filter(field => typeof field === 'string'),
                       type: 'phrase'
                     }
                   }
@@ -710,13 +520,7 @@ const binaryBooleanQuery = {
                         {
                           multi_match: {
                             query: 'Shakespeare',
-                            fields: [
-                              'creatorLiteral',
-                              'creatorLiteral.folded',
-                              'contributorLiteral.folded',
-                              'parallelCreatorLiteral.folded',
-                              'parallelContributorLiteral.folded'
-                            ],
+                            fields: SEARCH_SCOPES.contributor.fields,
                             type: 'phrase'
                           }
                         }
@@ -817,13 +621,7 @@ const ternaryBooleanQuery = {
                               {
                                 multi_match: {
                                   query: 'Shakespeare',
-                                  fields: [
-                                    'creatorLiteral',
-                                    'creatorLiteral.folded',
-                                    'contributorLiteral.folded',
-                                    'parallelCreatorLiteral.folded',
-                                    'parallelContributorLiteral.folded'
-                                  ],
+                                  fields: SEARCH_SCOPES.contributor.fields,
                                   type: 'phrase'
                                 }
                               }
@@ -927,7 +725,7 @@ const ternaryBooleanQuery = {
                         {
                           multi_match: {
                             query: 'tragedy',
-                            fields: ['genreForm', 'genreForm.folded'],
+                            fields: SEARCH_SCOPES.genre.fields,
                             type: 'phrase'
                           }
                         }

--- a/test/cql_query_builder.test.js
+++ b/test/cql_query_builder.test.js
@@ -15,7 +15,6 @@ const {
   identifierQuery,
   binaryBooleanQuery,
   ternaryBooleanQuery,
-  queryWithParentheses,
   dateBeforeQuery,
   dateBeforeOrOnQuery,
   dateAfterQuery,
@@ -159,13 +158,25 @@ describe('CQL Query Builder', function () {
   })
 
   it('Boolean query with parentheses', function () {
-    expect(new CqlQuery('author = "Shakespeare" AND (language = "English" OR genre = "tragedy")').buildEsQuery())
-      .to.deep.equal(
-        queryWithParentheses
-      )
+    const queryWithParentheses = new CqlQuery('author = "Shakespeare" AND (language = "English" OR genre = "tragedy")').buildEsQuery()
+    const musts = queryWithParentheses.bool.must[0].bool.must
+    // one must for each top level clause
+    expect(musts.length).to.equal(2)
+    const multiMatch = musts[0].bool.should[0].bool.should[0].multi_match
+    expect(multiMatch.query).to.equal('Shakespeare')
+    expect(multiMatch.fields).to.have.members(SEARCH_SCOPES.contributor.fields)
+    expect(multiMatch.type).to.equal('phrase')
+    const languageClauses = musts[1].bool.should[0].bool.should[0].bool.must[0].bool.should
+    // expect all relevant ids for english language to be present
+    expect(languageClauses.length).to.equal(4)
+    expect(languageClauses.every(isValidLanguageQuery))
+    const genreClause = musts[1].bool.should[1].bool.should[0].bool.should[0].multi_match
+    expect(genreClause.query).to.equal('tragedy')
+    expect(genreClause.fields).to.have.members(SEARCH_SCOPES.genre.fields)
+    expect(genreClause.type).to.equal('phrase')
   })
 
-  it('Boolean parenthesis and whitespace are ignored', function () {
+  it('whitespace is ignored with parens', function () {
     expect(new CqlQuery('  author = "Shakespeare"   AND ( language = "English" OR genre = "tragedy" )  ').buildEsQuery())
       .to.deep.equal(
         new CqlQuery('author = "Shakespeare" AND (language = "English" OR genre = "tragedy")').buildEsQuery()

--- a/test/cql_query_builder.test.js
+++ b/test/cql_query_builder.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai')
 
 const { CqlQuery } = require('../lib/elasticsearch/cql_query_builder')
-const ApiRequest = require('../lib/api-request')
+// const ApiRequest = require('../lib/api-request')
 const { InvalidParameterError } = require('../lib/errors')
 const ControlledVocabularies = require('../lib/models/ControlledVocabularies')
 const vocabFixture = require('./fixtures/controlledVocabularies.json')
@@ -9,8 +9,6 @@ const {
   simpleAdjQuery,
   simpleAnyQuery,
   simpleAllQuery,
-  prefixPhraseQuery,
-  anyWithPrefixQuery,
   keywordQueryForBarcode,
   keywordQueryForShelfMark,
   keywordQueryForGeneralTerm,
@@ -18,21 +16,24 @@ const {
   binaryBooleanQuery,
   ternaryBooleanQuery,
   queryWithParentheses,
-  negationQuery,
   dateBeforeQuery,
   dateBeforeOrOnQuery,
   dateAfterQuery,
   dateAfterOrOnQuery,
   dateWithinQuery,
   dateEnclosesQuery,
-  filterQuery,
   multiAdjQuery,
-  exactMatchQuery,
   divisionAdj,
   divisionAll,
   divisionAny,
   divisionExact
 } = require('./cql_es_queries')
+const { FILTER_CONFIG, SEARCH_SCOPES } = require('../lib/elasticsearch/config')
+
+const isValidLanguageQuery = (clause) => {
+  const hasIdAndLabelTerms = ({ term }) => expect(Object.keys(term)).to.have.members(['language.id', 'language.label'])
+  clause.bool.should.every(should => should.length === 2 && should.every(hasIdAndLabelTerms))
+}
 
 describe('CQL Query Builder', function () {
   before(() => {
@@ -89,17 +90,30 @@ describe('CQL Query Builder', function () {
   })
 
   it('Prefix phrase query', function () {
-    expect(new CqlQuery('title = "^The Tragedy of Hamlet, Prince of Denmark"').buildEsQuery())
-      .to.deep.equal(
-        prefixPhraseQuery
-      )
+    const prefixPhraseQuery = new CqlQuery('title = "^The Tragedy of Hamlet, Prince of Denmark"').buildEsQuery()
+    // expect a prefix should clause for every field in filter_config
+    const shoulds = prefixPhraseQuery.bool.must[0].bool.should[0].bool.should
+    expect(shoulds.map(({ prefix }) => Object.keys(prefix)).flat()).to.have.members(FILTER_CONFIG.title.field)
   })
 
   it('Prefix queries mixed into any query', function () {
-    expect(new CqlQuery('title any "^Tragedy ^Comedy Hamlet Othello"').buildEsQuery())
-      .to.deep.equal(
-        anyWithPrefixQuery
-      )
+    const anyWithPrefixQuery = new CqlQuery('title any "^Tragedy ^Comedy Hamlet Othello"')
+    const queryBody = anyWithPrefixQuery.buildEsQuery()
+    // one upper level should for every token
+    const topLevelShoulds = queryBody.bool.must[0].bool.should[0].bool.should
+    expect(topLevelShoulds.length).to.equal(4)
+    topLevelShoulds.forEach((queryPerToken, i) => {
+      const innerShoulds = queryPerToken.bool.should
+      if (i < 2) {
+        // individual prefix queries per field
+        expect(innerShoulds.map(({ prefix }) => Object.keys(prefix)).flat()).to.have.members(FILTER_CONFIG.title.field)
+      }
+      if (i > 1) {
+        // single multi match query on text fields
+        expect(innerShoulds.length).to.equal(1)
+        expect(innerShoulds[0].multi_match.fields).to.have.members(SEARCH_SCOPES.title.fields)
+      }
+    })
   })
 
   it('Keyword query for barcode', function () {
@@ -151,25 +165,32 @@ describe('CQL Query Builder', function () {
       )
   })
 
-  it('Boolean query with parentheses and whitespace', function () {
+  it('Boolean parenthesis and whitespace are ignored', function () {
     expect(new CqlQuery('  author = "Shakespeare"   AND ( language = "English" OR genre = "tragedy" )  ').buildEsQuery())
       .to.deep.equal(
-        queryWithParentheses
+        new CqlQuery('author = "Shakespeare" AND (language = "English" OR genre = "tragedy")').buildEsQuery()
       )
+  })
+
+  it('AND and AND NOT are equivalent', () => {
+    const NOT = new CqlQuery('author = "Shakespeare" NOT language = "English"').buildEsQuery()
+    const AND_NOT = new CqlQuery('author = "Shakespeare" AND NOT language = "English"').buildEsQuery()
+    expect(NOT).to.deep.equal(AND_NOT)
   })
 
   it('Query with NOT', function () {
-    expect(new CqlQuery('author = "Shakespeare" NOT language = "English"').buildEsQuery())
-      .to.deep.equal(
-        negationQuery
-      )
-  })
-
-  it('Query with AND NOT', function () {
-    expect(new CqlQuery('author = "Shakespeare" AND NOT language = "English"').buildEsQuery())
-      .to.deep.equal(
-        negationQuery
-      )
+    const negationQuery = new CqlQuery('author = "Shakespeare" NOT language = "English"').buildEsQuery()
+    const outerMusts = negationQuery.bool.must[0].bool.must
+    const outerMustNot = negationQuery.bool.must[0].bool.must_not
+    // expect a must for both queries
+    expect(outerMusts.length).to.equal(1)
+    expect(outerMustNot.length).to.equal(1)
+    const authorClause = outerMusts[0]
+    expect(authorClause.bool.should[0].bool.should[0].multi_match.fields).to.have.members(SEARCH_SCOPES.contributor.fields)
+    const languageClauses = outerMustNot[0].bool.should[0].bool.must[0].bool.should
+    // expect all relevant ids for english language to be present
+    expect(languageClauses.length).to.equal(4)
+    expect(languageClauses.every(isValidLanguageQuery))
   })
 
   it('Date after query', function () {
@@ -221,25 +242,27 @@ describe('CQL Query Builder', function () {
   })
 
   it('Query with applied filters', function () {
-    const apiRequest = new ApiRequest({ filters: { language: ['Klingon'] }, search_scope: 'cql' })
-    expect(new CqlQuery('author="Shakespeare"').buildEsQuery(apiRequest))
-      .to.deep.equal(
-        filterQuery
-      )
+    // const apiRequest = new ApiRequest({ filters: { language: ['Klingon'] }, search_scope: 'cql' })
+    // const filterQuery = new CqlQuery('author="Shakespeare"').buildEsQuery(apiRequest)
   })
 
   it('Exact match query', function () {
-    expect(new CqlQuery('author == "William Shakespeare"').buildEsQuery())
-      .to.deep.equal(
-        exactMatchQuery
-      )
+    const exactMatchQuery = new CqlQuery('author == "William Shakespeare"').buildEsQuery()
+    const shoulds = exactMatchQuery.bool.must[0].bool.should[0].bool.should
+    // expect a term should clause for every field in filter_config
+    expect(shoulds.map(({ term }) => Object.keys(term)).flat()).to.have.members(FILTER_CONFIG.contributorLiteral.field)
   })
 
   it('Handles query with funny casing', function () {
-    expect(new CqlQuery('AuThOr = "Shakespeare" aNd LaNgUaGe = "English"').buildEsQuery())
-      .to.deep.equal(
-        binaryBooleanQuery
-      )
+    const binaryBooleanQuery = new CqlQuery('AuThOr = "Shakespeare" aNd LaNgUaGe = "English"').buildEsQuery()
+    const outerMusts = binaryBooleanQuery.bool.must[0].bool.must
+    // expect a must for both queries
+    expect(outerMusts.length).to.equal(2)
+    const authorClause = outerMusts[0]
+    expect(authorClause.bool.should[0].bool.should[0].multi_match.fields).to.have.members(SEARCH_SCOPES.contributor.fields)
+    const languageClauses = outerMusts[1].bool.should[0].bool.must[0].bool.should
+    // expect all relevant ids for english language to be present
+    expect(languageClauses.length).to.equal(4)
   })
 
   describe('displayParsed', function () {

--- a/test/cql_query_builder.test.js
+++ b/test/cql_query_builder.test.js
@@ -1,11 +1,12 @@
 const { expect } = require('chai')
 
 const { CqlQuery } = require('../lib/elasticsearch/cql_query_builder')
-// const ApiRequest = require('../lib/api-request')
+const ApiRequest = require('../lib/api-request')
 const { InvalidParameterError } = require('../lib/errors')
 const ControlledVocabularies = require('../lib/models/ControlledVocabularies')
 const vocabFixture = require('./fixtures/controlledVocabularies.json')
 const {
+  filterQuery,
   simpleAdjQuery,
   simpleAnyQuery,
   simpleAllQuery,
@@ -253,8 +254,9 @@ describe('CQL Query Builder', function () {
   })
 
   it('Query with applied filters', function () {
-    // const apiRequest = new ApiRequest({ filters: { language: ['Klingon'] }, search_scope: 'cql' })
-    // const filterQuery = new CqlQuery('author="Shakespeare"').buildEsQuery(apiRequest)
+    const apiRequest = new ApiRequest({ filters: { language: ['Klingon'] }, search_scope: 'cql' })
+    const theThing = new CqlQuery('author="Shakespeare"').buildEsQuery(apiRequest)
+    expect(theThing).to.deep.equal(filterQuery)
   })
 
   it('Exact match query', function () {

--- a/test/elastic-query-builder.test.js
+++ b/test/elastic-query-builder.test.js
@@ -295,15 +295,6 @@ describe('ElasticQueryBuilder', () => {
         .include({ 'bool.filter[0].term.buildingLocationIds': 'ma' })
     })
 
-    it('applies genre filter to query', () => {
-      const request = new ApiRequest({ q: 'toast', filters: { genreForm: 'Maps' } })
-      const inst = ElasticQueryBuilder.forApiRequest(request)
-
-      // Expect the top level bool to now have a `filter` prop with the genreForm filter:
-      expect(inst.query.toJson()).to.nested
-        .include({ 'bool.filter[0].term.genreForm\\.raw': 'Maps' })
-    })
-
     it('supports contributor + role', () => {
       const request = new ApiRequest({ q: '', role: 'performer.', filters: { contributorLiteral: 'Patinkin, Mandy' } })
       const inst = ElasticQueryBuilder.forApiRequest(request)

--- a/test/fixtures/query-0d3d2d6b3f75eab9ef6a04dd89a1e098.json
+++ b/test/fixtures/query-0d3d2d6b3f75eab9ef6a04dd89a1e098.json
@@ -1,0 +1,14948 @@
+{
+  "took": 2710,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1517,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b11361121",
+        "_score": 3989.9512,
+        "_source": {
+          "extent": [
+            "191 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "editionStatement": [
+            "Wyd. 3."
+          ],
+          "publisherLiteral": [
+            "Wydawnictwo Literackie"
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*QPM 90-2088"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1974
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*QPM 90-2088"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11361121"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG89-B29663"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1369053"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779330618050,
+          "publicationStatement": [
+            "Krakow : Wydawnictwo Literackie, 1974."
+          ],
+          "identifier": [
+            "urn:shelfmark:*QPM 90-2088",
+            "urn:bnum:11361121",
+            "urn:oclc:NYPG89-B29663",
+            "urn:identifier:(WaOLN)nyp1369053"
+          ],
+          "creators_displayPacked": [
+            "Hen, Józef||Hen, Józef"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1975",
+                "gte": "1974"
+              },
+              "raw": "890428s1974    pl            000 1 pol dcam a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "191 p. ; 19 cm."
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "creatorLiteral": [
+            "Hen, Józef"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "NYPG89-B29663"
+          ],
+          "popularity": 6,
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "titleDisplay": [
+            "Toast / Józef Hen."
+          ],
+          "uri": "b11361121",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Krakow"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          3989.9512,
+          "b11361121"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term title.keywordLowercased",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "term title.keywordLowercasedStripped",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b11361121",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*QPM 90-2088",
+                      "urn:barcode:33433044323693"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*QPM 90-2088",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433044323693",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433044323693"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "*QPM 90-2088"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "*QPM 90-2088"
+                    ],
+                    "shelfMark_sort": "a*QPM 90-002088",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i13172719"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b17982563",
+        "_score": 3989.9512,
+        "_source": {
+          "note": [
+            {
+              "noteType": "Local note",
+              "label": "Artists' Books Collection (NYPL, Print Collection).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Artists' books"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            null
+          ],
+          "parallelSeriesAddedEntry": [],
+          "title": [
+            "Toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "MEMZ (Featheringill) 09-981"
+          ],
+          "createdString": [
+            "    "
+          ],
+          "creatorLiteral": [
+            "Featheringill, Julia"
+          ],
+          "parallelCreators_displayPacked": [],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            null
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "MEMZ (Featheringill) 09-981"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "17982563"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779479300938,
+          "publicationStatement": [
+            "Ithaca, NY: Julia Featheringill, 2001"
+          ],
+          "genreForm": [
+            "Artists' books."
+          ],
+          "identifier": [
+            "urn:shelfmark:MEMZ (Featheringill) 09-981",
+            "urn:bnum:17982563"
+          ],
+          "creators_displayPacked": [
+            "Featheringill, Julia||Featheringill, Julia"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "    "
+          ],
+          "dates": [],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Artists' books."
+          ],
+          "titleDisplay": [
+            "Toast"
+          ],
+          "uri": "b17982563",
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelContributorLiteral": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "collectionIds": [
+            "mau"
+          ],
+          "placeOfPublication": [
+            "Ithaca, NY: Julia Featheringill, 2001"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          3989.9512,
+          "b17982563"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term title.keywordLowercased",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "term title.keywordLowercasedStripped",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b17982563",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:p",
+                        "label": "Permit needed"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:p||Permit needed"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Featheringill%2C+Julia&CallNumber=MEMZ+%28Featheringill%29+09-981&Date=++++&Form=30&Genre=book+non-circ&ItemInfo1=Permit+needed&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db17982563&ItemISxN=i174467412&ItemPlace=Ithaca%2C+NY%3A+Julia+Featheringill%2C+2001&Location=Schwarzman+Prints+and+Photographs+Division&ReferenceNumber=b17982563x&Site=SASPR&Title=Toast"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mauu2",
+                        "label": "Schwarzman Building - Print Collection Room 308"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mauu2||Schwarzman Building - Print Collection Room 308"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:MEMZ (Featheringill) 09-981"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "MEMZ (Featheringill) 09-981",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1112",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Print Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1112||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Print Collection"
+                    ],
+                    "physicalLocation": [
+                      "MEMZ (Featheringill) 09-981"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "MEMZ (Featheringill) 09-981"
+                    ],
+                    "shelfMark_sort": "aMEMZ (Featheringill) 09-000981",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17446741"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b20970375",
+        "_score": 3989.9512,
+        "_source": {
+          "extent": [
+            "119 pages : illustrations (color) ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Phaidon Press Limited"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            2015
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFF 16-815"
+          ],
+          "idLccn": [
+            "2015473840"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2015
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 16-815"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "20970375"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780714869551"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0714869554"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "915941587"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2015473840"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)905521916"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)915941587"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Sung, Evan||Sung, Evan, photographer"
+          ],
+          "updatedAt": 1779503645748,
+          "publicationStatement": [
+            "London : Phaidon Press Limited, 2015.",
+            "©2015"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFF 16-815",
+            "urn:bnum:20970375",
+            "urn:isbn:9780714869551",
+            "urn:isbn:0714869554",
+            "urn:oclc:915941587",
+            "urn:lccn:2015473840",
+            "urn:identifier:(OCoLC)905521916",
+            "urn:identifier:(OCoLC)915941587"
+          ],
+          "creators_displayPacked": [
+            "Pelzel, Raquel||Pelzel, Raquel, author"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2016",
+                "gte": "2015"
+              },
+              "raw": "150323s2015    enka   e      001 0 eng  camIi ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Toast (Bread)"
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "titleAlt": [
+            "Toast : the cookbook"
+          ],
+          "physicalDescription": [
+            "119 pages : illustrations (color) ; 25 cm"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Toast (Bread)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2015"
+          ],
+          "creatorLiteral": [
+            "Pelzel, Raquel"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sung, Evan"
+          ],
+          "idOclc": [
+            "915941587"
+          ],
+          "popularity": 5,
+          "summary": [
+            "The ultimate canvas for sweet and savory culinary creativity. 50 seasonal recipes that reimagine the \"bread and butter\" of cuisine with simple ingredients in surprising ways. Easy enough for breakfast, yet suitable for brunch, lunch, dinner and even dessert, the possibilities of heaping beautiful seasonal ingredients on bread are limitless. Toast guides home chefs as they explore home cuisine's ultimate creative canvas. Organized by season, Toast features 50 recipes from savory to sweet that unleash the power of fresh ingredients and simple techniques guaranteed to impress and satisfy any kitchen audience on any occasion."
+          ],
+          "genreForm": [
+            "Cookbooks."
+          ],
+          "idIsbn": [
+            "9780714869551",
+            "0714869554"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2015"
+          ],
+          "titleDisplay": [
+            "Toast / by Raquel Pelzel ; photographs by Evan Sung."
+          ],
+          "uri": "b20970375",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm"
+          ],
+          "idIsbn_clean": [
+            "9780714869551",
+            "0714869554"
+          ]
+        },
+        "sort": [
+          3989.9512,
+          "b20970375"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term title.keywordLowercased",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "term title.keywordLowercasedStripped",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b20970375",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "dueDate": [
+                      "2025-06-28"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFF 16-815",
+                      "urn:barcode:33433118568447"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 16-815",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433118568447",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433118568447"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "physicalLocation": [
+                      "JFF 16-815"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "JFF 16-815"
+                    ],
+                    "shelfMark_sort": "aJFF 16-000815",
+                    "status": [
+                      {
+                        "id": "status:co",
+                        "label": "Loaned"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:co||Loaned"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i34162229"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b17759113",
+        "_score": 3988.9512,
+        "_source": {
+          "extent": [
+            "1 film reel (12 min.) : sd., col. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "[s.n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1974
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "17759113"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Hoffman, Daniel||Hoffman, Daniel, director",
+            "Earth Chronicles (Firm)||Earth Chronicles (Firm)"
+          ],
+          "updatedAt": 1779477831727,
+          "publicationStatement": [
+            "[S.l.] : [s.n.], 1974."
+          ],
+          "identifier": [
+            "urn:bnum:17759113"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "lt": "1975",
+                "gte": "1974"
+              },
+              "raw": "890428s1974    xx 012            vleng dcgmIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Fuel.",
+            "Energy conservation."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "g",
+          "collectionIds": [
+            "pav"
+          ],
+          "physicalDescription": [
+            "1 film reel (12 min.) : sd., col. ; 16 mm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Originally released as a short film in 1974.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Narration, Michael Ryan ; music, Klaus Schulze, Achim Reichel, Kraftwerk.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Fuel",
+            "Energy conservation"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Hoffman, Daniel",
+            "Earth Chronicles (Firm)"
+          ],
+          "popularity": 1,
+          "summary": [
+            "Focuses on the excessive use of fossil fuels in the preparation and marketing of food by tracing the production and distribution of a loaf of bread from the oil well to consumption. Also illustrates the concept of net energy profit."
+          ],
+          "genreForm": [
+            "Short films.",
+            "Educational films."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mov",
+              "label": "Moving image"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "titleDisplay": [
+            "Toast [motion picture] / Earth Chronicles presents ; a film by Daniel Hoffman ... [et al.]."
+          ],
+          "uri": "b17759113",
+          "parallelContributorLiteral": [
+            null,
+            null
+          ],
+          "recordTypeId": "g",
+          "placeOfPublication": [
+            "[S.l.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 mm."
+          ]
+        },
+        "sort": [
+          3988.9512,
+          "b17759113"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term title.keywordLowercased",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "term title.keywordLowercasedStripped",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b17759113",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:a",
+                        "label": "By appointment only"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:a||By appointment only"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&CallNumber=M16+5213+T+C.1+REEL+1+OF+1&Date=1974&Form=30&Genre=rfvc+-+film&ItemInfo1=By+appointment+only&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db17759113&ItemISxN=i239658231&ItemNumber=33433081452009&ItemPlace=%5BS.l.%5D&ItemPublisher=%5Bs.n.%5D%2C+1974.&ItemVolume=C.1+REEL+1+OF+1&Location=ReCAP&ReferenceNumber=b177591134&Site=LPARF&SubLocation=rcpr8&Title=Toast"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:72",
+                        "label": "rfvc - film"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:72||rfvc - film"
+                    ],
+                    "enumerationChronology": [
+                      "C.1 REEL 1 OF 1"
+                    ],
+                    "enumerationChronology_sort": "      9999-",
+                    "formatLiteral": [
+                      "Film, slide, etc."
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpr8",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpr8||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:M16 5213 T C.1 REEL 1 OF 1",
+                      "urn:barcode:33433081452009"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M16 5213 T C.1 REEL 1 OF 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433081452009",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433081452009"
+                    ],
+                    "physicalLocation": [
+                      "M16 5213 T C.1 REEL 1 OF 1"
+                    ],
+                    "recapCustomerCode": [
+                      "NN"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "M16 5213 T C.1 REEL 1 OF 1"
+                    ],
+                    "shelfMark_sort": "aM16 5213 T C.1 REEL 1 OF 000001",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i23965823",
+                    "volumeRange": [
+                      {
+                        "gte": 9999,
+                        "lte": 9999
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "      9999-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb2817873",
+        "_score": 3979.5984,
+        "_source": {
+          "extent": [
+            "191 p. ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "editionStatement": [
+            "Wyd. 2."
+          ],
+          "publisherLiteral": [
+            "Wydawn. Literackie"
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1967
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "PG7158.H43"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1967
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "PG7158.H43"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "2817873"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm10101466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-944961"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm10101466"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779535530981,
+          "publicationStatement": [
+            "Kraków : Wydawn. Literackie, 1967."
+          ],
+          "identifier": [
+            "urn:shelfmark:PG7158.H43",
+            "urn:bnum:2817873",
+            "urn:oclc:ocm10101466",
+            "urn:oclc:SCSB-944961",
+            "urn:identifier:(OCoLC)ocm10101466"
+          ],
+          "creators_displayPacked": [
+            "Hen, Józef||Hen, Józef"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1968",
+                "gte": "1967"
+              },
+              "raw": "831107s1967    pl            000 0 pol d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "191 p. ; 18 cm."
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "creatorLiteral": [
+            "Hen, Józef"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocm10101466",
+            "SCSB-944961"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "titleDisplay": [
+            "Toast / Józef Hen."
+          ],
+          "uri": "pb2817873",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Kraków"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          3979.5984,
+          "pb2817873"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term title.keywordLowercased",
+          "match_phrase title.folded",
+          "term title.keywordLowercasedStripped",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb2817873",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PG7158.H43T637 1967",
+                      "urn:barcode:32101075229904"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PG7158.H43T637 1967",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101075229904",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101075229904"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PG7158.H43T637 1967"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PG7158.H43T637 1967"
+                    ],
+                    "shelfMark_sort": "aPG7158.H43T637 001967",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi5571886"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb2847934",
+        "_score": 3979.5984,
+        "_source": {
+          "extent": [
+            "103 p. ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "publisherLiteral": [
+            "Oberon"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1999
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1999
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "2847934"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1840021047"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-964143"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(CStRLIN)GAEGO42263032-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(GEU)(Sirsi)o42263032"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779535957525,
+          "publicationStatement": [
+            "London : Oberon, 1999."
+          ],
+          "identifier": [
+            "urn:bnum:2847934",
+            "urn:isbn:1840021047",
+            "urn:oclc:SCSB-964143",
+            "urn:identifier:(CStRLIN)GAEGO42263032-B",
+            "urn:identifier:(GEU)(Sirsi)o42263032"
+          ],
+          "creators_displayPacked": [
+            "Bean, Richard, 1956-||Bean, Richard, 1956-"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2000",
+                "gte": "1999"
+              },
+              "raw": "990830s1999    enk           000 0 eng d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "103 p. ; 21 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"First performed at the Royal Court Theatre Upstairs ... on 12th February 1999.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1999"
+          ],
+          "creatorLiteral": [
+            "Bean, Richard, 1956-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "SCSB-964143"
+          ],
+          "idIsbn": [
+            "1840021047"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1999"
+          ],
+          "titleDisplay": [
+            "Toast / by Richard Bean."
+          ],
+          "uri": "pb2847934",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "1840021047"
+          ]
+        },
+        "sort": [
+          3979.5984,
+          "pb2847934"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term title.keywordLowercased",
+          "match_phrase title.folded",
+          "term title.keywordLowercasedStripped",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb2847934",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR6052.E176 T627 1999",
+                      "urn:barcode:32101095377683"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PR6052.E176 T627 1999",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101095377683",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101095377683"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PR6052.E176 T627 1999"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PR6052.E176 T627 1999"
+                    ],
+                    "shelfMark_sort": "aPR6052.E176 T627 001999",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi2440892"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb9928178733506421",
+        "_score": 3979.5984,
+        "_source": {
+          "extent": [
+            "191 p. ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "editionStatement": [
+            "Wyd. 2."
+          ],
+          "publisherLiteral": [
+            "Wydawn. Literackie"
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1967
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1967
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9928178733506421"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm10101466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-944961"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)2817873-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm10101466"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager2817873"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779621862656,
+          "publicationStatement": [
+            "Kraków : Wydawn. Literackie, 1967."
+          ],
+          "identifier": [
+            "urn:bnum:9928178733506421",
+            "urn:oclc:ocm10101466",
+            "urn:oclc:SCSB-944961",
+            "urn:identifier:(NjP)2817873-princetondb",
+            "urn:identifier:(OCoLC)ocm10101466",
+            "urn:identifier:(NjP)Voyager2817873"
+          ],
+          "creators_displayPacked": [
+            "Hen, Józef||Hen, Józef"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1968",
+                "gte": "1967"
+              },
+              "raw": "831107s1967    pl            000 0 pol d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "191 p. ; 18 cm."
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "creatorLiteral": [
+            "Hen, Józef"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocm10101466",
+            "SCSB-944961"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "titleDisplay": [
+            "Toast / Józef Hen."
+          ],
+          "uri": "pb9928178733506421",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Kraków"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          3979.5984,
+          "pb9928178733506421"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term title.keywordLowercased",
+          "match_phrase title.folded",
+          "term title.keywordLowercasedStripped",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb9928178733506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PG7158.H43 T637 1967",
+                      "urn:barcode:32101075229904"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PG7158.H43 T637 1967",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101075229904",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101075229904"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PG7158.H43 T637 1967"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PG7158.H43 T637 1967"
+                    ],
+                    "shelfMark_sort": "aPG7158.H43 T637 001967",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi23546661110006421"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb9928479343506421",
+        "_score": 3979.5984,
+        "_source": {
+          "extent": [
+            "103 p. ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "publisherLiteral": [
+            "Oberon"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1999
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1999
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9928479343506421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1840021047"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm53231811"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-964143"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(CStRLIN)GAEGO42263032-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(GEU)(Sirsi)o42263032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)2847934-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm53231811"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager2847934"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779622002540,
+          "publicationStatement": [
+            "London : Oberon, 1999."
+          ],
+          "identifier": [
+            "urn:bnum:9928479343506421",
+            "urn:isbn:1840021047",
+            "urn:oclc:ocm53231811",
+            "urn:oclc:SCSB-964143",
+            "urn:identifier:(CStRLIN)GAEGO42263032-B",
+            "urn:identifier:(GEU)(Sirsi)o42263032",
+            "urn:identifier:(NjP)2847934-princetondb",
+            "urn:identifier:(OCoLC)ocm53231811",
+            "urn:identifier:(NjP)Voyager2847934"
+          ],
+          "creators_displayPacked": [
+            "Bean, Richard, 1956-||Bean, Richard, 1956-"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2000",
+                "gte": "1999"
+              },
+              "raw": "990830s1999    enk           000 0 eng d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "103 p. ; 21 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"First performed at the Royal Court Theatre Upstairs ... on 12th February 1999.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1999"
+          ],
+          "creatorLiteral": [
+            "Bean, Richard, 1956-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocm53231811",
+            "SCSB-964143"
+          ],
+          "idIsbn": [
+            "1840021047"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1999"
+          ],
+          "titleDisplay": [
+            "Toast / by Richard Bean."
+          ],
+          "uri": "pb9928479343506421",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "1840021047"
+          ]
+        },
+        "sort": [
+          3979.5984,
+          "pb9928479343506421"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term title.keywordLowercased",
+          "match_phrase title.folded",
+          "term title.keywordLowercasedStripped",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb9928479343506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR6052.E176 T627 1999",
+                      "urn:barcode:32101095377683"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PR6052.E176 T627 1999",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101095377683",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101095377683"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PR6052.E176 T627 1999"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PR6052.E176 T627 1999"
+                    ],
+                    "shelfMark_sort": "aPR6052.E176 T627 001999",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi23486469710006421"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "hb990052336220203941",
+        "_score": 2363.7139,
+        "_source": {
+          "extent": [
+            "187 p."
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "publisherLiteral": [
+            "Wydawnictwo Literackie"
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1964
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1964
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990052336220203941"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "7224766"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-10588391"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)977353017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)7224766"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779586119033,
+          "publicationStatement": [
+            "Kraków, Wydawnictwo Literackie [1964]"
+          ],
+          "identifier": [
+            "urn:bnum:990052336220203941",
+            "urn:oclc:7224766",
+            "urn:oclc:SCSB-10588391",
+            "urn:identifier:(OCoLC)977353017",
+            "urn:identifier:(OCoLC)7224766"
+          ],
+          "creators_displayPacked": [
+            "Hen, Józef||Hen, Józef"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1965",
+                "gte": "1964"
+              },
+              "raw": "810313s1964    pl            000 1 pol d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PG7158.H43 T6"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "187 p."
+          ],
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain 20181001 in perpetuity ReCAP Shared Collection HUL 221942284910003941",
+              "type": "bf:Note"
+            }
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "creatorLiteral": [
+            "Hen, Józef"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "7224766",
+            "SCSB-10588391"
+          ],
+          "genreForm": [
+            "Polish fiction"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "titleDisplay": [
+            "Toast."
+          ],
+          "uri": "hb990052336220203941",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Kraków"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          2363.7139,
+          "hb990052336220203941"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "match_phrase title.folded",
+          "term title.keywordLowercasedStripped",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "hb990052336220203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Slav 7147.24.2110 copy ",
+                      "urn:barcode:HNAASE"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Slav 7147.24.2110 copy ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "HNAASE",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "HNAASE"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "physicalLocation": [
+                      "Slav 7147.24.2110"
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "Slav 7147.24.2110 copy "
+                    ],
+                    "shelfMark_sort": "aSlav 7147.24.2110 copy ",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "hi231942284890003941"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b17133475",
+        "_score": 887.9126,
+        "_source": {
+          "extent": [
+            "1 v. (unpaged) : col. ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Houghton Mifflin"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1997
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "96013720"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1997
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "17133475"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0395796180"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0618111212 (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "96013720 /AC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "96013720"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779474262846,
+          "publicationStatement": [
+            "Boston : Houghton Mifflin, c1997."
+          ],
+          "identifier": [
+            "urn:bnum:17133475",
+            "urn:isbn:0395796180",
+            "urn:isbn:0618111212 (pbk.)",
+            "urn:oclc:96013720 /AC",
+            "urn:lccn:96013720"
+          ],
+          "creators_displayPacked": [
+            "Egan, Tim||Egan, Tim"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1998",
+                "gte": "1997"
+              },
+              "raw": "960314s1997    maua   j      000 1 eng  pam a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Dogs -- Fiction.",
+            "Wishes -- Fiction."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PZ7.E2815 Bu 1997"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "1 v. (unpaged) : col. ill. ; 28 cm."
+          ],
+          "subjectLiteral_exploded": [
+            "Dogs",
+            "Dogs -- Fiction",
+            "Wishes",
+            "Wishes -- Fiction"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Burnt toast on Davenport Street"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1997"
+          ],
+          "creatorLiteral": [
+            "Egan, Tim"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "96013720 /AC"
+          ],
+          "popularity": 32,
+          "summary": [
+            "Arthur and Stella Crandall, two dogs, are for the most part content with their lives until a fly comes along and grants Arthur three wishes."
+          ],
+          "genreForm": [
+            "Humorous fiction.",
+            "Picture books."
+          ],
+          "idIsbn": [
+            "0395796180",
+            "0618111212 (pbk.)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1997"
+          ],
+          "titleDisplay": [
+            "Burnt toast on Davenport Street / written and illustrated by Tim Egan."
+          ],
+          "uri": "b17133475",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Boston"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ],
+          "idIsbn_clean": [
+            "0395796180",
+            "0618111212"
+          ]
+        },
+        "sort": [
+          887.9126,
+          "b17133475"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "popularity >= 10",
+          "popularity >= 20",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b17133475",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:J PIC E",
+                      "urn:barcode:33333113836635"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J PIC E",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33333113836635",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33333113836635"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "physicalLocation": [
+                      "J PIC E"
+                    ],
+                    "recapCustomerCode": [
+                      "NH"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "J PIC E"
+                    ],
+                    "shelfMark_sort": "aJ PIC E",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i18069850"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b21290385",
+        "_score": 803.5737,
+        "_source": {
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Compiled by The Billy Rose Theatre Division, The New York Public Library.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Four reviews of ToasT by Lemon Andersen. This prison drama starring Keith David and John Earl Jelks takes place in Attica just prior to the riots of 1971. Opened May 5, 2015, at Public Theater, 425 Lafayette Street, New York, N.Y.  Most of  the characters are African Americans.",
+              "type": "bf:Note"
+            }
+          ],
+          "partOf": [
+            "Collection of newspaper clippings of dramatic criticism, 2014/15."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Attica Correctional Facility",
+            "Attica Correctional Facility -- Drama",
+            "Theater",
+            "Theater -- New York (State)",
+            "Theater -- New York (State) -- New York",
+            "Theater -- New York (State) -- New York -- Reviews",
+            "Andersen, Lemon. ToasT",
+            "Public Theater (New York, N.Y.)",
+            "Prisons",
+            "Prisons -- Drama"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            null
+          ],
+          "parallelSeriesAddedEntry": [],
+          "title": [
+            "ToasT (Andersen)"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "*T-NBL+ Collection 2014/15 (ToasT)"
+          ],
+          "createdString": [
+            "    "
+          ],
+          "creatorLiteral": [],
+          "parallelCreators_displayPacked": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "New York Public Library for the Performing Arts. Billy Rose Theatre Division"
+          ],
+          "dateStartYear": [
+            null
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*T-NBL+ Collection 2014/15 (ToasT)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "21290385"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "New York Public Library for the Performing Arts. Billy Rose Theatre Division||New York Public Library for the Performing Arts. Billy Rose Theatre Division, compiler"
+          ],
+          "updatedAt": 1779506982146,
+          "genreForm": [
+            "Reviews (document genre)."
+          ],
+          "identifier": [
+            "urn:shelfmark:*T-NBL+ Collection 2014/15 (ToasT)",
+            "urn:bnum:21290385"
+          ],
+          "creators_displayPacked": [],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "    "
+          ],
+          "dates": [],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Attica Correctional Facility -- Drama.",
+            "Theater -- New York (State) -- New York -- Reviews.",
+            "Andersen, Lemon. ToasT.",
+            "Public Theater (New York, N.Y.)",
+            "Prisons -- Drama."
+          ],
+          "titleDisplay": [
+            "ToasT (Andersen), 2014/15 : reviews."
+          ],
+          "uri": "b21290385",
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelContributorLiteral": [
+            null
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "collectionIds": [
+            "pat"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          803.5737,
+          "b21290385"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b21290385",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:22",
+                        "label": "clipping files"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:22||clipping files"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pat11",
+                        "label": "Performing Arts Research Collections - Theatre - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pat11||Performing Arts Research Collections - Theatre - Reference"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*T-NBL+ Collection 2014/15 (ToasT)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*T-NBL+ Collection 2014/15 (ToasT)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*T-NBL+ Collection 2014/15 (ToasT)"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*T-NBL+ Collection 2014/15 (ToasT)"
+                    ],
+                    "shelfMark_sort": "a*T-NBL+ Collection 2014/15 (ToasT)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i37684790"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b21501833",
+        "_score": 803.5737,
+        "_source": {
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Compiled by The Billy Rose Theatre Division, The New York Public Library.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Four reviews of Toast by Richard Bean. This comedy about British factory life was reviewed May 19, 2016, when it was produced as part of Brits Off-Broadway festival at 59E59 Theaters, 59 East 59th Street, New York, N.Y.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Reviewed by Ben Brantley in The New York Times, Hilton Als in The New Yorker, Barry Bassis in The Epoch Times, and Elisabeth Vincentelli in New Yor Post.",
+              "type": "bf:Note"
+            }
+          ],
+          "partOf": [
+            "Collection of newspaper clippings of dramatic criticism, 2015/16."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Theater",
+            "Theater -- New York (State)",
+            "Theater -- New York (State) -- New York",
+            "Theater -- New York (State) -- New York -- Reviews",
+            "Bean, Richard, 1956- Toast",
+            "Brits Off-Broadway",
+            "59E59 Theaters (New York, N.Y.)",
+            "Factories",
+            "Factories -- England",
+            "Factories -- England -- Drama",
+            "Employees",
+            "Employees -- England",
+            "Employees -- England -- Drama"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            null
+          ],
+          "parallelSeriesAddedEntry": [],
+          "title": [
+            "Toast (Bean)"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "*T-NBL+ Collection 2015/16 (Toast)"
+          ],
+          "createdString": [
+            "    "
+          ],
+          "creatorLiteral": [],
+          "parallelCreators_displayPacked": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "New York Public Library for the Performing Arts. Billy Rose Theatre Division"
+          ],
+          "dateStartYear": [
+            null
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*T-NBL+ Collection 2015/16 (Toast)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "21501833"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "New York Public Library for the Performing Arts. Billy Rose Theatre Division||New York Public Library for the Performing Arts. Billy Rose Theatre Division, compiler"
+          ],
+          "updatedAt": 1779509062398,
+          "genreForm": [
+            "Reviews (document genre)."
+          ],
+          "identifier": [
+            "urn:shelfmark:*T-NBL+ Collection 2015/16 (Toast)",
+            "urn:bnum:21501833"
+          ],
+          "creators_displayPacked": [],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "    "
+          ],
+          "dates": [],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Theater -- New York (State) -- New York -- Reviews.",
+            "Bean, Richard, 1956- Toast.",
+            "Brits Off-Broadway.",
+            "59E59 Theaters (New York, N.Y.)",
+            "Factories -- England -- Drama.",
+            "Employees -- England -- Drama."
+          ],
+          "titleDisplay": [
+            "Toast (Bean), 2015/16 : reviews."
+          ],
+          "uri": "b21501833",
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelContributorLiteral": [
+            null
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "collectionIds": [
+            "pat"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          803.5737,
+          "b21501833"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b21501833",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:22",
+                        "label": "clipping files"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:22||clipping files"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pat11",
+                        "label": "Performing Arts Research Collections - Theatre - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pat11||Performing Arts Research Collections - Theatre - Reference"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*T-NBL+ Collection 2015/16 (Toast)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*T-NBL+ Collection 2015/16 (Toast)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*T-NBL+ Collection 2015/16 (Toast)"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*T-NBL+ Collection 2015/16 (Toast)"
+                    ],
+                    "shelfMark_sort": "a*T-NBL+ Collection 2015/16 (Toast)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i37685439"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b14570561",
+        "_score": 802.5737,
+        "_source": {
+          "extent": [
+            "[97] p., ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "John C. Winston Co."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            1905
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "Rare Books 18-3570"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1905
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Rare Books 18-3570"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "14570561"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "14233575"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)R250001642"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Dwiggins, Clare Victor||Dwiggins, Clare Victor"
+          ],
+          "updatedAt": 1779410746472,
+          "publicationStatement": [
+            "Philadelphia : John C. Winston Co., c1905."
+          ],
+          "identifier": [
+            "urn:shelfmark:Rare Books 18-3570",
+            "urn:bnum:14570561",
+            "urn:oclc:14233575",
+            "urn:identifier:(WaOLN)R250001642"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "lt": "1906",
+                "gte": "1905"
+              },
+              "raw": "860918s1905    ohua          000 0 eng dnamIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Toasts."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mar"
+          ],
+          "physicalDescription": [
+            "[97] p., : ill. ; 18 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Skeleton head cover.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Illustrated t.-p.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Toasts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "title": [
+            "Toast book"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1905"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Dwiggins, Clare Victor"
+          ],
+          "idOclc": [
+            "14233575"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1905"
+          ],
+          "titleDisplay": [
+            "Toast book / compiled and illustrated by Clare Victor Dwiggins."
+          ],
+          "uri": "b14570561",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Philadelphia"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          802.5737,
+          "b14570561"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b21965138",
+        "_score": 760.97174,
+        "_source": {
+          "extent": [
+            "1 folder. "
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Programs for productions of the play Toast by Henry Filloux-Bennett. Based on the book by Nigel Slater.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Filloux-Bennett, Henry. Toast",
+            "Slater, Nigel. Toast"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "parallelSeriesAddedEntry": [],
+          "title": [
+            "Toast (Filloux-Bennett)"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "*T-PRG (Toast (Filloux-Bennett))"
+          ],
+          "creatorLiteral": [],
+          "parallelCreators_displayPacked": [],
+          "numElectronicResources": [
+            0
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*T-PRG (Toast (Filloux-Bennett))"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "21965138"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779514485816,
+          "genreForm": [
+            "Programs."
+          ],
+          "identifier": [
+            "urn:shelfmark:*T-PRG (Toast (Filloux-Bennett))",
+            "urn:bnum:21965138"
+          ],
+          "creators_displayPacked": [],
+          "numCheckinCardItems": [
+            0
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dates": [],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Filloux-Bennett, Henry. Toast.",
+            "Slater, Nigel. Toast."
+          ],
+          "titleDisplay": [
+            "Toast (Filloux-Bennett) : programs."
+          ],
+          "uri": "b21965138",
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelContributorLiteral": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "p",
+          "recordTypeId": " ",
+          "collectionIds": [
+            "pat"
+          ],
+          "physicalDescription": [
+            "1 folder. "
+          ]
+        },
+        "sort": [
+          760.97174,
+          "b21965138"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b21965138",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&CallNumber=*T-PRG+%28Toast+%28Filloux-Bennett%29%29&Form=30&Genre=archival+material&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db21965138&ItemISxN=i373192253&ItemNumber=33433120459403&Location=Performing+Arts+Theatre+Division&ReferenceNumber=b219651383&Site=LPATH&Title=Toast+%28Filloux-Bennett%29+%3A+programs."
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:21",
+                        "label": "archival material"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:21||archival material"
+                    ],
+                    "formatLiteral": [
+                      "Archival mix"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pat38",
+                        "label": "Performing Arts Research Collections - Theatre"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pat38||Performing Arts Research Collections - Theatre"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*T-PRG (Toast (Filloux-Bennett))",
+                      "urn:barcode:33433120459403"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*T-PRG (Toast (Filloux-Bennett))",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433120459403",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433120459403"
+                    ],
+                    "physicalLocation": [
+                      "*T-PRG (Toast (Filloux-Bennett))"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*T-PRG (Toast (Filloux-Bennett))"
+                    ],
+                    "shelfMark_sort": "a*T-PRG (Toast (Filloux-Bennett))",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i37319225"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b18576841",
+        "_score": 759.97174,
+        "_source": {
+          "extent": [
+            "386 pp."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "buildingLocationIds": [],
+          "parallelSeriesAddedEntry": [],
+          "title": [
+            "Toast za przodkow"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [],
+          "creatorLiteral": [
+            "Gorecki, Wojciech"
+          ],
+          "parallelCreators_displayPacked": [],
+          "numElectronicResources": [
+            0
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "18576841"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9788373561940"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779483855713,
+          "publicationStatement": [
+            "Wolowiec : Czarne, 2010"
+          ],
+          "idIsbn": [
+            "9788373561940"
+          ],
+          "identifier": [
+            "urn:bnum:18576841",
+            "urn:isbn:9788373561940"
+          ],
+          "creators_displayPacked": [
+            "Gorecki, Wojciech||Gorecki, Wojciech"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dates": [],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "titleDisplay": [
+            "Toast za przodkow"
+          ],
+          "uri": "b18576841",
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelContributorLiteral": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "placeOfPublication": [
+            "Wolowiec : Czarne, 2010"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "physicalDescription": [
+            "386 pp."
+          ],
+          "idIsbn_clean": [
+            "9788373561940"
+          ]
+        },
+        "sort": [
+          759.97174,
+          "b18576841"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b18806309",
+        "_score": 759.97174,
+        "_source": {
+          "extent": [
+            "386 p. : map ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "editionStatement": [
+            "Wyd. 1."
+          ],
+          "publisherLiteral": [
+            "Wydawn. Czarne"
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2010
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "ReCAP 11-4380"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2010
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "ReCAP 11-4380"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "18806309"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9788375361940 (pbk)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "8375361941 (pbk)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "671293997"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)671293997"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779485114438,
+          "publicationStatement": [
+            "Wołowiec : Wydawn. Czarne, 2010."
+          ],
+          "identifier": [
+            "urn:shelfmark:ReCAP 11-4380",
+            "urn:bnum:18806309",
+            "urn:isbn:9788375361940 (pbk)",
+            "urn:isbn:8375361941 (pbk)",
+            "urn:oclc:671293997",
+            "urn:identifier:(OCoLC)671293997"
+          ],
+          "creators_displayPacked": [
+            "Górecki, Wojciech, 1970-||Górecki, Wojciech, 1970-"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2011",
+                "gte": "2010"
+              },
+              "raw": "101021s2010    pl b     b    000 0 pol  camIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Caucasus.",
+            "Caucasus -- Civilization."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "386 p. : map ; 20 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. 383-[387])",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Polish.",
+              "type": "bf:Note"
+            }
+          ],
+          "seriesUniformTitle_displayPacked": [
+            "Seria Reportaż.||Seria Reportaż."
+          ],
+          "subjectLiteral_exploded": [
+            "Caucasus",
+            "Caucasus -- Civilization"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast za przodków"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2010"
+          ],
+          "creatorLiteral": [
+            "Górecki, Wojciech, 1970-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "671293997"
+          ],
+          "popularity": 3,
+          "seriesUniformTitle": [
+            "Seria Reportaż."
+          ],
+          "idIsbn": [
+            "9788375361940 (pbk)",
+            "8375361941 (pbk)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2010"
+          ],
+          "titleDisplay": [
+            "Toast za przodków / Wojciech Górecki."
+          ],
+          "uri": "b18806309",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Wołowiec"
+          ],
+          "series": [
+            "Reportaż"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Reportaż||Reportaż"
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "9788375361940",
+            "8375361941"
+          ]
+        },
+        "sort": [
+          759.97174,
+          "b18806309"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b18806309",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "dueDate": [
+                      "2025-01-02"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:ReCAP 11-4380",
+                      "urn:barcode:33433090460647"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "ReCAP 11-4380",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433090460647",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433090460647"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "physicalLocation": [
+                      "ReCAP 11-4380"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "ReCAP 11-4380"
+                    ],
+                    "shelfMark_sort": "aReCAP 11-004380",
+                    "status": [
+                      {
+                        "id": "status:co",
+                        "label": "Loaned"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:co||Loaned"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i26121731"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b11302028",
+        "_score": 753.5737,
+        "_source": {
+          "extent": [
+            "vi, 301 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "editionStatement": [
+            "3rd ed."
+          ],
+          "publisherLiteral": [
+            "Women's Auxiliary of the California Babies' and Children's Hospital"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1950
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 89-9691"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1950
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 89-9691"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11302028"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "4365987"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG90-B62543"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1309761"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)4365987"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "California Babies' and Children's Hospital. Women's Auxiliary||California Babies' and Children's Hospital. Women's Auxiliary"
+          ],
+          "updatedAt": 1779329552574,
+          "publicationStatement": [
+            "Los Angeles, Calif. : Women's Auxiliary of the California Babies' and Children's Hospital, 1950."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 89-9691",
+            "urn:bnum:11302028",
+            "urn:oclc:4365987",
+            "urn:oclc:NYPG90-B62543",
+            "urn:identifier:(WaOLN)nyp1309761",
+            "urn:identifier:(OCoLC)4365987"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "lt": "1951",
+                "gte": "1950"
+              },
+              "raw": "900717s1950    caua          001 0 eng dcam a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Cooking, American -- California -- Los Angeles."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "vi, 301 p. : ill. ; 23 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Cooking, American",
+            "Cooking, American -- California",
+            "Cooking, American -- California -- Los Angeles"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Burnt toast."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1950"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "California Babies' and Children's Hospital. Women's Auxiliary"
+          ],
+          "idOclc": [
+            "4365987",
+            "NYPG90-B62543"
+          ],
+          "popularity": 1,
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1950"
+          ],
+          "titleDisplay": [
+            "Burnt toast."
+          ],
+          "uri": "b11302028",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Los Angeles, Calif."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          753.5737,
+          "b11302028"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b11302028",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 89-9691",
+                      "urn:barcode:33433040618625"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFD 89-9691",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433040618625",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433040618625"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "JFD 89-9691"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFD 89-9691"
+                    ],
+                    "shelfMark_sort": "aJFD 89-009691",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i13162098"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b11373665",
+        "_score": 753.5737,
+        "_source": {
+          "extent": [
+            "1 ms. score (6 p.) ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1918
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JPB 84-312"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1918
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 84-312"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11373665"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG004000622-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405622"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1381621"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Burnside, R. H. (Robert Hubberthorne), 1873-1952||Burnside, R. H. (Robert Hubberthorne), 1873-1952",
+            "Champlin, Fred P.||Champlin, Fred P."
+          ],
+          "updatedAt": 1779330819635,
+          "publicationStatement": [
+            "[ca. 1918]"
+          ],
+          "identifier": [
+            "urn:shelfmark:JPB 84-312",
+            "urn:bnum:11373665",
+            "urn:oclc:NYPG004000622-C",
+            "urn:identifier:NNSZ00405622",
+            "urn:identifier:(WaOLN)nyp1381621"
+          ],
+          "creators_displayPacked": [
+            "Sousa, John Philip, 1854-1932||Sousa, John Philip, 1854-1932"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1919",
+                "gte": "1918"
+              },
+              "raw": "850627s1918    nyusga         n    eng dcdm a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Songs (Medium voice) with piano."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "d",
+          "collectionIds": [
+            "pam"
+          ],
+          "physicalDescription": [
+            "1 ms. score (6 p.) ; 34 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Copyist's ms., in ink.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For voice and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Stamp on pp. [1] & 6: Fred P. Champlin, Autographing and Copying.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Songs (Medium voice) with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "The toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1918"
+          ],
+          "creatorLiteral": [
+            "Sousa, John Philip, 1854-1932"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Burnside, R. H. (Robert Hubberthorne), 1873-1952",
+            "Champlin, Fred P."
+          ],
+          "idOclc": [
+            "NYPG004000622-C"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1918"
+          ],
+          "titleDisplay": [
+            "The toast / words by R.J. Burnside ; music by John Philip Sousa."
+          ],
+          "uri": "b11373665",
+          "parallelContributorLiteral": [
+            null,
+            null
+          ],
+          "recordTypeId": "d",
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "34 cm."
+          ]
+        },
+        "sort": [
+          753.5737,
+          "b11373665"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b11373665",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Sousa%2C+John+Philip%2C+1854-1932&CallNumber=JPB+84-312&Date=1918&Form=30&Genre=book+non-circ&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db11373665&ItemISxN=i158970068&ItemPublisher=%5Bca.+1918%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b113736654&Site=LPAMR&Title=The+toast"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Manuscript notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pam38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pam38||Performing Arts Research Collections - Music"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JPB 84-312"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JPB 84-312",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JPB 84-312"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "JPB 84-312"
+                    ],
+                    "shelfMark_sort": "aJPB 84-000312",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15897006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b11373666",
+        "_score": 753.5737,
+        "_source": {
+          "extent": [
+            "1 ms. score (5 leaves) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Holograph signed, in ink and pencil.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For voice and orchestra; music for orchestra only (includes cue for voice).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Alternate musical setting from mss. of Mar. 6, 1918.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "At end: N.Y., March 15, 1918.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Title from caption (in pencil); other caption title information illegible.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sousa, John Philip, 1854-1932",
+            "Sousa, John Philip, 1854-1932 -- Manuscripts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1918
+          ],
+          "parallelSeriesAddedEntry": [],
+          "title": [
+            "The toast"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "JPB 84-313"
+          ],
+          "createdString": [
+            "1918"
+          ],
+          "creatorLiteral": [
+            "Sousa, John Philip, 1854-1932"
+          ],
+          "parallelCreators_displayPacked": [],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1918
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "idOclc": [
+            "NYPG004000623-C"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 84-313"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11373666"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG004000623-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405623"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1381622"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779330819635,
+          "publicationStatement": [
+            "1918 Mar. 15"
+          ],
+          "identifier": [
+            "urn:shelfmark:JPB 84-313",
+            "urn:bnum:11373666",
+            "urn:oclc:NYPG004000623-C",
+            "urn:identifier:NNSZ00405623",
+            "urn:identifier:(WaOLN)nyp1381622"
+          ],
+          "creators_displayPacked": [
+            "Sousa, John Philip, 1854-1932||Sousa, John Philip, 1854-1932"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1918"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1919",
+                "gte": "1918"
+              },
+              "raw": "850627s1918    nyusga         n    zxx dcdm a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Sousa, John Philip, 1854-1932 -- Manuscripts."
+          ],
+          "titleDisplay": [
+            "The toast / J.P.S. [John Philip Sousa]."
+          ],
+          "uri": "b11373666",
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelContributorLiteral": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "d",
+          "recordTypeId": "d",
+          "collectionIds": [
+            "pam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "physicalDescription": [
+            "1 ms. score (5 leaves) ; 34 cm."
+          ],
+          "dimensions": [
+            "34 cm."
+          ]
+        },
+        "sort": [
+          753.5737,
+          "b11373666"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b11373666",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Sousa%2C+John+Philip%2C+1854-1932&CallNumber=JPB+84-313&Date=1918&Form=30&Genre=book+non-circ&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db11373666&ItemISxN=i15897007x&ItemPublisher=1918+Mar.+15&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b113736666&Site=LPAMR&Title=The+toast"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Manuscript notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pam38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pam38||Performing Arts Research Collections - Music"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JPB 84-313"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JPB 84-313",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JPB 84-313"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "JPB 84-313"
+                    ],
+                    "shelfMark_sort": "aJPB 84-000313",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15897007"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b11373667",
+        "_score": 753.5737,
+        "_source": {
+          "extent": [
+            "1 ms. score (14 p.) ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1918
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JPB 84-314"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1918
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 84-314"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11373667"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG004000624-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405624"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1381623"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Burnside, R. H. (Robert Hubberthorne), 1873-1952||Burnside, R. H. (Robert Hubberthorne), 1873-1952"
+          ],
+          "updatedAt": 1779330819635,
+          "publicationStatement": [
+            "1918 Mar. 6"
+          ],
+          "identifier": [
+            "urn:shelfmark:JPB 84-314",
+            "urn:bnum:11373667",
+            "urn:oclc:NYPG004000624-C",
+            "urn:identifier:NNSZ00405624",
+            "urn:identifier:(WaOLN)nyp1381623"
+          ],
+          "creators_displayPacked": [
+            "Sousa, John Philip, 1854-1932||Sousa, John Philip, 1854-1932"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1919",
+                "gte": "1918"
+              },
+              "raw": "850627s1918    nyusga         n    zxx dcdm a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Sousa, John Philip, 1854-1932 -- Manuscripts.",
+            "Songs (Medium voice) with orchestra -- Scores."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "d",
+          "collectionIds": [
+            "pam"
+          ],
+          "physicalDescription": [
+            "1 ms. score (14 p.) ; 34 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Holograph signed, in ink.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For voice and orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Without the words.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Alternate musical setting from mss. of Mar. 15, 1918.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "At end: Port Washington, March 6th 1918.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Sousa, John Philip, 1854-1932",
+            "Sousa, John Philip, 1854-1932 -- Manuscripts",
+            "Songs (Medium voice) with orchestra",
+            "Songs (Medium voice) with orchestra -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "The toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1918"
+          ],
+          "creatorLiteral": [
+            "Sousa, John Philip, 1854-1932"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Burnside, R. H. (Robert Hubberthorne), 1873-1952"
+          ],
+          "idOclc": [
+            "NYPG004000624-C"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1918"
+          ],
+          "titleDisplay": [
+            "The toast / words by Frank Warren & R.H. Burnside ; music by John Philip Sousa."
+          ],
+          "uri": "b11373667",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "d",
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "34 cm."
+          ]
+        },
+        "sort": [
+          753.5737,
+          "b11373667"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b11373667",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Sousa%2C+John+Philip%2C+1854-1932&CallNumber=JPB+84-314&Date=1918&Form=30&Genre=book+non-circ&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db11373667&ItemISxN=i158970081&ItemPublisher=1918+Mar.+6&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b113736678&Site=LPAMR&Title=The+toast"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Manuscript notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pam38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pam38||Performing Arts Research Collections - Music"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JPB 84-314"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JPB 84-314",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JPB 84-314"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "JPB 84-314"
+                    ],
+                    "shelfMark_sort": "aJPB 84-000314",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15897008"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b15876151",
+        "_score": 753.5737,
+        "_source": {
+          "extent": [
+            "1 sound disc : analog, 33 1/3 rpm ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Angel Records"
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            195
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LZO 356"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            195
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LZO 356"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15876151"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "53378691"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "ANG-60009 Angel Records"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A100000016"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Chevallier, Christian||Chevallier, Christian, performer",
+            "Lafitte, Guy||Lafitte, Guy, performer"
+          ],
+          "updatedAt": 1779429891706,
+          "publicationStatement": [
+            "New York, [N.Y.] : Angel Records, [195-]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LZO 356",
+            "urn:bnum:15876151",
+            "urn:oclc:53378691",
+            "urn:identifier:ANG-60009 Angel Records",
+            "urn:identifier:(WaOLN)A100000016"
+          ],
+          "creators_displayPacked": [
+            "Persiany, André||Persiany, André, performer"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1960",
+                "gte": "1950"
+              },
+              "raw": "031110p195u1954nyujzn   i              dnjmIa ",
+              "tag": "p"
+            },
+            {
+              "range": {
+                "lt": "1955",
+                "gte": "1954"
+              },
+              "raw": "031110p195u1954nyujzn   i              dnjmIa ",
+              "tag": "p"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Jazz -- France -- 1951-1960."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "j",
+          "collectionIds": [
+            "pah"
+          ],
+          "physicalDescription": [
+            "1 sound disc : analog, 33 1/3 rpm ; 10 in."
+          ],
+          "tableOfContents": [
+            "Nice joke -- Fiction -- Quartet mind -- Saxology -- Little story -- Halbe fünf -- Christmas song -- Two cats and a piece of lung."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Program notes by \"Jonah\" Jones on container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded Oct. 8, 1954 and May 1955 in Paris.",
+              "type": "bf:Note"
+            }
+          ],
+          "seriesUniformTitle_displayPacked": [
+            "Jazz series (Angel Records) ;||Jazz series (Angel Records) ; vol. 1, no. 10."
+          ],
+          "subjectLiteral_exploded": [
+            "Jazz",
+            "Jazz -- France",
+            "Jazz -- France -- 1951-1960"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1954"
+          ],
+          "title": [
+            "French toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "195"
+          ],
+          "creatorLiteral": [
+            "Persiany, André"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Chevallier, Christian",
+            "Lafitte, Guy"
+          ],
+          "idOclc": [
+            "53378691"
+          ],
+          "dateEndYear": [
+            1954
+          ],
+          "seriesUniformTitle": [
+            "Jazz series (Angel Records) ;"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "195"
+          ],
+          "titleDisplay": [
+            "French toast [sound recording]."
+          ],
+          "uri": "b15876151",
+          "parallelContributorLiteral": [
+            null,
+            null
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "New York, [N.Y.]"
+          ],
+          "series": [
+            "Jazz series ;"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Jazz series ;||Jazz series ; vol. 1, no. 10"
+          ],
+          "dimensions": [
+            "10 in."
+          ]
+        },
+        "sort": [
+          753.5737,
+          "b15876151"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b15876151",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Persiany%2C+Andr%C3%A9&CallNumber=*LZO+356+%5BDisc%5D&Date=195&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15876151&ItemISxN=i146601877&ItemNumber=33433035294234&ItemPlace=New+York%2C+%5BN.Y.%5D&ItemPublisher=Angel+Records%2C+%5B195-%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b158761510&Site=LPAMRAMI&Title=French+toast"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LZO 356 [Disc]",
+                      "urn:barcode:33433035294234"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LZO 356 [Disc]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433035294234",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433035294234"
+                    ],
+                    "physicalLocation": [
+                      "*LZO 356 [Disc]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LZO 356 [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LZO 356 [Disc]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i14660187"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b18054582",
+        "_score": 753.5737,
+        "_source": {
+          "extent": [
+            "1 videodisc (approximately 52 min.) : sound, color ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Bullfrog Films"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            2005
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2005
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "18054582"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1594583560"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781594583568"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "191872445"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1053113461"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)191872445"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Weinstein, Larry||Weinstein, Larry, director, producer",
+            "Louie, Alexina, 1949-||Louie, Alexina, 1949-, composer",
+            "Redican, Dan||Redican, Dan, librettist, performer",
+            "Daniel, Jessica||Daniel, Jessica, producer",
+            "Hornburg, Matthew||Hornburg, Matthew, producer",
+            "Franco, David, 1963-||Franco, David, 1963-, cinematographer",
+            "Gross, Paul, 1959-||Gross, Paul, 1959-, performer",
+            "Szabó, Krisztina (Mezzo-soprano)||Szabó, Krisztina (Mezzo-soprano), performer",
+            "Houtman, Martin||Houtman, Martin, performer",
+            "McGillivray, Peter||McGillivray, Peter, performer",
+            "Mercer, Shannon||Mercer, Shannon, performer",
+            "Stilwell, Jean, 1955-||Stilwell, Jean, 1955-, performer",
+            "Butterfield, Benjamin||Butterfield, Benjamin, performer",
+            "Bayrakdarian, Isabel||Bayrakdarian, Isabel, performer",
+            "Martin, Bob, 1962-||Martin, Bob, 1962-, performer",
+            "Balaban, Liane, 1980-||Balaban, Liane, 1980-, performer",
+            "Colvin, Michael (Tenor)||Colvin, Michael (Tenor), performer",
+            "Sadiq, Zorana||Sadiq, Zorana, performer",
+            "Braun, Russell, 1968-||Braun, Russell, 1968-, performer",
+            "Monoyios, Ann, 1949-||Monoyios, Ann, 1949-, performer",
+            "McNaughton, Doug||McNaughton, Doug, performer",
+            "Hannigan, Barbara||Hannigan, Barbara, performer",
+            "Pauk, Alex, 1945-||Pauk, Alex, 1945-, conductor",
+            "Esprit Orchestra||Esprit Orchestra, performer",
+            "Bullfrog Films||Bullfrog Films, production manager",
+            "Rhombus Media (Firm)||Rhombus Media (Firm), production manager",
+            "Canadian Television Fund||Canadian Television Fund",
+            "Canadian Broadcasting Corporation||Canadian Broadcasting Corporation",
+            "Channel Four Films (Firm)||Channel Four Films (Firm)",
+            "Zweites Deutsches Fernsehen||Zweites Deutsches Fernsehen",
+            "Association relative à la télévision européenne||Association relative à la télévision européenne"
+          ],
+          "updatedAt": 1779480096602,
+          "publicationStatement": [
+            "Oley, PA : Bullfrog Films, [2005]"
+          ],
+          "identifier": [
+            "urn:bnum:18054582",
+            "urn:isbn:1594583560",
+            "urn:isbn:9781594583568",
+            "urn:oclc:191872445",
+            "urn:identifier:(OCoLC)1053113461",
+            "urn:identifier:(OCoLC)191872445"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "lt": "2006",
+                "gte": "2005"
+              },
+              "raw": "080207s2005    pau052            vleng dcgm4a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Love -- Drama.",
+            "Television operas.",
+            "Vignettes -- Drama."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PN1997.2 .B87 2005"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "v",
+          "collectionIds": [
+            "pav"
+          ],
+          "physicalDescription": [
+            "1 videodisc (approximately 52 min.) : sound, color ; 4 3/4 in."
+          ],
+          "tableOfContents": [
+            "The 8 stages of love. Stage 1: Attraction ; Stage 2: Connection ; Stage 3: Commitment ; Stage 4: Marriage ; Stage 5: Consummation ; Stage 6: Perseverance ; Stage 7: Disintegration ; Stage 8: Starting over."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Original comic opera.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Larry Weinstein, director; Jessica Daniel, Matthew Hornburg, Larry Weinstein, producers; David Franco, director of photography.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "DVD-R format.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Love",
+            "Love -- Drama",
+            "Television operas",
+            "Vignettes",
+            "Vignettes -- Drama"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Burnt toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2005"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Weinstein, Larry",
+            "Louie, Alexina, 1949-",
+            "Redican, Dan",
+            "Daniel, Jessica",
+            "Hornburg, Matthew",
+            "Franco, David, 1963-",
+            "Gross, Paul, 1959-",
+            "Szabó, Krisztina (Mezzo-soprano)",
+            "Houtman, Martin",
+            "McGillivray, Peter",
+            "Mercer, Shannon",
+            "Stilwell, Jean, 1955-",
+            "Butterfield, Benjamin",
+            "Bayrakdarian, Isabel",
+            "Martin, Bob, 1962-",
+            "Balaban, Liane, 1980-",
+            "Colvin, Michael (Tenor)",
+            "Sadiq, Zorana",
+            "Braun, Russell, 1968-",
+            "Monoyios, Ann, 1949-",
+            "McNaughton, Doug",
+            "Hannigan, Barbara",
+            "Pauk, Alex, 1945-",
+            "Esprit Orchestra",
+            "Bullfrog Films",
+            "Rhombus Media (Firm)",
+            "Canadian Television Fund",
+            "Canadian Broadcasting Corporation",
+            "Channel Four Films (Firm)",
+            "Zweites Deutsches Fernsehen",
+            "Association relative à la télévision européenne"
+          ],
+          "idOclc": [
+            "191872445"
+          ],
+          "popularity": 2,
+          "summary": [
+            "\"Comprised of a series of eight comedic mini-operas, each depicting a different stage of a romantic relationship set in contemporary settings. With original music and libretti, each vignette is a self-contained story, but together they work as a cohesive single piece\"--Container."
+          ],
+          "genreForm": [
+            "Drama.",
+            "Feature films.",
+            "Musical films."
+          ],
+          "idIsbn": [
+            "1594583560",
+            "9781594583568"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mov",
+              "label": "Moving image"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2005"
+          ],
+          "titleDisplay": [
+            "Burnt toast / Bullfrog Films presents Rhombus Media and marblemedia present a film by Larry Weinstein ; music by Alexina Louie ; words by Dan Redican ; produced with the participation of the Canadian Television Fund ; produced in association with the Canadian Broadcasting Corporation ; Channel Four Television Corporation ; ZDF in cooperation with ARTE."
+          ],
+          "uri": "b18054582",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "recordTypeId": "g",
+          "placeOfPublication": [
+            "Oley, PA"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ],
+          "idIsbn_clean": [
+            "1594583560",
+            "9781594583568"
+          ]
+        },
+        "sort": [
+          753.5737,
+          "b18054582"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b18054582",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:a",
+                        "label": "By appointment only"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:a||By appointment only"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:75",
+                        "label": "dvd"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:75||dvd"
+                    ],
+                    "enumerationChronology": [
+                      "C.1"
+                    ],
+                    "formatLiteral": [
+                      "DVD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pav28",
+                        "label": "Performing Arts Research Collections - Reserve Film and Video"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pav28||Performing Arts Research Collections - Reserve Film and Video"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:DVDR 1348 B C.1",
+                      "urn:barcode:33333225144951"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "DVDR 1348 B C.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33333225144951",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33333225144951"
+                    ],
+                    "physicalLocation": [
+                      "DVDR 1348 B C.1"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "DVDR 1348 B C.1"
+                    ],
+                    "shelfMark_sort": "aDVDR 1348 B C.000001",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i24601154"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b19650848",
+        "_score": 753.5737,
+        "_source": {
+          "extent": [
+            "256, 31 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "editionStatement": [
+            "2nd ed."
+          ],
+          "publisherLiteral": [
+            "Metheun"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1916
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "NCW (Ridge, W. P. On toast)"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1916
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NCW (Ridge, W. P. On toast)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "19650848"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "26167955"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)26167955"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779489907711,
+          "publicationStatement": [
+            "London : Metheun, 1916."
+          ],
+          "identifier": [
+            "urn:shelfmark:NCW (Ridge, W. P. On toast)",
+            "urn:bnum:19650848",
+            "urn:oclc:26167955",
+            "urn:identifier:(OCoLC)26167955"
+          ],
+          "creators_displayPacked": [
+            "Ridge, W. Pett (William Pett), -1930||Ridge, W. Pett (William Pett), -1930"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1917",
+                "gte": "1916"
+              },
+              "raw": "920710s1916    enk           000 1 eng dcamIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "256, 31 p. ; 20 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Advertisements: p. [1]-31 (second group).",
+              "type": "bf:Note"
+            }
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "On toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1916"
+          ],
+          "creatorLiteral": [
+            "Ridge, W. Pett (William Pett), -1930"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "26167955"
+          ],
+          "popularity": 6,
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1916"
+          ],
+          "titleDisplay": [
+            "On toast / by W. Pett Ridge."
+          ],
+          "uri": "b19650848",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          753.5737,
+          "b19650848"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b19650848",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NCW (Ridge, W. P. On toast)",
+                      "urn:barcode:33433101440497"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "NCW (Ridge, W. P. On toast)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433101440497",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433101440497"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "NCW (Ridge, W. P. On toast)"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "NCW (Ridge, W. P. On toast)"
+                    ],
+                    "shelfMark_sort": "aNCW (Ridge, W. P. On toast)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i28924660"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b22227752",
+        "_score": 753.5737,
+        "_source": {
+          "extent": [
+            "1 volume (unpaged) : colour illustrations ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "editionStatement": [
+            "First edition."
+          ],
+          "publisherLiteral": [
+            "Pajama Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            2016
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFF 17-1945"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2016
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 17-1945"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22227752"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781772780062"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1772780065"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "943594881"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)943594881"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Thisdale, François, 1964-||Thisdale, François, 1964-, illustrator"
+          ],
+          "updatedAt": 1779517958058,
+          "publicationStatement": [
+            "Toronto, Ontario, Canada : Pajama Press, 2016."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFF 17-1945",
+            "urn:bnum:22227752",
+            "urn:isbn:9781772780062",
+            "urn:isbn:1772780065",
+            "urn:oclc:943594881",
+            "urn:identifier:(OCoLC)943594881"
+          ],
+          "creators_displayPacked": [
+            "Winters, Kari-Lynn, 1969-||Winters, Kari-Lynn, 1969-, author"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2017",
+                "gte": "2016"
+              },
+              "raw": "160411s2016    onca   j      000 1 eng  cam i ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Racially mixed people -- Juvenile fiction.",
+            "Grandmothers -- Juvenile fiction.",
+            "Blind -- Juvenile fiction.",
+            "Human skin color -- Juvenile fiction.",
+            "Self-esteem -- Juvenile fiction.",
+            "Picture books for children."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PZ7.W7674 Fr 2016"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "1 volume (unpaged) : colour illustrations ; 24 x 27 cm"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"This is a first edition\"--Title page verso.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Racially mixed people",
+            "Racially mixed people -- Juvenile fiction",
+            "Grandmothers",
+            "Grandmothers -- Juvenile fiction",
+            "Blind",
+            "Blind -- Juvenile fiction",
+            "Human skin color",
+            "Human skin color -- Juvenile fiction",
+            "Self-esteem",
+            "Self-esteem -- Juvenile fiction",
+            "Picture books for children"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "French toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2016"
+          ],
+          "creatorLiteral": [
+            "Winters, Kari-Lynn, 1969-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Thisdale, François, 1964-"
+          ],
+          "idOclc": [
+            "943594881"
+          ],
+          "summary": [
+            "While out on a walk with her blind grandmother, Phoebe tries to describe the skin color of members of her family by comparing them to various foods."
+          ],
+          "genreForm": [
+            "Fiction.",
+            "Juvenile works."
+          ],
+          "idIsbn": [
+            "9781772780062",
+            "1772780065"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2016"
+          ],
+          "titleDisplay": [
+            "French toast / written by Kari-Lynn Winters ; illustrated by François Thisdale."
+          ],
+          "uri": "b22227752",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Toronto, Ontario, Canada"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 x 27 cm"
+          ],
+          "idIsbn_clean": [
+            "9781772780062",
+            "1772780065"
+          ]
+        },
+        "sort": [
+          753.5737,
+          "b22227752"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b22227752",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFF 17-1945",
+                      "urn:barcode:33433122276318"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 17-1945",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433122276318",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433122276318"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "physicalLocation": [
+                      "JFF 17-1945"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFF 17-1945"
+                    ],
+                    "shelfMark_sort": "aJFF 17-001945",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i37949151"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b12269299",
+        "_score": 752.5737,
+        "_source": {
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Directions and music.",
+              "type": "bf:Note"
+            }
+          ],
+          "partOf": [
+            "Pedersen, Dagny. Folk games of Denmark and Sweden. Chicago [c1915] p 24. illus, diagr"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Gustafs skål (Dance)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            1915
+          ],
+          "parallelSeriesAddedEntry": [],
+          "title": [
+            "Gustaf's toast."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "*MGS (Scandinavian)"
+          ],
+          "createdString": [
+            "1915"
+          ],
+          "creatorLiteral": [],
+          "parallelCreators_displayPacked": [],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1915
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "idOclc": [
+            "NYPY710236921-B"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*MGS (Scandinavian)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12269299"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPY710236921-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NN-PD)710236921"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp2256094"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779372283374,
+          "identifier": [
+            "urn:shelfmark:*MGS (Scandinavian)",
+            "urn:bnum:12269299",
+            "urn:oclc:NYPY710236921-B",
+            "urn:identifier:(NN-PD)710236921",
+            "urn:identifier:(WaOLN)nyp2256094"
+          ],
+          "creators_displayPacked": [],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1915"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1916",
+                "gte": "1915"
+              },
+              "raw": "710331s1915    xxua|g  |    |0|| | eng dnaazi ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Gustafs skål (Dance)"
+          ],
+          "titleDisplay": [
+            "Gustaf's toast."
+          ],
+          "uri": "b12269299",
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelContributorLiteral": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "collectionIds": [
+            "pad"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:a",
+              "label": "monograph component part"
+            }
+          ]
+        },
+        "sort": [
+          752.5737,
+          "b12269299"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b14264413",
+        "_score": 752.5737,
+        "_source": {
+          "extent": [
+            "2 p.l., 7-73 p., 2 l."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Edizioni di Novissima"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            1937
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "SB p.v. 443"
+          ],
+          "idLccn": [
+            "38006165"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1937
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "SB p.v. 443"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "14264413"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "10504920"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "38006165"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)R020000041"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779406050217,
+          "publicationStatement": [
+            "Roma, Edizioni di Novissima [1937]"
+          ],
+          "identifier": [
+            "urn:shelfmark:SB p.v. 443",
+            "urn:bnum:14264413",
+            "urn:oclc:10504920",
+            "urn:lccn:38006165",
+            "urn:identifier:(WaOLN)R020000041"
+          ],
+          "creators_displayPacked": [
+            "Baravelli, G. C. (Giulio Cesare)||Baravelli, G. C. (Giulio Cesare)"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1938",
+                "gte": "1937"
+              },
+              "raw": "840309s1937    it            000 0 eng  camI  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Stalin, Joseph, 1878-1953.",
+            "Communism -- Soviet Union.",
+            "Soviet Union -- Economic conditions -- 1917-1945."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "DK267 .B27"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "2 p.l., 7-73 p., 2 l. ; 19 cm."
+          ],
+          "tableOfContents": [
+            "A class which refuses to die.--Fighting the party.--Rifle shots in Moscow.--The lowest wages in the world.--Sordid housing.--Yagoda: a name and a symbol.--Six million convicts.--The revenge of militarism.--Bolshevism paramount to supercapitalism."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "At head of title: G.C. Baravelli.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Stalin, Joseph, 1878-1953",
+            "Communism",
+            "Communism -- Soviet Union",
+            "Soviet Union",
+            "Soviet Union -- Economic conditions",
+            "Soviet Union -- Economic conditions -- 1917-1945"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "title": [
+            "Stalin's toast."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1937"
+          ],
+          "creatorLiteral": [
+            "Baravelli, G. C. (Giulio Cesare)"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "10504920"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1937"
+          ],
+          "titleDisplay": [
+            "Stalin's toast."
+          ],
+          "uri": "b14264413",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Roma"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          752.5737,
+          "b14264413"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "hb990099650640203941",
+        "_score": 750.619,
+        "_source": {
+          "extent": [
+            "247 p. ;"
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "publisherLiteral": [
+            "Cosmos Books"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2006
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2006
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990099650640203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0809556030 (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "69652590"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-12049344"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)69652590"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779600182453,
+          "publicationStatement": [
+            "Holicong, PA : Cosmos Books, c2006, c2002."
+          ],
+          "identifier": [
+            "urn:bnum:990099650640203941",
+            "urn:isbn:0809556030 (pbk.)",
+            "urn:oclc:69652590",
+            "urn:oclc:SCSB-12049344",
+            "urn:identifier:(OCoLC)69652590"
+          ],
+          "creators_displayPacked": [
+            "Stross, Charles||Stross, Charles"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2007",
+                "gte": "2006"
+              },
+              "raw": "060530r20062002pau           000 j eng d",
+              "tag": "r"
+            },
+            {
+              "range": {
+                "lt": "2003",
+                "gte": "2002"
+              },
+              "raw": "060530r20062002pau           000 j eng d",
+              "tag": "r"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Short stories."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PR6119.T79 T63 2006"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "247 p. ; 23 cm."
+          ],
+          "tableOfContents": [
+            "Antibodies -- Bear trap -- Extracts from the Club Diary -- A colder war -- Toast: a con report -- A boy and his God -- Ship of fools -- Dechlorinating the moderator -- Yellow snow -- Big Brother Iron."
+          ],
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain 20181001 in perpetuity ReCAP Shared Collection HUL 222106586330003941",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Short stories"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "2002"
+          ],
+          "title": [
+            "Toast / Charles Stross."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2006"
+          ],
+          "creatorLiteral": [
+            "Stross, Charles"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "69652590",
+            "SCSB-12049344"
+          ],
+          "dateEndYear": [
+            2002
+          ],
+          "genreForm": [
+            "short stories.",
+            "Short stories",
+            "Science fiction",
+            "Nouvelles."
+          ],
+          "idIsbn": [
+            "0809556030 (pbk.)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2006"
+          ],
+          "titleDisplay": [
+            "Toast / Charles Stross."
+          ],
+          "uri": "hb990099650640203941",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Holicong, PA"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ],
+          "idIsbn_clean": [
+            "0809556030"
+          ]
+        },
+        "sort": [
+          750.619,
+          "hb990099650640203941"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "hb990099650640203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR6119.T79 T63 2006 copy ",
+                      "urn:barcode:32044077499465"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PR6119.T79 T63 2006 copy ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32044077499465",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32044077499465"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "physicalLocation": [
+                      "PR6119.T79 T63 2006"
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PR6119.T79 T63 2006 copy "
+                    ],
+                    "shelfMark_sort": "aPR6119.T79 T63 2006 copy ",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "hi232106586300003941"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb6955197",
+        "_score": 750.619,
+        "_source": {
+          "extent": [
+            "386 p. ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "editionStatement": [
+            "Wyd. 1."
+          ],
+          "publisherLiteral": [
+            "Wydawn. \"Czarne\""
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2010
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2010
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "6955197"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9788375361940"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocn671293997"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-1622764"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(PlWaKWL)lx2010024594"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocn671293997"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779562679286,
+          "publicationStatement": [
+            "Wołowiec : Wydawn. \"Czarne\", 2010."
+          ],
+          "identifier": [
+            "urn:bnum:6955197",
+            "urn:isbn:9788375361940",
+            "urn:oclc:ocn671293997",
+            "urn:oclc:SCSB-1622764",
+            "urn:identifier:(PlWaKWL)lx2010024594",
+            "urn:identifier:(OCoLC)ocn671293997"
+          ],
+          "creators_displayPacked": [
+            "Górecki, Wojciech, 1970-||Górecki, Wojciech, 1970-"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2011",
+                "gte": "2010"
+              },
+              "raw": "100505s2010    pl       b    000 0 pol  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PG7223.I78 T627 2010"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "386 p. ; 20 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "seriesUniformTitle_displayPacked": [
+            "Reportaż.||Reportaż."
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast za przodków"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2010"
+          ],
+          "creatorLiteral": [
+            "Górecki, Wojciech, 1970-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocn671293997",
+            "SCSB-1622764"
+          ],
+          "seriesUniformTitle": [
+            "Reportaż."
+          ],
+          "idIsbn": [
+            "9788375361940"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2010"
+          ],
+          "titleDisplay": [
+            "Toast za przodków / Wojciech Górecki."
+          ],
+          "uri": "pb6955197",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Wołowiec"
+          ],
+          "series": [
+            "Reportaż"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Reportaż||Reportaż"
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "9788375361940"
+          ]
+        },
+        "sort": [
+          750.619,
+          "pb6955197"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb6955197",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PG7223.I78 T627 2010",
+                      "urn:barcode:32101072287822"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PG7223.I78 T627 2010",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101072287822",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101072287822"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PG7223.I78 T627 2010"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PG7223.I78 T627 2010"
+                    ],
+                    "shelfMark_sort": "aPG7223.I78 T627 002010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi6260657"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb9969551973506421",
+        "_score": 750.619,
+        "_source": {
+          "extent": [
+            "386 pages : map ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "editionStatement": [
+            "Wyd. 1."
+          ],
+          "publisherLiteral": [
+            "Wydawn. Czarne"
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2010
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2010
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9969551973506421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9788375361940"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "8375361941"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocn671293997"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "671293997"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-1622764"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(PlWaKWL)lx2010024594"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)6955197-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocn671293997"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager6955197"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)671293997"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779628932640,
+          "publicationStatement": [
+            "Wołowiec : Wydawn. Czarne, 2010."
+          ],
+          "identifier": [
+            "urn:bnum:9969551973506421",
+            "urn:isbn:9788375361940",
+            "urn:isbn:8375361941",
+            "urn:oclc:ocn671293997",
+            "urn:oclc:671293997",
+            "urn:oclc:SCSB-1622764",
+            "urn:identifier:(PlWaKWL)lx2010024594",
+            "urn:identifier:(NjP)6955197-princetondb",
+            "urn:identifier:(OCoLC)ocn671293997",
+            "urn:identifier:(NjP)Voyager6955197",
+            "urn:identifier:(OCoLC)671293997"
+          ],
+          "creators_displayPacked": [
+            "Górecki, Wojciech, 1970-||Górecki, Wojciech, 1970-"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2011",
+                "gte": "2010"
+              },
+              "raw": "101021s2010    pl b     b    000 0 pol  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Caucasus.",
+            "Caucasus -- Civilization."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PG7223.I78 T627 2010"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "386 pages : map ; 20 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "seriesUniformTitle_displayPacked": [
+            "Seria Reportaż.||Seria Reportaż."
+          ],
+          "subjectLiteral_exploded": [
+            "Caucasus",
+            "Caucasus -- Civilization"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast za przodków"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2010"
+          ],
+          "creatorLiteral": [
+            "Górecki, Wojciech, 1970-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocn671293997",
+            "671293997",
+            "SCSB-1622764"
+          ],
+          "seriesUniformTitle": [
+            "Seria Reportaż."
+          ],
+          "idIsbn": [
+            "9788375361940",
+            "8375361941"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2010"
+          ],
+          "titleDisplay": [
+            "Toast za przodków / Wojciech Górecki."
+          ],
+          "uri": "pb9969551973506421",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Wołowiec"
+          ],
+          "series": [
+            "Reportaż"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Reportaż||Reportaż"
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "9788375361940",
+            "8375361941"
+          ]
+        },
+        "sort": [
+          750.619,
+          "pb9969551973506421"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb9969551973506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PG7223.I78 T627 2010",
+                      "urn:barcode:32101072287822"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PG7223.I78 T627 2010",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101072287822",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101072287822"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PG7223.I78 T627 2010"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PG7223.I78 T627 2010"
+                    ],
+                    "shelfMark_sort": "aPG7223.I78 T627 002010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi23652743930006421"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b15868157",
+        "_score": 722.9889,
+        "_source": {
+          "extent": [
+            "64 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Hope Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "sc"
+          ],
+          "createdYear": [
+            2002
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "Sc D 13-57 no. 1"
+          ],
+          "idLccn": [
+            "2004352407"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2002
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 13-57 no. 1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15868157"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9783654845 (pbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9789783654846 (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "54955577"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2004352407"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)54955577"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779429767620,
+          "publicationStatement": [
+            "Ibadan, Nigeria : Hope Publications, 2002."
+          ],
+          "identifier": [
+            "urn:shelfmark:Sc D 13-57 no. 1",
+            "urn:bnum:15868157",
+            "urn:isbn:9783654845 (pbk.)",
+            "urn:isbn:9789783654846 (pbk.)",
+            "urn:oclc:54955577",
+            "urn:lccn:2004352407",
+            "urn:identifier:(OCoLC)54955577"
+          ],
+          "creators_displayPacked": [
+            "Odeleye, Biodun||Odeleye, Biodun"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2003",
+                "gte": "2002"
+              },
+              "raw": "040130s2002    nr a          000 p eng  cam a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Conduct of life -- Poetry.",
+            "Nigeria -- Poetry."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PR9387.9.O3115 T63 2002"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "scf"
+          ],
+          "titleAlt": [
+            "Toast to life and vision"
+          ],
+          "physicalDescription": [
+            "64 p. : ill. ; 21 cm."
+          ],
+          "tableOfContents": [
+            "Moon among stars -- Vampires on rampage -- The dangling visionary saw -- Much to a name -- Dear mother -- La Rambla -- Personifying death -- Success turns albatross in the hall of nobility."
+          ],
+          "subjectLiteral_exploded": [
+            "Conduct of life",
+            "Conduct of life -- Poetry",
+            "Nigeria",
+            "Nigeria -- Poetry"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast to life & vision"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2002"
+          ],
+          "creatorLiteral": [
+            "Odeleye, Biodun"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "54955577"
+          ],
+          "popularity": 1,
+          "idIsbn": [
+            "9783654845 (pbk.)",
+            "9789783654846 (pbk.)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2002"
+          ],
+          "titleDisplay": [
+            "Toast to life & vision / Biodun Odeleye."
+          ],
+          "uri": "b15868157",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Ibadan, Nigeria"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "9783654845",
+            "9789783654846"
+          ]
+        },
+        "sort": [
+          722.9889,
+          "b15868157"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b15868157",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:61",
+                        "label": "pamphlet volumes, bound with"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:61||pamphlet volumes, bound with"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc D 13-57",
+                      "urn:barcode:33433089426146"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 13-57",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433089426146",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433089426146"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "physicalLocation": [
+                      "Sc D 13-57"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "Sc D 13-57"
+                    ],
+                    "shelfMark_sort": "aSc D 13-000057",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i29987107"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b19635190",
+        "_score": 722.9889,
+        "_source": {
+          "extent": [
+            "1 sound disc (46 min.) : digital, mono. ;"
+          ],
+          "partOf": [
+            "Oscar Hammerstein collection of noncommercial sound recordings, 1942-1955."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1951
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LDC 37733",
+            "*LJ-12 5896"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1951
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 37733"
+            },
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LJ-12 5896"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "19635190"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "794597226"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)794597226"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Sullivan, Ed, 1901-1974||Sullivan, Ed, 1901-1974, narrator",
+            "Hammerstein, Oscar, II, 1895-1960||Hammerstein, Oscar, II, 1895-1960, interviewee",
+            "Horne, Lena||Horne, Lena, performer",
+            "Merrill, Robert, 1917-2004||Merrill, Robert, 1917-2004, performer",
+            "Benzell, Mimi||Benzell, Mimi, performer",
+            "Tabbert, William, 1919-1974||Tabbert, William, 1919-1974, performer",
+            "Hall, George, 1916-2002||Hall, George, 1916-2002, performer",
+            "Cox, Wally, 1924-1973||Cox, Wally, 1924-1973, performer"
+          ],
+          "updatedAt": 1779489754758,
+          "publicationStatement": [
+            "1951."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 37733",
+            "urn:shelfmark:*LJ-12 5896",
+            "urn:bnum:19635190",
+            "urn:oclc:794597226",
+            "urn:identifier:(OCoLC)794597226"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "gte": "1951-09-09",
+                "lte": "1951-09-09T23:59:59"
+              },
+              "raw": "120601e19510909nyumcnn           n eng dnjmIa ",
+              "tag": "e"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Hammerstein, Oscar, II, 1895-1960 -- Interviews.",
+            "Lyricists -- United States -- Biography.",
+            "Musicals -- Excerpts."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "y",
+          "collectionIds": [
+            "pah"
+          ],
+          "titleAlt": [
+            "Oscar Hammerstein story, pt. 1",
+            "Oscar Hammerstein collection of noncommercial sound recordings."
+          ],
+          "physicalDescription": [
+            "1 sound disc (46 min.) : digital, mono. ; 4 3/4 in."
+          ],
+          "tableOfContents": [
+            "Opening commentary and early biography of Oscar Hammerstein II -- Indian love call (Mimi Benzell and Robert Merrill) -- Biography continued (incomplete) -- One alone (Bill Tabbert) (incomplete) -- Biography continued -- Can't help lovin' that man (Lena Horne) -- Biography continued (incomplete) -- Old man river (Robert Merrill) -- Biography continued (incomplete) -- Lover come back to me (Mimi Benzell) -- Comedy skit (incomplete) / George Hall ; Wally Cox -- Interview with Oscar Hammerstein II -- Ending commentary & sponsor's advertisements (Lincoln automobiles) -- Announcement for the next show."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Audio portion of CBS Television broadcast.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Transfer to compact disc incomplete due to damage to the original lacquer discs; side one is completely delaminated, and other sides have minor damage.  Original program ran 60 min.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access to original items restricted.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Marlo Lewis and Ed Sullivan (producers) ; John Wray (direction) ; Ray Bloch (musical direction)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Forms part of the Oscar Hammerstein collection of noncommercial sound recordings, 1942-1955.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Local note",
+              "label": "Archival original: (7 sound discs : analog, aluminum based lacquer, 78 rpm, mono. ; 12 in.) in *LJ-12 5896.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Hammerstein, Oscar, II, 1895-1960",
+            "Hammerstein, Oscar, II, 1895-1960 -- Interviews",
+            "Lyricists",
+            "Lyricists -- United States",
+            "Lyricists -- United States -- Biography",
+            "Musicals",
+            "Musicals -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "0909"
+          ],
+          "title": [
+            "Toast of the town."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1951"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sullivan, Ed, 1901-1974",
+            "Hammerstein, Oscar, II, 1895-1960",
+            "Horne, Lena",
+            "Merrill, Robert, 1917-2004",
+            "Benzell, Mimi",
+            "Tabbert, William, 1919-1974",
+            "Hall, George, 1916-2002",
+            "Cox, Wally, 1924-1973"
+          ],
+          "idOclc": [
+            "794597226"
+          ],
+          "uniformTitle": [
+            "Ed Sullivan show (Television program)"
+          ],
+          "dateEndYear": [
+            909
+          ],
+          "genreForm": [
+            "Variety shows (Television programs)",
+            "Television commercials."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1951"
+          ],
+          "titleDisplay": [
+            "Toast of the town. 1951-09-09, the Oscar Hammerstein story, pt. 1 [sound recording] / CBS-TV ; written by Ed Sullivan."
+          ],
+          "uri": "b19635190",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "recordTypeId": "j",
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          722.9889,
+          "b19635190"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b19635190",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&CallNumber=*LDC+37733&Date=1951&Form=30&Genre=archival+sound+recording&ItemInfo1=Use+in+library&ItemInfo2=Access+to+original+items+restricted.&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db19635190&ItemISxN=i288025581&ItemNumber=33433099082954&ItemPublisher=1951.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b19635190x&Site=LPAMRAMI&Title=Toast+of+the+town.&Transaction.CustomFields.MapsLocationNote=%5BCD%5D"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:23",
+                        "label": "archival sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:23||archival sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 37733",
+                      "urn:barcode:33433099082954"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LDC 37733",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433099082954",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433099082954"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 37733"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LDC 37733"
+                    ],
+                    "shelfMark_sort": "a*LDC 037733",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i28802558"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b19635203",
+        "_score": 722.9889,
+        "_source": {
+          "extent": [
+            "1 sound disc (46 min.) : digital, mono. ;"
+          ],
+          "partOf": [
+            "Oscar Hammerstein collection of noncommercial sound recordings, 1942-1955."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1951
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LDC 50447",
+            "*LJ-12 5909"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1951
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 50447"
+            },
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LJ-12 5909"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "19635203"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "794597454"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)794597454"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Sullivan, Ed, 1901-1974||Sullivan, Ed, 1901-1974, narrator",
+            "Hammerstein, Oscar, II, 1895-1960||Hammerstein, Oscar, II, 1895-1960, interviewee",
+            "Rodgers, Richard, 1902-1979||Rodgers, Richard, 1902-1979, interviewee",
+            "Rodgers, Richard, 1902-1979||Rodgers, Richard, 1902-1979, instrumentalist",
+            "Deel, Sandra||Deel, Sandra, performer",
+            "Merrill, Robert, 1917-2004||Merrill, Robert, 1917-2004, performer",
+            "Rahn, Muriel||Rahn, Muriel, performer",
+            "Tabbert, William, 1919-1974||Tabbert, William, 1919-1974, performer",
+            "Lawrence, Gertrude||Lawrence, Gertrude, performer"
+          ],
+          "updatedAt": 1779489754758,
+          "publicationStatement": [
+            "1951."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 50447",
+            "urn:shelfmark:*LJ-12 5909",
+            "urn:bnum:19635203",
+            "urn:oclc:794597454",
+            "urn:identifier:(OCoLC)794597454"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "gte": "1951-09-16",
+                "lte": "1951-09-16T23:59:59"
+              },
+              "raw": "120601e19510916nyumcnn           n eng dnjmIa ",
+              "tag": "e"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Hammerstein, Oscar, II, 1895-1960 -- Interviews.",
+            "Rodgers, Richard, 1902-1979 -- Interviews.",
+            "Lyricists -- United States -- Biography.",
+            "Musicals -- Excerpts."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "y",
+          "collectionIds": [
+            "pah"
+          ],
+          "titleAlt": [
+            "Oscar Hammerstein story, pt. 2",
+            "Oscar Hammerstein collection of noncommercial sound recordings."
+          ],
+          "physicalDescription": [
+            "1 sound disc (46 min.) : digital, mono. ; 4 3/4 in."
+          ],
+          "tableOfContents": [
+            "[Sides 1 & 2 unplayable] -- Commentary on Oklahoma (Ed Sullivan, incomplete) -- People will say we're in love (Robert Merrill & Sandra Deel) -- Habanera from Carmen Jones (Murial Rahn, incomplete) -- [Side 5 unplayable] -- Some Enchanted Evening (Robert Merrill) -- You've Got To Be Carefully Taught (Bill Tabbert) -- Sullivan speaks with Hammerstein and Richard Rodgers about their partnership -- Whistle A Happy Tune & Getting To Know You (Gertrude Lawrence & Richard Rodgers, piano) -- You'll never walk alone (Merrill) -- Commercial announcement for Lincoln automobiles -- Concluding announcements (incomplete)"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Audio portion of CBS Television broadcast.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Audio distortion from original source. Transfer to compact disc incomplete due to damage to the original lacquer discs; side one, two, five, and seven are completely delaminated, and other sides have minor damage.  Original program ran 60 min.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access to original items restricted.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Marlo Lewis and Ed Sullivan (producers) ; John Wray (direction) ; Ray Bloch (musical direction)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Forms part of the Oscar Hammerstein collection of noncommercial sound recordings, 1942-1955.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Local note",
+              "label": "Archival original: (7 sound discs : analog, aluminum based lacquer, 78 rpm, mono. ; 12 in.) in *LJ-12 5909.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Hammerstein, Oscar, II, 1895-1960",
+            "Hammerstein, Oscar, II, 1895-1960 -- Interviews",
+            "Rodgers, Richard, 1902-1979",
+            "Rodgers, Richard, 1902-1979 -- Interviews",
+            "Lyricists",
+            "Lyricists -- United States",
+            "Lyricists -- United States -- Biography",
+            "Musicals",
+            "Musicals -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "0916"
+          ],
+          "title": [
+            "Toast of the town."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1951"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sullivan, Ed, 1901-1974",
+            "Hammerstein, Oscar, II, 1895-1960",
+            "Rodgers, Richard, 1902-1979",
+            "Rodgers, Richard, 1902-1979",
+            "Deel, Sandra",
+            "Merrill, Robert, 1917-2004",
+            "Rahn, Muriel",
+            "Tabbert, William, 1919-1974",
+            "Lawrence, Gertrude"
+          ],
+          "idOclc": [
+            "794597454"
+          ],
+          "uniformTitle": [
+            "Ed Sullivan show (Television program)"
+          ],
+          "dateEndYear": [
+            916
+          ],
+          "genreForm": [
+            "Variety shows (Television programs)",
+            "Television commercials."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1951"
+          ],
+          "titleDisplay": [
+            "Toast of the town. 1951-09-16, the Oscar Hammerstein story, pt. 2 [sound recording] / CBS-TV ; written by Ed Sullivan."
+          ],
+          "uri": "b19635203",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "recordTypeId": "j",
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          722.9889,
+          "b19635203"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b19635203",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&CallNumber=*LDC+50447&Date=1951&Form=30&Genre=archival+sound+recording&ItemInfo1=Use+in+library&ItemInfo2=Access+to+original+items+restricted.&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db19635203&ItemISxN=i288025854&ItemNumber=33433099082962&ItemPublisher=1951.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b196352034&Site=LPAMRAMI&Title=Toast+of+the+town.&Transaction.CustomFields.MapsLocationNote=%5BCD%5D"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:23",
+                        "label": "archival sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:23||archival sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 50447",
+                      "urn:barcode:33433099082962"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LDC 50447",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433099082962",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433099082962"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 50447"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LDC 50447"
+                    ],
+                    "shelfMark_sort": "a*LDC 050447",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i28802585"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b12004445",
+        "_score": 717.7355,
+        "_source": {
+          "extent": [
+            "124 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Kneipp"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1993
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 94-21395"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1993
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 94-21395"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12004445"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3900696349"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "31256373"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGR31256373-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)31256373"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "LC 199410"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779342465834,
+          "publicationStatement": [
+            "Leoben : Kneipp, 1993."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 94-21395",
+            "urn:bnum:12004445",
+            "urn:isbn:3900696349",
+            "urn:oclc:31256373",
+            "urn:oclc:NYPGR31256373-B",
+            "urn:identifier:(OCoLC)31256373",
+            "urn:identifier:LC 199410"
+          ],
+          "creators_displayPacked": [
+            "Heindel, Gabriele||Heindel, Gabriele"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1994",
+                "gte": "1993"
+              },
+              "raw": "941011s1993    au            000 0 ger dnamua ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "124 p. ; 21 cm."
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Mein Lieblings-Toast : 300 heisse Tips für Toast-Fans"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1993"
+          ],
+          "creatorLiteral": [
+            "Heindel, Gabriele"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "31256373",
+            "NYPGR31256373-B"
+          ],
+          "idIsbn": [
+            "3900696349"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1993"
+          ],
+          "titleDisplay": [
+            "Mein Lieblings-Toast : 300 heisse Tips für Toast-Fans / Gabriele Heindel."
+          ],
+          "uri": "b12004445",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Leoben"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "3900696349"
+          ]
+        },
+        "sort": [
+          717.7355,
+          "b12004445"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b12004445",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 94-21395",
+                      "urn:barcode:33433041530118"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFD 94-21395",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433041530118",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433041530118"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "physicalLocation": [
+                      "JFD 94-21395"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFD 94-21395"
+                    ],
+                    "shelfMark_sort": "aJFD 94-021395",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i13317173"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b11294632",
+        "_score": 710.97174,
+        "_source": {
+          "extent": [
+            "xxi, 273 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "editionStatement": [
+            "1st Vintage Books ed."
+          ],
+          "publisherLiteral": [
+            "Vintage Books"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1990
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 90-6303"
+          ],
+          "idLccn": [
+            "89040281"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1990
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 90-6303"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11294632"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0679726861"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "70304237"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG90-B53168"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "89040281"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1302350"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)70304237"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779329441733,
+          "publicationStatement": [
+            "New York : Vintage Books, 1990, c1940."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 90-6303",
+            "urn:bnum:11294632",
+            "urn:isbn:0679726861",
+            "urn:oclc:70304237",
+            "urn:oclc:NYPG90-B53168",
+            "urn:lccn:89040281",
+            "urn:identifier:(WaOLN)nyp1302350",
+            "urn:identifier:(OCoLC)70304237"
+          ],
+          "creators_displayPacked": [
+            "Powell, Dawn||Powell, Dawn"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1991",
+                "gte": "1990"
+              },
+              "raw": "900615r19901940nyu           000 1 eng  cam8a ",
+              "tag": "r"
+            },
+            {
+              "range": {
+                "lt": "1941",
+                "gte": "1940"
+              },
+              "raw": "900615r19901940nyu           000 1 eng  cam8a ",
+              "tag": "r"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PS3531.O936 A83 1989"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "xxi, 273 p. ; 21 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Originally published ... by Charles Scribner's Sons ... in 1940\"--T.p. verso.",
+              "type": "bf:Note"
+            }
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1940"
+          ],
+          "title": [
+            "Angels on toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1990"
+          ],
+          "creatorLiteral": [
+            "Powell, Dawn"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "70304237",
+            "NYPG90-B53168"
+          ],
+          "popularity": 2,
+          "dateEndYear": [
+            1940
+          ],
+          "idIsbn": [
+            "0679726861"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1990"
+          ],
+          "titleDisplay": [
+            "Angels on toast / Dawn Powell ; with an introduction by Gore Vidal."
+          ],
+          "uri": "b11294632",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "0679726861"
+          ]
+        },
+        "sort": [
+          710.97174,
+          "b11294632"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b11294632",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 90-6303",
+                      "urn:barcode:33433040606604"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFD 90-6303",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433040606604",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433040606604"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "JFD 90-6303"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFD 90-6303"
+                    ],
+                    "shelfMark_sort": "aJFD 90-006303",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i13160245"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b13060795",
+        "_score": 710.97174,
+        "_source": {
+          "extent": [
+            "29 p. col. illus."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Coward-McCann, inc."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1942
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "NAS (Kantor, M. Angleworms on toast)"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1942
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NAS (Kantor, M. Angleworms on toast)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13060795"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "26982453"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Wiese, Kurt, 1887-||Wiese, Kurt, 1887-, illustrator"
+          ],
+          "updatedAt": 1779386328350,
+          "publicationStatement": [
+            "New York, Coward-McCann, inc., c1942."
+          ],
+          "identifier": [
+            "urn:shelfmark:NAS (Kantor, M. Angleworms on toast)",
+            "urn:bnum:13060795",
+            "urn:oclc:26982453"
+          ],
+          "creators_displayPacked": [
+            "Kantor, MacKinlay, 1904-1977||Kantor, MacKinlay, 1904-1977"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1943",
+                "gte": "1942"
+              },
+              "raw": "921116s1942    nyua   j      000 1 eng dnamI  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "29 p. : col. illus. ; 18 x 25 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Grades 1-3.",
+              "type": "bf:Note"
+            }
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Angleworms on toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1942"
+          ],
+          "creatorLiteral": [
+            "Kantor, MacKinlay, 1904-1977"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Wiese, Kurt, 1887-"
+          ],
+          "idOclc": [
+            "26982453"
+          ],
+          "popularity": 1,
+          "summary": [
+            "Thomas always pretended his favorite menu was creamed angleworms on toast. Then one day when he also pretended he was sick enough to miss school, his family thought he deserved whatever he wanted for lunch."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1942"
+          ],
+          "titleDisplay": [
+            "Angleworms on toast, by MacKinlay Kantor. Illustrated by Kurt Wiese."
+          ],
+          "uri": "b13060795",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 x 25 cm."
+          ]
+        },
+        "sort": [
+          710.97174,
+          "b13060795"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b13060795",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:66",
+                        "label": "book, poor condition, non-MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:66||book, poor condition, non-MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NAS (Kantor, M. Angleworms on toast)",
+                      "urn:barcode:33433084609134"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "NAS (Kantor, M. Angleworms on toast)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433084609134",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433084609134"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "NAS (Kantor, M. Angleworms on toast)"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "NAS (Kantor, M. Angleworms on toast)"
+                    ],
+                    "shelfMark_sort": "aNAS (Kantor, M. Angleworms on toast)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i16222433"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b16436832",
+        "_score": 710.97174,
+        "_source": {
+          "extent": [
+            "on 1 side of 1 sound disc : analog, 78 rpm, mono. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Victor"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1908
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LO 338"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1908
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LO 338"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16436832"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "71232236"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "4074 Victor"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "B1105 Victor"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M010000216"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Gogorza, Emilio de, 1872-1949||Gogorza, Emilio de, 1872-1949, performer",
+            "Victor Orchestra||Victor Orchestra, performer"
+          ],
+          "updatedAt": 1779436758053,
+          "publicationStatement": [
+            "Camden, NJ : Victor, [between 1908 and 1913]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LO 338",
+            "urn:bnum:16436832",
+            "urn:oclc:71232236",
+            "urn:identifier:4074 Victor",
+            "urn:identifier:B1105 Victor",
+            "urn:identifier:(WaOLN)M010000216"
+          ],
+          "creators_displayPacked": [
+            "Bizet, Georges, 1838-1875||Bizet, Georges, 1838-1875"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1909",
+                "gte": "1908"
+              },
+              "raw": "060901q19081913njuopn              fre dnjmIa ",
+              "tag": "q"
+            },
+            {
+              "range": {
+                "lt": "1914",
+                "gte": "1913"
+              },
+              "raw": "060901q19081913njuopn              fre dnjmIa ",
+              "tag": "q"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "j",
+          "collectionIds": [
+            "pah"
+          ],
+          "titleAlt": [
+            "Carmen. Chanson du toréador",
+            "Toreador song",
+            "Votre toast"
+          ],
+          "physicalDescription": [
+            "on 1 side of 1 sound disc : analog, 78 rpm, mono. ; 10 in."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Victor: 4074; matrix no.: B1105.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in French.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1913"
+          ],
+          "title": [
+            "Carmen. [Votre toast]"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1908"
+          ],
+          "creatorLiteral": [
+            "Bizet, Georges, 1838-1875"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Gogorza, Emilio de, 1872-1949",
+            "Victor Orchestra"
+          ],
+          "idOclc": [
+            "71232236"
+          ],
+          "uniformTitle": [
+            "Carmen. Chanson du toréador"
+          ],
+          "dateEndYear": [
+            1913
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1908"
+          ],
+          "titleDisplay": [
+            "Carmen. Toreador song [sound recording] = [Votre toast] / Bizet."
+          ],
+          "uri": "b16436832",
+          "parallelContributorLiteral": [
+            null,
+            null
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Camden, NJ"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "10 in."
+          ]
+        },
+        "sort": [
+          710.97174,
+          "b16436832"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16436832",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Bizet%2C+Georges%2C+1838-1875&CallNumber=*LO+338+%5BDisc%5D&Date=1908&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16436832&ItemISxN=i172397315&ItemNumber=33433070578319&ItemPlace=Camden%2C+NJ&ItemPublisher=Victor%2C+%5Bbetween+1908+and+1913%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b164368322&Site=LPAMRAMI&Title=Carmen.+%5BVotre+toast%5D"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LO 338 [Disc]",
+                      "urn:barcode:33433070578319"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LO 338 [Disc]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433070578319",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433070578319"
+                    ],
+                    "physicalLocation": [
+                      "*LO 338 [Disc]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LO 338 [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LO 338 [Disc]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17239731"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b16671423",
+        "_score": 710.97174,
+        "_source": {
+          "extent": [
+            "1 folder"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Clippings from the Music Division clippings files",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Roma's Toast (song)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            null
+          ],
+          "parallelSeriesAddedEntry": [],
+          "title": [
+            "Roma's Toast (song)"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "M-Clippings (Subjects)"
+          ],
+          "createdString": [
+            "    "
+          ],
+          "creatorLiteral": [],
+          "parallelCreators_displayPacked": [],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            null
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "idOclc": [
+            "Local - CLIP Music Clippings"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "M-Clippings (Subjects)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16671423"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "Local - CLIP Music Clippings"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779469061378,
+          "genreForm": [
+            "Clippings."
+          ],
+          "identifier": [
+            "urn:shelfmark:M-Clippings (Subjects)",
+            "urn:bnum:16671423",
+            "urn:oclc:Local - CLIP Music Clippings"
+          ],
+          "creators_displayPacked": [],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "    "
+          ],
+          "dates": [],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Roma's Toast (song)"
+          ],
+          "titleDisplay": [
+            "Roma's Toast (song) : clippings"
+          ],
+          "uri": "b16671423",
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelContributorLiteral": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "p",
+          "recordTypeId": "a",
+          "collectionIds": [
+            "pam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "physicalDescription": [
+            "1 folder"
+          ]
+        },
+        "sort": [
+          710.97174,
+          "b16671423"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16671423",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&CallNumber=M-Clippings+%28Subjects%29&Date=++++&Form=30&Genre=clipping+files&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16671423&ItemISxN=i17393514x&ItemNumber=33433087491175&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b166714239&Site=LPAMR&Title=Roma%27s+Toast+%28song%29+%3A+clippings"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:22",
+                        "label": "clipping files"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:22||clipping files"
+                    ],
+                    "formatLiteral": [
+                      "Archival mix"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pam38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pam38||Performing Arts Research Collections - Music"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:M-Clippings (Subjects)",
+                      "urn:barcode:33433087491175"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-Clippings (Subjects)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433087491175",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433087491175"
+                    ],
+                    "physicalLocation": [
+                      "M-Clippings (Subjects)"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "M-Clippings (Subjects)"
+                    ],
+                    "shelfMark_sort": "aM-Clippings (Subjects)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17393514"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b10981311",
+        "_score": 709.97174,
+        "_source": {
+          "extent": [
+            "1 miniature score (12 p.) ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Jalni Publications : Boosey & Hawkes, sole selling agent"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JNF 87-27"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1984
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNF 87-27"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10981311"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11578466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG85-C1260"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "HPS 976. Boosey & Hawkes"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0988546"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)11578466"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Kostelanetz, Andre, 1901-1980||Kostelanetz, Andre, 1901-1980"
+          ],
+          "updatedAt": 1779324369308,
+          "publicationStatement": [
+            "[United States] : Jalni Publications : Boosey & Hawkes, sole selling agent, 1984, c1980."
+          ],
+          "identifier": [
+            "urn:shelfmark:JNF 87-27",
+            "urn:bnum:10981311",
+            "urn:oclc:11578466",
+            "urn:oclc:NYPG85-C1260",
+            "urn:identifier:HPS 976. Boosey & Hawkes",
+            "urn:identifier:(WaOLN)nyp0988546",
+            "urn:identifier:(OCoLC)11578466"
+          ],
+          "creators_displayPacked": [
+            "Bernstein, Leonard, 1918-1990||Bernstein, Leonard, 1918-1990"
+          ],
+          "dates": [],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "c",
+          "collectionIds": [
+            "pam"
+          ],
+          "physicalDescription": [
+            "1 miniature score (12 p.) ; 27 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: H.P.S. 976.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Fondly dedicated to the memory of André Kostelanetz.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 2:30.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1980"
+          ],
+          "title": [
+            "A musical toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [
+            "Bernstein, Leonard, 1918-1990"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Kostelanetz, Andre, 1901-1980"
+          ],
+          "idOclc": [
+            "11578466",
+            "NYPG85-C1260"
+          ],
+          "popularity": 1,
+          "dateEndYear": [
+            1980
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "titleDisplay": [
+            "A musical toast / Leonard Bernstein."
+          ],
+          "uri": "b10981311",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "[United States]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          709.97174,
+          "b10981311"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b10981311",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:57",
+                        "label": "printed music limited circ MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:57||printed music limited circ MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JNF 87-27",
+                      "urn:barcode:33433047232982"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JNF 87-27",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433047232982",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433047232982"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "physicalLocation": [
+                      "JNF 87-27"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JNF 87-27"
+                    ],
+                    "shelfMark_sort": "aJNF 87-000027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i13956002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b13131869",
+        "_score": 709.97174,
+        "_source": {
+          "extent": [
+            "242 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Kingston Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1920
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "NCM (Back, K. J. Royal toast)"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1920
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NCM (Back, K. J. Royal toast)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13131869"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "18297389"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779387466830,
+          "publicationStatement": [
+            "Sydney [N.S.W.] : Kingston Press, 1920."
+          ],
+          "identifier": [
+            "urn:shelfmark:NCM (Back, K. J. Royal toast)",
+            "urn:bnum:13131869",
+            "urn:oclc:18297389"
+          ],
+          "creators_displayPacked": [
+            "Australianus||Australianus"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1921",
+                "gte": "1920"
+              },
+              "raw": "880801s1920    at            000 p eng dnamIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "242 p. ; 19 cm."
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "The royal toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1920"
+          ],
+          "creatorLiteral": [
+            "Australianus"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "18297389"
+          ],
+          "popularity": 2,
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1920"
+          ],
+          "titleDisplay": [
+            "The royal toast / by \"Australianus\"."
+          ],
+          "uri": "b13131869",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Sydney [N.S.W.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          709.97174,
+          "b13131869"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b13131869",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NCM (Back, K. J. Royal toast)",
+                      "urn:barcode:33433112057363"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "NCM (Back, K. J. Royal toast)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433112057363",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433112057363"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "physicalLocation": [
+                      "NCM (Back, K. J. Royal toast)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "NCM (Back, K. J. Royal toast)"
+                    ],
+                    "shelfMark_sort": "aNCM (Back, K. J. Royal toast)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i16274064"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b17174971",
+        "_score": 709.97174,
+        "_source": {
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Putnam"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "68024523"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1969
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "17174971"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "68024523"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Wiese, Kurt, 1887-||Wiese, Kurt, 1887-, illustrator"
+          ],
+          "updatedAt": 1779474560028,
+          "publicationStatement": [
+            "New York : Putnam, [1969, c1942]"
+          ],
+          "identifier": [
+            "urn:bnum:17174971",
+            "urn:lccn:68024523"
+          ],
+          "creators_displayPacked": [
+            "Kantor, MacKinlay, 1904-1977||Kantor, MacKinlay, 1904-1977"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1970",
+                "gte": "1969"
+              },
+              "raw": "851130t19691942nyua   j      000 1 eng  nam   ",
+              "tag": "t"
+            },
+            {
+              "range": {
+                "lt": "1943",
+                "gte": "1942"
+              },
+              "raw": "851130t19691942nyua   j      000 1 eng  nam   ",
+              "tag": "t"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PZ7.K128 An5"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1942"
+          ],
+          "title": [
+            "Angleworms on toast."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "creatorLiteral": [
+            "Kantor, MacKinlay, 1904-1977"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Wiese, Kurt, 1887-"
+          ],
+          "popularity": 1,
+          "dateEndYear": [
+            1942
+          ],
+          "summary": [
+            "Thomas always pretended his favorite menu was creamed angleworms on toast. Then one day when he also pretended he was sick enough to miss school, his family thought he deserved whatever he wanted for lunch."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "titleDisplay": [
+            "Angleworms on toast. Illustrated by Kurt Wiese."
+          ],
+          "uri": "b17174971",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          709.97174,
+          "b17174971"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b17174971",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:J FIC K",
+                      "urn:barcode:33333059683314"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J FIC K",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33333059683314",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33333059683314"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "physicalLocation": [
+                      "J FIC K"
+                    ],
+                    "recapCustomerCode": [
+                      "NH"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "J FIC K"
+                    ],
+                    "shelfMark_sort": "aJ FIC K",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i22474239"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "cb15861113",
+        "_score": 700.619,
+        "_source": {
+          "extent": [
+            "288 pages ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "publisherLiteral": [
+            "Parthian"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2022
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "60002450032"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2022
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "15861113"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781912681877"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1912681870"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "on1263812851"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-13992812"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "60002450032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)on1263812851"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Edwards, Jonathan||Edwards, Jonathan, editor"
+          ],
+          "updatedAt": 1779429649371,
+          "publicationStatement": [
+            "Cardigan : Parthian, 2022."
+          ],
+          "identifier": [
+            "urn:bnum:15861113",
+            "urn:isbn:9781912681877",
+            "urn:isbn:1912681870",
+            "urn:oclc:on1263812851",
+            "urn:oclc:SCSB-13992812",
+            "urn:lccn:60002450032",
+            "urn:identifier:(OCoLC)on1263812851"
+          ],
+          "creators_displayPacked": [
+            "Mills, Tôpher||Mills, Tôpher, author"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2023",
+                "gte": "2022"
+              },
+              "raw": "210806s2022    wlk           000 p eng d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:undefined",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PR6113.I5865 S39 2022"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "288 pages ; 21 cm"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Sex on toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2022"
+          ],
+          "creatorLiteral": [
+            "Mills, Tôpher"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Edwards, Jonathan"
+          ],
+          "idOclc": [
+            "on1263812851",
+            "SCSB-13992812"
+          ],
+          "idIsbn": [
+            "9781912681877",
+            "1912681870"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2022"
+          ],
+          "titleDisplay": [
+            "Sex on toast / Tôpher Mills ; [editor, Jonathan Edwards]."
+          ],
+          "uri": "cb15861113",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Cardigan"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm"
+          ],
+          "idIsbn_clean": [
+            "9781912681877",
+            "1912681870"
+          ]
+        },
+        "sort": [
+          700.619,
+          "cb15861113"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb15861113",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR6113.I5865 S39 2022g",
+                      "urn:barcode:CU27972887"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PR6113.I5865 S39 2022g",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "CU27972887",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU27972887"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "PR6113.I5865 S39 2022g"
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PR6113.I5865 S39 2022g"
+                    ],
+                    "shelfMark_sort": "aPR6113.I5865 S39 2022g",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci10035633"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "cb1808514",
+        "_score": 700.619,
+        "_source": {
+          "extent": [
+            "1 score (3 unnumbered pages, 12 pages) ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "publisherLiteral": [
+            "Jalni Publications ; Boosey & Hawkes, sole selling agent"
+          ],
+          "language": [
+            {
+              "id": "lang:N/A",
+              "label": ""
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1984
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "1808514"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm11578466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-3364085"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "H.P.S. 976 Boosey & Hawkes"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm11578466"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)1808514"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "1808514"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779480345156,
+          "publicationStatement": [
+            "[Place of publication not identified] : Jalni Publications ; New York, N.Y. : Boosey & Hawkes, sole selling agent, 1984, ©1980."
+          ],
+          "identifier": [
+            "urn:bnum:1808514",
+            "urn:oclc:ocm11578466",
+            "urn:oclc:SCSB-3364085",
+            "urn:identifier:H.P.S. 976 Boosey & Hawkes",
+            "urn:identifier:(OCoLC)ocm11578466",
+            "urn:identifier:(NNC)1808514",
+            "urn:identifier:1808514"
+          ],
+          "creators_displayPacked": [
+            "Bernstein, Leonard, 1918-1990||Bernstein, Leonard, 1918-1990"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1985",
+                "gte": "1984"
+              },
+              "raw": "850114t19841980nyuzza   i     n    N/A d",
+              "tag": "t"
+            },
+            {
+              "range": {
+                "lt": "1981",
+                "gte": "1980"
+              },
+              "raw": "850114t19841980nyuzza   i     n    N/A d",
+              "tag": "t"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "c",
+          "collectionIds": [],
+          "titleAlt": [
+            "Musical toast"
+          ],
+          "physicalDescription": [
+            "1 score (3 unnumbered pages, 12 pages) ; 27 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes by Jack Gottlieb.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 2:30.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Recorded by the Israel Philharmonic, the composer conducting, on Deutsche Grammophon 2532 052.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Also available in a version for symphonic band.",
+              "type": "bf:Note"
+            }
+          ],
+          "seriesUniformTitle_displayPacked": [
+            "Hawkes pocket scores.||Hawkes pocket scores."
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1980"
+          ],
+          "title": [
+            "A musical toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [
+            "Bernstein, Leonard, 1918-1990"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocm11578466",
+            "SCSB-3364085"
+          ],
+          "uniformTitle": [
+            "Musical toast"
+          ],
+          "dateEndYear": [
+            1980
+          ],
+          "seriesUniformTitle": [
+            "Hawkes pocket scores."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "titleDisplay": [
+            "A musical toast / Leonard Bernstein."
+          ],
+          "uri": "cb1808514",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "[Place of publication not identified] : New York, N.Y."
+          ],
+          "series": [
+            "Hawkes pocket scores"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Hawkes pocket scores||Hawkes pocket scores"
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          700.619,
+          "cb1808514"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb1808514",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:61 B458 M9",
+                      "urn:barcode:MR61509485"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "61 B458 M9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "MR61509485",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "MR61509485"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "61 B458 M9"
+                    ],
+                    "recapCustomerCode": [
+                      "MR"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "61 B458 M9"
+                    ],
+                    "shelfMark_sort": "a61 B458 M000009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci2278358"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "cb1869694",
+        "_score": 700.619,
+        "_source": {
+          "extent": [
+            "2 volumes ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "publisherLiteral": [
+            "J.B. Lyon Company, Printers"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1908
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "08036390"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1908
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "1869694"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm18495675"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-3416373"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "08036390"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm18495675"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "1869694"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779484485733,
+          "publicationStatement": [
+            "Albany : J.B. Lyon Company, Printers, 1908."
+          ],
+          "identifier": [
+            "urn:bnum:1869694",
+            "urn:oclc:ocm18495675",
+            "urn:oclc:SCSB-3416373",
+            "urn:lccn:08036390",
+            "urn:identifier:(OCoLC)ocm18495675",
+            "urn:identifier:1869694"
+          ],
+          "creators_displayPacked": [
+            "Rowe, William H., Jr||Rowe, William H., Jr"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1909",
+                "gte": "1908"
+              },
+              "raw": "880917s1908    nyu           000 0 eng  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "2 volumes ; 19 cm"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "title": [
+            "Verse and toast"
+          ],
+          "numItemVolumesParsed": [
+            2
+          ],
+          "createdString": [
+            "1908"
+          ],
+          "creatorLiteral": [
+            "Rowe, William H., Jr"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocm18495675",
+            "SCSB-3416373"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1908"
+          ],
+          "titleDisplay": [
+            "Verse and toast / by Col. William H. Rowe, Jr."
+          ],
+          "uri": "cb1869694",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Albany"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm"
+          ]
+        },
+        "sort": [
+          700.619,
+          "cb1869694"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb1869694",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "enumerationChronology": [
+                      "v.2"
+                    ],
+                    "enumerationChronology_sort": "         2-",
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:812R79 Y",
+                      "urn:barcode:1002217449"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "812R79 Y",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "1002217449",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "1002217449"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "812R79 Y"
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "812R79 Y"
+                    ],
+                    "shelfMark_sort": "a812R79 Y",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci2345976",
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 2
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb1869694",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "enumerationChronology_sort": "         1-",
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:812R79 Y",
+                      "urn:barcode:1002217392"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "812R79 Y",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "1002217392",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "1002217392"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "812R79 Y"
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "812R79 Y"
+                    ],
+                    "shelfMark_sort": "a812R79 Y",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci2345977",
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b10038245",
+        "_score": 672.9889,
+        "_source": {
+          "extent": [
+            "176 p. illus."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "editionStatement": [
+            "[1st ed.]"
+          ],
+          "publisherLiteral": [
+            "Knopf"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 71-3298"
+          ],
+          "idLccn": [
+            "70147880"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1971
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 71-3298"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10038245"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG710603184-B"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "70147880"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NN710603184"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0038376"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779307353177,
+          "publicationStatement": [
+            "New York, Knopf, 1971."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 71-3298",
+            "urn:bnum:10038245",
+            "urn:oclc:NYPG710603184-B",
+            "urn:lccn:70147880",
+            "urn:identifier:NN710603184",
+            "urn:identifier:(WaOLN)nyp0038376"
+          ],
+          "creators_displayPacked": [
+            "Gould, Peter||Gould, Peter"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1972",
+                "gte": "1971"
+              },
+              "raw": "720103s1971    nyua          00| f|eng| cam   ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "176 p. : illus. ; 21 cm."
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Burnt toast; a novel."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "creatorLiteral": [
+            "Gould, Peter"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "NYPG710603184-B"
+          ],
+          "popularity": 1,
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "titleDisplay": [
+            "Burnt toast; a novel."
+          ],
+          "uri": "b10038245",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          672.9889,
+          "b10038245"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b10038245",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 71-3298",
+                      "urn:barcode:33433038923789"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFD 71-3298",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433038923789",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433038923789"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "JFD 71-3298"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFD 71-3298"
+                    ],
+                    "shelfMark_sort": "aJFD 71-003298",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i12867982"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b12471757",
+        "_score": 672.9889,
+        "_source": {
+          "extent": [
+            "188 p., 13 leaves of plates : front., ill., ports. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Phoenix House"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1950
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "AN (Willis) (Willis, F. Peace and dripping toast)"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1950
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "AN (Willis) (Willis, F. Peace and dripping toast)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12471757"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "2275721"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779375904650,
+          "publicationStatement": [
+            "London : Phoenix House, 1950."
+          ],
+          "identifier": [
+            "urn:shelfmark:AN (Willis) (Willis, F. Peace and dripping toast)",
+            "urn:bnum:12471757",
+            "urn:oclc:2275721"
+          ],
+          "creators_displayPacked": [
+            "Willis, Frederick||Willis, Frederick"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1951",
+                "gte": "1950"
+              },
+              "raw": "760623s1950    enkac         000 0aeng dnamIi ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Willis, Frederick."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "188 p., 13 leaves of plates : front., ill., ports. ; 23 cm."
+          ],
+          "subjectLiteral_exploded": [
+            "Willis, Frederick"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Peace and dripping toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1950"
+          ],
+          "creatorLiteral": [
+            "Willis, Frederick"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "2275721"
+          ],
+          "popularity": 1,
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1950"
+          ],
+          "titleDisplay": [
+            "Peace and dripping toast / by Frederick Willis."
+          ],
+          "uri": "b12471757",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          672.9889,
+          "b12471757"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b12471757",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:AN (Willis) (Willis, F. Peace and dripping toast)",
+                      "urn:barcode:33433103600973"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "AN (Willis) (Willis, F. Peace and dripping toast)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433103600973",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433103600973"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "AN (Willis) (Willis, F. Peace and dripping toast)"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "AN (Willis) (Willis, F. Peace and dripping toast)"
+                    ],
+                    "shelfMark_sort": "aAN (Willis) (Willis, F. Peace and dripping toast)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i16049510"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b13147602",
+        "_score": 672.9889,
+        "_source": {
+          "extent": [
+            "310 p."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Doubleday"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1941
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "NCW (Coles, M. Toast to tomorrow)"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1941
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NCW (Coles, M. Toast to tomorrow)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13147602"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "48802346"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1370631"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3125942"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)48802346"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779387680805,
+          "publicationStatement": [
+            "Garden City, N.Y. Doubleday [1941]"
+          ],
+          "identifier": [
+            "urn:shelfmark:NCW (Coles, M. Toast to tomorrow)",
+            "urn:bnum:13147602",
+            "urn:oclc:48802346",
+            "urn:oclc:1370631",
+            "urn:identifier:(WaOLN)nyp3125942",
+            "urn:identifier:(OCoLC)48802346"
+          ],
+          "creators_displayPacked": [
+            "Coles, Manning||Coles, Manning"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1942",
+                "gte": "1941"
+              },
+              "raw": "750603s1941    xx            000 0 eng dnamI  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "310 p. ; 21cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"First edition.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "A toast to tomorrow."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1941"
+          ],
+          "creatorLiteral": [
+            "Coles, Manning"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "48802346",
+            "1370631"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1941"
+          ],
+          "titleDisplay": [
+            "A toast to tomorrow."
+          ],
+          "uri": "b13147602",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Garden City, N.Y."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21cm."
+          ]
+        },
+        "sort": [
+          672.9889,
+          "b13147602"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b13147602",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NCW (Coles, M. Toast to tomorrow)",
+                      "urn:barcode:33433114070448"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "NCW (Coles, M. Toast to tomorrow)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433114070448",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433114070448"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "NCW (Coles, M. Toast to tomorrow)"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "NCW (Coles, M. Toast to tomorrow)"
+                    ],
+                    "shelfMark_sort": "aNCW (Coles, M. Toast to tomorrow)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i16287071"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b13279082",
+        "_score": 672.9889,
+        "_source": {
+          "extent": [
+            "41 p."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Harvard university press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1937
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "NTRW (Rand, E. K. Toast to Horace)"
+          ],
+          "idLccn": [
+            "38001889"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1937
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NTRW (Rand, E. K. Toast to Horace)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13279082"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "5581153"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "38001889"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3256542"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779389723027,
+          "publicationStatement": [
+            "Cambridge, Harvard university press, 1937."
+          ],
+          "identifier": [
+            "urn:shelfmark:NTRW (Rand, E. K. Toast to Horace)",
+            "urn:bnum:13279082",
+            "urn:oclc:5581153",
+            "urn:lccn:38001889",
+            "urn:identifier:(WaOLN)nyp3256542"
+          ],
+          "creators_displayPacked": [
+            "Rand, Edward Kennard, 1871-1945||Rand, Edward Kennard, 1871-1945"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1938",
+                "gte": "1937"
+              },
+              "raw": "791024s1937    mau           000 0 eng  namI  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Horace."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PA6411.Z5 R3"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "41 p. ; 18 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"An address delivered on January 16, 1936 before the Municipal art society of Baltimore city and now published under its auspices. Some of the ideas expressed were further developed in lectures given ... at the Rice institute of Houston, Texas, in January, 1937.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Horace"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "A toast to Horace"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1937"
+          ],
+          "creatorLiteral": [
+            "Rand, Edward Kennard, 1871-1945"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "5581153"
+          ],
+          "popularity": 1,
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1937"
+          ],
+          "titleDisplay": [
+            "A toast to Horace, by Edward Kennard Rand."
+          ],
+          "uri": "b13279082",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Cambridge"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          672.9889,
+          "b13279082"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b13279082",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NTRW (Rand, E. K. Toast to Horace)",
+                      "urn:barcode:33433097996379"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "NTRW (Rand, E. K. Toast to Horace)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433097996379",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433097996379"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "NTRW (Rand, E. K. Toast to Horace)"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "NTRW (Rand, E. K. Toast to Horace)"
+                    ],
+                    "shelfMark_sort": "aNTRW (Rand, E. K. Toast to Horace)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i16397426"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b15877453",
+        "_score": 672.9889,
+        "_source": {
+          "extent": [
+            "1 sound disc : analog, 33 1/3 rpm, stereo. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Alshire"
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1966
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LZR 9189"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1966
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LZR 9189"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15877453"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "13323483"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "ST-5074 Alshire"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "S-5074 Alshire"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A310000041"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779429917135,
+          "publicationStatement": [
+            "Burbank, Calif. : Alshire, [1966?]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LZR 9189",
+            "urn:bnum:15877453",
+            "urn:oclc:13323483",
+            "urn:identifier:ST-5074 Alshire",
+            "urn:identifier:S-5074 Alshire",
+            "urn:identifier:(WaOLN)A310000041"
+          ],
+          "creators_displayPacked": [
+            "101 Strings||101 Strings, performer"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1967",
+                "gte": "1966"
+              },
+              "raw": "860321s1966    caumcn   i              dcjmIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Musicals -- Excerpts, Arranged.",
+            "Orchestral music, Arranged."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "j",
+          "collectionIds": [
+            "pah"
+          ],
+          "titleAlt": [
+            "8:40 curtain.",
+            "Small world.",
+            "Till there was you.",
+            "Just in time.",
+            "Promise me a rose.",
+            "Til tomorrow.",
+            "Hey there.",
+            "Climb every mountain.",
+            "I enjoy being a girl.",
+            "Tonight.",
+            "Aisle talk."
+          ],
+          "physicalDescription": [
+            "1 sound disc : analog, 33 1/3 rpm, stereo. ; 12 in."
+          ],
+          "tableOfContents": [
+            "8:40 curtain -- Small world -- Till there was you -- Just in time -- Promise me a rose -- Til tomorrow -- Hey there -- Climb every mountan -- I enjoy being a girl -- Tonight -- Aisle talk."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Alshire: ST-5074 (on container: S-5074).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Selections from musicals arranged for orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes on container.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Musicals",
+            "Musicals -- Excerpts, Arranged",
+            "Orchestral music, Arranged"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "A toast to Broadway"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1966"
+          ],
+          "creatorLiteral": [
+            "101 Strings"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "13323483"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1966"
+          ],
+          "titleDisplay": [
+            "A toast to Broadway [sound recording] / 101 Strings."
+          ],
+          "uri": "b15877453",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Burbank, Calif."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          672.9889,
+          "b15877453"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b15877453",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=101+Strings&CallNumber=*LZR+9189+%5BDisc%5D&Date=1966&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15877453&ItemISxN=i14661544x&ItemNumber=33433035395361&ItemPlace=Burbank%2C+Calif.&ItemPublisher=Alshire%2C+%5B1966%3F%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b15877453x&Site=LPAMRAMI&Title=A+toast+to+Broadway"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LZR 9189 [Disc]",
+                      "urn:barcode:33433035395361"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LZR 9189 [Disc]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433035395361",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433035395361"
+                    ],
+                    "physicalLocation": [
+                      "*LZR 9189 [Disc]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LZR 9189 [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LZR 9189 [Disc]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i14661544"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b16019290",
+        "_score": 672.9889,
+        "_source": {
+          "extent": [
+            "1 sound disc (29 min.) : analog, 33 1/3 rpm, stereo. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Mega"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1973
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LZR 33485"
+          ],
+          "idLccn": [
+            "94764528"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1973
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LZR 33485"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16019290"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "16918975"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "94764528"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "M31-1021 Mega"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A250000131"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779432002538,
+          "publicationStatement": [
+            "Nashville, Tenn. : Mega, p1973."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LZR 33485",
+            "urn:bnum:16019290",
+            "urn:oclc:16918975",
+            "urn:lccn:94764528",
+            "urn:identifier:M31-1021 Mega",
+            "urn:identifier:(WaOLN)A250000131"
+          ],
+          "creators_displayPacked": [
+            "Smith, Sammi||Smith, Sammi, performer"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1974",
+                "gte": "1973"
+              },
+              "raw": "871030s1973    tnucyn              eng dcjm a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Country music -- 1971-1980."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "j",
+          "collectionIds": [
+            "pah"
+          ],
+          "titleAlt": [
+            "Rings for sale.",
+            "If I may.",
+            "Have I stayed away too long.",
+            "Tony.",
+            "That's the price I pay for loving you.",
+            "I miss you most when you're right here.",
+            "I'm in for stormy weather.",
+            "City of New Orleans.",
+            "Send me the pillow you dream on."
+          ],
+          "physicalDescription": [
+            "1 sound disc (29 min.) : analog, 33 1/3 rpm, stereo. ; 12 in."
+          ],
+          "tableOfContents": [
+            "Rings for sale (2:14) -- If I may (2:39) -- Have I stayed away too long (3:22) -- Tony (3:02) -- That's the price I pay for loving you (2:14) -- I miss you most when you're right here (3:37) -- I'm in for stormy weather (2:27) -- City of New Orleans (4:15) -- The toast of '45 (2:47) -- Send me the pillow you dream on (2:43)."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Country songs.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Notes by Jim Malloy on container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded at Monument Recording Studio, Nashville.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Country music",
+            "Country music -- 1971-1980"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "The toast of '45"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "creatorLiteral": [
+            "Smith, Sammi"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "16918975"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "titleDisplay": [
+            "The toast of '45 [sound recording] / Sammi Smith."
+          ],
+          "uri": "b16019290",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Nashville, Tenn."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          672.9889,
+          "b16019290"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16019290",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Smith%2C+Sammi&CallNumber=*LZR+33485+%5BDisc%5D&Date=1973&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16019290&ItemISxN=i154315503&ItemNumber=33433036315707&ItemPlace=Nashville%2C+Tenn.&ItemPublisher=Mega%2C+p1973.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b160192900&Site=LPAMRAMI&Title=The+toast+of+%2745"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LZR 33485 [Disc]",
+                      "urn:barcode:33433036315707"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LZR 33485 [Disc]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433036315707",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433036315707"
+                    ],
+                    "physicalLocation": [
+                      "*LZR 33485 [Disc]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LZR 33485 [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LZR 33485 [Disc]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15431550"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b16151201",
+        "_score": 672.9889,
+        "_source": {
+          "extent": [
+            "1 sound disc : analog, 33 1/3 rpm ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Seeco"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            19
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LZR 43109"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            19
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LZR 43109"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16151201"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "58387713"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "SCLP 9109 Seeco"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A070000038"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Aguilera, F.||Aguilera, F., performer, editor, arranger",
+            "García Matos, Manuel, 1912-||García Matos, Manuel, 1912-, conductor, editor, arranger"
+          ],
+          "updatedAt": 1779433889165,
+          "publicationStatement": [
+            "New York, N.Y. : Seeco, [19--?]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LZR 43109",
+            "urn:bnum:16151201",
+            "urn:oclc:58387713",
+            "urn:identifier:SCLP 9109 Seeco",
+            "urn:identifier:(WaOLN)A070000038"
+          ],
+          "creators_displayPacked": [
+            "Flores, Lola||Flores, Lola, performer"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2000",
+                "gte": "1900"
+              },
+              "raw": "050307s19uu    nyuppn   i          spa dnjmIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Popular music -- Spain."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "j",
+          "collectionIds": [
+            "pah"
+          ],
+          "physicalDescription": [
+            "1 sound disc : analog, 33 1/3 rpm ; 12 in."
+          ],
+          "tableOfContents": [
+            "Lola de España -- Concha veneno -- Tu cartel por las mũrallas -- Mi pelo negro -- Mi embajaora -- Valgame la Magdalena -- Remedios la de montilla -- Venga pronto el volapie -- Gritenme piedras del campo -- Me serenaste -- Pa su papa -- Maldigo tus ojos verdes."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Program notes in English and Spanish on container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in Spanish.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Popular music",
+            "Popular music -- Spain"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "The toast of Spain"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "19uu"
+          ],
+          "creatorLiteral": [
+            "Flores, Lola"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Aguilera, F.",
+            "García Matos, Manuel, 1912-"
+          ],
+          "idOclc": [
+            "58387713"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "19uu"
+          ],
+          "titleDisplay": [
+            "The toast of Spain [sound recording] / Lola Flores."
+          ],
+          "uri": "b16151201",
+          "parallelContributorLiteral": [
+            null,
+            null
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "New York, N.Y."
+          ],
+          "series": [
+            "Gold series"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Gold series||Gold series"
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          672.9889,
+          "b16151201"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16151201",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Flores%2C+Lola&CallNumber=*LZR+43109+%5BDisc%5D&Date=19uu&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16151201&ItemISxN=i155562502&ItemNumber=33433036075665&ItemPlace=New+York%2C+N.Y.&ItemPublisher=Seeco%2C+%5B19--%3F%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b16151201x&Site=LPAMRAMI&Title=The+toast+of+Spain"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LZR 43109 [Disc]",
+                      "urn:barcode:33433036075665"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LZR 43109 [Disc]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433036075665",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433036075665"
+                    ],
+                    "physicalLocation": [
+                      "*LZR 43109 [Disc]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LZR 43109 [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LZR 43109 [Disc]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15556250"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-209e26eb4aead570b51f7ebbef68aaa1.json
+++ b/test/fixtures/query-209e26eb4aead570b51f7ebbef68aaa1.json
@@ -1,0 +1,16357 @@
+{
+  "took": 1737,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 916,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b20970375",
+        "_score": 3989.9512,
+        "_source": {
+          "extent": [
+            "119 pages : illustrations (color) ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Phaidon Press Limited"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            2015
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFF 16-815"
+          ],
+          "idLccn": [
+            "2015473840"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2015
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 16-815"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "20970375"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780714869551"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0714869554"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "915941587"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2015473840"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)905521916"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)915941587"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Sung, Evan||Sung, Evan, photographer"
+          ],
+          "updatedAt": 1779503645748,
+          "publicationStatement": [
+            "London : Phaidon Press Limited, 2015.",
+            "©2015"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFF 16-815",
+            "urn:bnum:20970375",
+            "urn:isbn:9780714869551",
+            "urn:isbn:0714869554",
+            "urn:oclc:915941587",
+            "urn:lccn:2015473840",
+            "urn:identifier:(OCoLC)905521916",
+            "urn:identifier:(OCoLC)915941587"
+          ],
+          "creators_displayPacked": [
+            "Pelzel, Raquel||Pelzel, Raquel, author"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2016",
+                "gte": "2015"
+              },
+              "raw": "150323s2015    enka   e      001 0 eng  camIi ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Toast (Bread)"
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "titleAlt": [
+            "Toast : the cookbook"
+          ],
+          "physicalDescription": [
+            "119 pages : illustrations (color) ; 25 cm"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Toast (Bread)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2015"
+          ],
+          "creatorLiteral": [
+            "Pelzel, Raquel"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sung, Evan"
+          ],
+          "idOclc": [
+            "915941587"
+          ],
+          "popularity": 5,
+          "summary": [
+            "The ultimate canvas for sweet and savory culinary creativity. 50 seasonal recipes that reimagine the \"bread and butter\" of cuisine with simple ingredients in surprising ways. Easy enough for breakfast, yet suitable for brunch, lunch, dinner and even dessert, the possibilities of heaping beautiful seasonal ingredients on bread are limitless. Toast guides home chefs as they explore home cuisine's ultimate creative canvas. Organized by season, Toast features 50 recipes from savory to sweet that unleash the power of fresh ingredients and simple techniques guaranteed to impress and satisfy any kitchen audience on any occasion."
+          ],
+          "genreForm": [
+            "Cookbooks."
+          ],
+          "idIsbn": [
+            "9780714869551",
+            "0714869554"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2015"
+          ],
+          "titleDisplay": [
+            "Toast / by Raquel Pelzel ; photographs by Evan Sung."
+          ],
+          "uri": "b20970375",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm"
+          ],
+          "idIsbn_clean": [
+            "9780714869551",
+            "0714869554"
+          ]
+        },
+        "sort": [
+          3989.9512,
+          "b20970375"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term title.keywordLowercased",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "term title.keywordLowercasedStripped",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b20970375",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "dueDate": [
+                      "2025-06-28"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFF 16-815",
+                      "urn:barcode:33433118568447"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 16-815",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433118568447",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433118568447"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "physicalLocation": [
+                      "JFF 16-815"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "JFF 16-815"
+                    ],
+                    "shelfMark_sort": "aJFF 16-000815",
+                    "status": [
+                      {
+                        "id": "status:co",
+                        "label": "Loaned"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:co||Loaned"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i34162229"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb2847934",
+        "_score": 3979.5984,
+        "_source": {
+          "extent": [
+            "103 p. ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "publisherLiteral": [
+            "Oberon"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1999
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1999
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "2847934"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1840021047"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-964143"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(CStRLIN)GAEGO42263032-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(GEU)(Sirsi)o42263032"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779535957525,
+          "publicationStatement": [
+            "London : Oberon, 1999."
+          ],
+          "identifier": [
+            "urn:bnum:2847934",
+            "urn:isbn:1840021047",
+            "urn:oclc:SCSB-964143",
+            "urn:identifier:(CStRLIN)GAEGO42263032-B",
+            "urn:identifier:(GEU)(Sirsi)o42263032"
+          ],
+          "creators_displayPacked": [
+            "Bean, Richard, 1956-||Bean, Richard, 1956-"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2000",
+                "gte": "1999"
+              },
+              "raw": "990830s1999    enk           000 0 eng d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "103 p. ; 21 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"First performed at the Royal Court Theatre Upstairs ... on 12th February 1999.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1999"
+          ],
+          "creatorLiteral": [
+            "Bean, Richard, 1956-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "SCSB-964143"
+          ],
+          "idIsbn": [
+            "1840021047"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1999"
+          ],
+          "titleDisplay": [
+            "Toast / by Richard Bean."
+          ],
+          "uri": "pb2847934",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "1840021047"
+          ]
+        },
+        "sort": [
+          3979.5984,
+          "pb2847934"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term title.keywordLowercased",
+          "match_phrase title.folded",
+          "term title.keywordLowercasedStripped",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb2847934",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR6052.E176 T627 1999",
+                      "urn:barcode:32101095377683"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PR6052.E176 T627 1999",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101095377683",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101095377683"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PR6052.E176 T627 1999"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PR6052.E176 T627 1999"
+                    ],
+                    "shelfMark_sort": "aPR6052.E176 T627 001999",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi2440892"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb9928479343506421",
+        "_score": 3979.5984,
+        "_source": {
+          "extent": [
+            "103 p. ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "publisherLiteral": [
+            "Oberon"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1999
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1999
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9928479343506421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1840021047"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm53231811"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-964143"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(CStRLIN)GAEGO42263032-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(GEU)(Sirsi)o42263032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)2847934-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm53231811"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager2847934"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779622002540,
+          "publicationStatement": [
+            "London : Oberon, 1999."
+          ],
+          "identifier": [
+            "urn:bnum:9928479343506421",
+            "urn:isbn:1840021047",
+            "urn:oclc:ocm53231811",
+            "urn:oclc:SCSB-964143",
+            "urn:identifier:(CStRLIN)GAEGO42263032-B",
+            "urn:identifier:(GEU)(Sirsi)o42263032",
+            "urn:identifier:(NjP)2847934-princetondb",
+            "urn:identifier:(OCoLC)ocm53231811",
+            "urn:identifier:(NjP)Voyager2847934"
+          ],
+          "creators_displayPacked": [
+            "Bean, Richard, 1956-||Bean, Richard, 1956-"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2000",
+                "gte": "1999"
+              },
+              "raw": "990830s1999    enk           000 0 eng d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "103 p. ; 21 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"First performed at the Royal Court Theatre Upstairs ... on 12th February 1999.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1999"
+          ],
+          "creatorLiteral": [
+            "Bean, Richard, 1956-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocm53231811",
+            "SCSB-964143"
+          ],
+          "idIsbn": [
+            "1840021047"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1999"
+          ],
+          "titleDisplay": [
+            "Toast / by Richard Bean."
+          ],
+          "uri": "pb9928479343506421",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "1840021047"
+          ]
+        },
+        "sort": [
+          3979.5984,
+          "pb9928479343506421"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term title.keywordLowercased",
+          "match_phrase title.folded",
+          "term title.keywordLowercasedStripped",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb9928479343506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR6052.E176 T627 1999",
+                      "urn:barcode:32101095377683"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PR6052.E176 T627 1999",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101095377683",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101095377683"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PR6052.E176 T627 1999"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PR6052.E176 T627 1999"
+                    ],
+                    "shelfMark_sort": "aPR6052.E176 T627 001999",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi23486469710006421"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b17133475",
+        "_score": 887.9126,
+        "_source": {
+          "extent": [
+            "1 v. (unpaged) : col. ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Houghton Mifflin"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1997
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "96013720"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1997
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "17133475"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0395796180"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0618111212 (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "96013720 /AC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "96013720"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779474262846,
+          "publicationStatement": [
+            "Boston : Houghton Mifflin, c1997."
+          ],
+          "identifier": [
+            "urn:bnum:17133475",
+            "urn:isbn:0395796180",
+            "urn:isbn:0618111212 (pbk.)",
+            "urn:oclc:96013720 /AC",
+            "urn:lccn:96013720"
+          ],
+          "creators_displayPacked": [
+            "Egan, Tim||Egan, Tim"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1998",
+                "gte": "1997"
+              },
+              "raw": "960314s1997    maua   j      000 1 eng  pam a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Dogs -- Fiction.",
+            "Wishes -- Fiction."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PZ7.E2815 Bu 1997"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "1 v. (unpaged) : col. ill. ; 28 cm."
+          ],
+          "subjectLiteral_exploded": [
+            "Dogs",
+            "Dogs -- Fiction",
+            "Wishes",
+            "Wishes -- Fiction"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Burnt toast on Davenport Street"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1997"
+          ],
+          "creatorLiteral": [
+            "Egan, Tim"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "96013720 /AC"
+          ],
+          "popularity": 32,
+          "summary": [
+            "Arthur and Stella Crandall, two dogs, are for the most part content with their lives until a fly comes along and grants Arthur three wishes."
+          ],
+          "genreForm": [
+            "Humorous fiction.",
+            "Picture books."
+          ],
+          "idIsbn": [
+            "0395796180",
+            "0618111212 (pbk.)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1997"
+          ],
+          "titleDisplay": [
+            "Burnt toast on Davenport Street / written and illustrated by Tim Egan."
+          ],
+          "uri": "b17133475",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Boston"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ],
+          "idIsbn_clean": [
+            "0395796180",
+            "0618111212"
+          ]
+        },
+        "sort": [
+          887.9126,
+          "b17133475"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "popularity >= 10",
+          "popularity >= 20",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b17133475",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:J PIC E",
+                      "urn:barcode:33333113836635"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J PIC E",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33333113836635",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33333113836635"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "physicalLocation": [
+                      "J PIC E"
+                    ],
+                    "recapCustomerCode": [
+                      "NH"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "J PIC E"
+                    ],
+                    "shelfMark_sort": "aJ PIC E",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i18069850"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b18806309",
+        "_score": 759.97174,
+        "_source": {
+          "extent": [
+            "386 p. : map ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "editionStatement": [
+            "Wyd. 1."
+          ],
+          "publisherLiteral": [
+            "Wydawn. Czarne"
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2010
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "ReCAP 11-4380"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2010
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "ReCAP 11-4380"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "18806309"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9788375361940 (pbk)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "8375361941 (pbk)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "671293997"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)671293997"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779485114438,
+          "publicationStatement": [
+            "Wołowiec : Wydawn. Czarne, 2010."
+          ],
+          "identifier": [
+            "urn:shelfmark:ReCAP 11-4380",
+            "urn:bnum:18806309",
+            "urn:isbn:9788375361940 (pbk)",
+            "urn:isbn:8375361941 (pbk)",
+            "urn:oclc:671293997",
+            "urn:identifier:(OCoLC)671293997"
+          ],
+          "creators_displayPacked": [
+            "Górecki, Wojciech, 1970-||Górecki, Wojciech, 1970-"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2011",
+                "gte": "2010"
+              },
+              "raw": "101021s2010    pl b     b    000 0 pol  camIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Caucasus.",
+            "Caucasus -- Civilization."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "386 p. : map ; 20 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. 383-[387])",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Polish.",
+              "type": "bf:Note"
+            }
+          ],
+          "seriesUniformTitle_displayPacked": [
+            "Seria Reportaż.||Seria Reportaż."
+          ],
+          "subjectLiteral_exploded": [
+            "Caucasus",
+            "Caucasus -- Civilization"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast za przodków"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2010"
+          ],
+          "creatorLiteral": [
+            "Górecki, Wojciech, 1970-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "671293997"
+          ],
+          "popularity": 3,
+          "seriesUniformTitle": [
+            "Seria Reportaż."
+          ],
+          "idIsbn": [
+            "9788375361940 (pbk)",
+            "8375361941 (pbk)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2010"
+          ],
+          "titleDisplay": [
+            "Toast za przodków / Wojciech Górecki."
+          ],
+          "uri": "b18806309",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Wołowiec"
+          ],
+          "series": [
+            "Reportaż"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Reportaż||Reportaż"
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "9788375361940",
+            "8375361941"
+          ]
+        },
+        "sort": [
+          759.97174,
+          "b18806309"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b18806309",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "dueDate": [
+                      "2025-01-02"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:ReCAP 11-4380",
+                      "urn:barcode:33433090460647"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "ReCAP 11-4380",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433090460647",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433090460647"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "physicalLocation": [
+                      "ReCAP 11-4380"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "ReCAP 11-4380"
+                    ],
+                    "shelfMark_sort": "aReCAP 11-004380",
+                    "status": [
+                      {
+                        "id": "status:co",
+                        "label": "Loaned"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:co||Loaned"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i26121731"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b18054582",
+        "_score": 753.5737,
+        "_source": {
+          "extent": [
+            "1 videodisc (approximately 52 min.) : sound, color ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Bullfrog Films"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            2005
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2005
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "18054582"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1594583560"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781594583568"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "191872445"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1053113461"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)191872445"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Weinstein, Larry||Weinstein, Larry, director, producer",
+            "Louie, Alexina, 1949-||Louie, Alexina, 1949-, composer",
+            "Redican, Dan||Redican, Dan, librettist, performer",
+            "Daniel, Jessica||Daniel, Jessica, producer",
+            "Hornburg, Matthew||Hornburg, Matthew, producer",
+            "Franco, David, 1963-||Franco, David, 1963-, cinematographer",
+            "Gross, Paul, 1959-||Gross, Paul, 1959-, performer",
+            "Szabó, Krisztina (Mezzo-soprano)||Szabó, Krisztina (Mezzo-soprano), performer",
+            "Houtman, Martin||Houtman, Martin, performer",
+            "McGillivray, Peter||McGillivray, Peter, performer",
+            "Mercer, Shannon||Mercer, Shannon, performer",
+            "Stilwell, Jean, 1955-||Stilwell, Jean, 1955-, performer",
+            "Butterfield, Benjamin||Butterfield, Benjamin, performer",
+            "Bayrakdarian, Isabel||Bayrakdarian, Isabel, performer",
+            "Martin, Bob, 1962-||Martin, Bob, 1962-, performer",
+            "Balaban, Liane, 1980-||Balaban, Liane, 1980-, performer",
+            "Colvin, Michael (Tenor)||Colvin, Michael (Tenor), performer",
+            "Sadiq, Zorana||Sadiq, Zorana, performer",
+            "Braun, Russell, 1968-||Braun, Russell, 1968-, performer",
+            "Monoyios, Ann, 1949-||Monoyios, Ann, 1949-, performer",
+            "McNaughton, Doug||McNaughton, Doug, performer",
+            "Hannigan, Barbara||Hannigan, Barbara, performer",
+            "Pauk, Alex, 1945-||Pauk, Alex, 1945-, conductor",
+            "Esprit Orchestra||Esprit Orchestra, performer",
+            "Bullfrog Films||Bullfrog Films, production manager",
+            "Rhombus Media (Firm)||Rhombus Media (Firm), production manager",
+            "Canadian Television Fund||Canadian Television Fund",
+            "Canadian Broadcasting Corporation||Canadian Broadcasting Corporation",
+            "Channel Four Films (Firm)||Channel Four Films (Firm)",
+            "Zweites Deutsches Fernsehen||Zweites Deutsches Fernsehen",
+            "Association relative à la télévision européenne||Association relative à la télévision européenne"
+          ],
+          "updatedAt": 1779480096602,
+          "publicationStatement": [
+            "Oley, PA : Bullfrog Films, [2005]"
+          ],
+          "identifier": [
+            "urn:bnum:18054582",
+            "urn:isbn:1594583560",
+            "urn:isbn:9781594583568",
+            "urn:oclc:191872445",
+            "urn:identifier:(OCoLC)1053113461",
+            "urn:identifier:(OCoLC)191872445"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "lt": "2006",
+                "gte": "2005"
+              },
+              "raw": "080207s2005    pau052            vleng dcgm4a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Love -- Drama.",
+            "Television operas.",
+            "Vignettes -- Drama."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PN1997.2 .B87 2005"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "v",
+          "collectionIds": [
+            "pav"
+          ],
+          "physicalDescription": [
+            "1 videodisc (approximately 52 min.) : sound, color ; 4 3/4 in."
+          ],
+          "tableOfContents": [
+            "The 8 stages of love. Stage 1: Attraction ; Stage 2: Connection ; Stage 3: Commitment ; Stage 4: Marriage ; Stage 5: Consummation ; Stage 6: Perseverance ; Stage 7: Disintegration ; Stage 8: Starting over."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Original comic opera.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Larry Weinstein, director; Jessica Daniel, Matthew Hornburg, Larry Weinstein, producers; David Franco, director of photography.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "DVD-R format.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Love",
+            "Love -- Drama",
+            "Television operas",
+            "Vignettes",
+            "Vignettes -- Drama"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Burnt toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2005"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Weinstein, Larry",
+            "Louie, Alexina, 1949-",
+            "Redican, Dan",
+            "Daniel, Jessica",
+            "Hornburg, Matthew",
+            "Franco, David, 1963-",
+            "Gross, Paul, 1959-",
+            "Szabó, Krisztina (Mezzo-soprano)",
+            "Houtman, Martin",
+            "McGillivray, Peter",
+            "Mercer, Shannon",
+            "Stilwell, Jean, 1955-",
+            "Butterfield, Benjamin",
+            "Bayrakdarian, Isabel",
+            "Martin, Bob, 1962-",
+            "Balaban, Liane, 1980-",
+            "Colvin, Michael (Tenor)",
+            "Sadiq, Zorana",
+            "Braun, Russell, 1968-",
+            "Monoyios, Ann, 1949-",
+            "McNaughton, Doug",
+            "Hannigan, Barbara",
+            "Pauk, Alex, 1945-",
+            "Esprit Orchestra",
+            "Bullfrog Films",
+            "Rhombus Media (Firm)",
+            "Canadian Television Fund",
+            "Canadian Broadcasting Corporation",
+            "Channel Four Films (Firm)",
+            "Zweites Deutsches Fernsehen",
+            "Association relative à la télévision européenne"
+          ],
+          "idOclc": [
+            "191872445"
+          ],
+          "popularity": 2,
+          "summary": [
+            "\"Comprised of a series of eight comedic mini-operas, each depicting a different stage of a romantic relationship set in contemporary settings. With original music and libretti, each vignette is a self-contained story, but together they work as a cohesive single piece\"--Container."
+          ],
+          "genreForm": [
+            "Drama.",
+            "Feature films.",
+            "Musical films."
+          ],
+          "idIsbn": [
+            "1594583560",
+            "9781594583568"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mov",
+              "label": "Moving image"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2005"
+          ],
+          "titleDisplay": [
+            "Burnt toast / Bullfrog Films presents Rhombus Media and marblemedia present a film by Larry Weinstein ; music by Alexina Louie ; words by Dan Redican ; produced with the participation of the Canadian Television Fund ; produced in association with the Canadian Broadcasting Corporation ; Channel Four Television Corporation ; ZDF in cooperation with ARTE."
+          ],
+          "uri": "b18054582",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "recordTypeId": "g",
+          "placeOfPublication": [
+            "Oley, PA"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ],
+          "idIsbn_clean": [
+            "1594583560",
+            "9781594583568"
+          ]
+        },
+        "sort": [
+          753.5737,
+          "b18054582"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b18054582",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:a",
+                        "label": "By appointment only"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:a||By appointment only"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:75",
+                        "label": "dvd"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:75||dvd"
+                    ],
+                    "enumerationChronology": [
+                      "C.1"
+                    ],
+                    "formatLiteral": [
+                      "DVD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pav28",
+                        "label": "Performing Arts Research Collections - Reserve Film and Video"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pav28||Performing Arts Research Collections - Reserve Film and Video"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:DVDR 1348 B C.1",
+                      "urn:barcode:33333225144951"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "DVDR 1348 B C.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33333225144951",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33333225144951"
+                    ],
+                    "physicalLocation": [
+                      "DVDR 1348 B C.1"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "DVDR 1348 B C.1"
+                    ],
+                    "shelfMark_sort": "aDVDR 1348 B C.000001",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i24601154"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b22227752",
+        "_score": 753.5737,
+        "_source": {
+          "extent": [
+            "1 volume (unpaged) : colour illustrations ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "editionStatement": [
+            "First edition."
+          ],
+          "publisherLiteral": [
+            "Pajama Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            2016
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFF 17-1945"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2016
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 17-1945"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22227752"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781772780062"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1772780065"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "943594881"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)943594881"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Thisdale, François, 1964-||Thisdale, François, 1964-, illustrator"
+          ],
+          "updatedAt": 1779517958058,
+          "publicationStatement": [
+            "Toronto, Ontario, Canada : Pajama Press, 2016."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFF 17-1945",
+            "urn:bnum:22227752",
+            "urn:isbn:9781772780062",
+            "urn:isbn:1772780065",
+            "urn:oclc:943594881",
+            "urn:identifier:(OCoLC)943594881"
+          ],
+          "creators_displayPacked": [
+            "Winters, Kari-Lynn, 1969-||Winters, Kari-Lynn, 1969-, author"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2017",
+                "gte": "2016"
+              },
+              "raw": "160411s2016    onca   j      000 1 eng  cam i ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Racially mixed people -- Juvenile fiction.",
+            "Grandmothers -- Juvenile fiction.",
+            "Blind -- Juvenile fiction.",
+            "Human skin color -- Juvenile fiction.",
+            "Self-esteem -- Juvenile fiction.",
+            "Picture books for children."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PZ7.W7674 Fr 2016"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "1 volume (unpaged) : colour illustrations ; 24 x 27 cm"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"This is a first edition\"--Title page verso.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Racially mixed people",
+            "Racially mixed people -- Juvenile fiction",
+            "Grandmothers",
+            "Grandmothers -- Juvenile fiction",
+            "Blind",
+            "Blind -- Juvenile fiction",
+            "Human skin color",
+            "Human skin color -- Juvenile fiction",
+            "Self-esteem",
+            "Self-esteem -- Juvenile fiction",
+            "Picture books for children"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "French toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2016"
+          ],
+          "creatorLiteral": [
+            "Winters, Kari-Lynn, 1969-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Thisdale, François, 1964-"
+          ],
+          "idOclc": [
+            "943594881"
+          ],
+          "summary": [
+            "While out on a walk with her blind grandmother, Phoebe tries to describe the skin color of members of her family by comparing them to various foods."
+          ],
+          "genreForm": [
+            "Fiction.",
+            "Juvenile works."
+          ],
+          "idIsbn": [
+            "9781772780062",
+            "1772780065"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2016"
+          ],
+          "titleDisplay": [
+            "French toast / written by Kari-Lynn Winters ; illustrated by François Thisdale."
+          ],
+          "uri": "b22227752",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Toronto, Ontario, Canada"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 x 27 cm"
+          ],
+          "idIsbn_clean": [
+            "9781772780062",
+            "1772780065"
+          ]
+        },
+        "sort": [
+          753.5737,
+          "b22227752"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b22227752",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFF 17-1945",
+                      "urn:barcode:33433122276318"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 17-1945",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433122276318",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433122276318"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "physicalLocation": [
+                      "JFF 17-1945"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFF 17-1945"
+                    ],
+                    "shelfMark_sort": "aJFF 17-001945",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i37949151"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "hb990099650640203941",
+        "_score": 750.619,
+        "_source": {
+          "extent": [
+            "247 p. ;"
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "publisherLiteral": [
+            "Cosmos Books"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2006
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2006
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990099650640203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0809556030 (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "69652590"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-12049344"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)69652590"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779600182453,
+          "publicationStatement": [
+            "Holicong, PA : Cosmos Books, c2006, c2002."
+          ],
+          "identifier": [
+            "urn:bnum:990099650640203941",
+            "urn:isbn:0809556030 (pbk.)",
+            "urn:oclc:69652590",
+            "urn:oclc:SCSB-12049344",
+            "urn:identifier:(OCoLC)69652590"
+          ],
+          "creators_displayPacked": [
+            "Stross, Charles||Stross, Charles"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2007",
+                "gte": "2006"
+              },
+              "raw": "060530r20062002pau           000 j eng d",
+              "tag": "r"
+            },
+            {
+              "range": {
+                "lt": "2003",
+                "gte": "2002"
+              },
+              "raw": "060530r20062002pau           000 j eng d",
+              "tag": "r"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Short stories."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PR6119.T79 T63 2006"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "247 p. ; 23 cm."
+          ],
+          "tableOfContents": [
+            "Antibodies -- Bear trap -- Extracts from the Club Diary -- A colder war -- Toast: a con report -- A boy and his God -- Ship of fools -- Dechlorinating the moderator -- Yellow snow -- Big Brother Iron."
+          ],
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain 20181001 in perpetuity ReCAP Shared Collection HUL 222106586330003941",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Short stories"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "2002"
+          ],
+          "title": [
+            "Toast / Charles Stross."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2006"
+          ],
+          "creatorLiteral": [
+            "Stross, Charles"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "69652590",
+            "SCSB-12049344"
+          ],
+          "dateEndYear": [
+            2002
+          ],
+          "genreForm": [
+            "short stories.",
+            "Short stories",
+            "Science fiction",
+            "Nouvelles."
+          ],
+          "idIsbn": [
+            "0809556030 (pbk.)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2006"
+          ],
+          "titleDisplay": [
+            "Toast / Charles Stross."
+          ],
+          "uri": "hb990099650640203941",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Holicong, PA"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ],
+          "idIsbn_clean": [
+            "0809556030"
+          ]
+        },
+        "sort": [
+          750.619,
+          "hb990099650640203941"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "hb990099650640203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR6119.T79 T63 2006 copy ",
+                      "urn:barcode:32044077499465"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PR6119.T79 T63 2006 copy ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32044077499465",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32044077499465"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "physicalLocation": [
+                      "PR6119.T79 T63 2006"
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PR6119.T79 T63 2006 copy "
+                    ],
+                    "shelfMark_sort": "aPR6119.T79 T63 2006 copy ",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "hi232106586300003941"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb6955197",
+        "_score": 750.619,
+        "_source": {
+          "extent": [
+            "386 p. ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "editionStatement": [
+            "Wyd. 1."
+          ],
+          "publisherLiteral": [
+            "Wydawn. \"Czarne\""
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2010
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2010
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "6955197"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9788375361940"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocn671293997"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-1622764"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(PlWaKWL)lx2010024594"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocn671293997"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779562679286,
+          "publicationStatement": [
+            "Wołowiec : Wydawn. \"Czarne\", 2010."
+          ],
+          "identifier": [
+            "urn:bnum:6955197",
+            "urn:isbn:9788375361940",
+            "urn:oclc:ocn671293997",
+            "urn:oclc:SCSB-1622764",
+            "urn:identifier:(PlWaKWL)lx2010024594",
+            "urn:identifier:(OCoLC)ocn671293997"
+          ],
+          "creators_displayPacked": [
+            "Górecki, Wojciech, 1970-||Górecki, Wojciech, 1970-"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2011",
+                "gte": "2010"
+              },
+              "raw": "100505s2010    pl       b    000 0 pol  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PG7223.I78 T627 2010"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "386 p. ; 20 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "seriesUniformTitle_displayPacked": [
+            "Reportaż.||Reportaż."
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast za przodków"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2010"
+          ],
+          "creatorLiteral": [
+            "Górecki, Wojciech, 1970-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocn671293997",
+            "SCSB-1622764"
+          ],
+          "seriesUniformTitle": [
+            "Reportaż."
+          ],
+          "idIsbn": [
+            "9788375361940"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2010"
+          ],
+          "titleDisplay": [
+            "Toast za przodków / Wojciech Górecki."
+          ],
+          "uri": "pb6955197",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Wołowiec"
+          ],
+          "series": [
+            "Reportaż"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Reportaż||Reportaż"
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "9788375361940"
+          ]
+        },
+        "sort": [
+          750.619,
+          "pb6955197"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb6955197",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PG7223.I78 T627 2010",
+                      "urn:barcode:32101072287822"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PG7223.I78 T627 2010",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101072287822",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101072287822"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PG7223.I78 T627 2010"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PG7223.I78 T627 2010"
+                    ],
+                    "shelfMark_sort": "aPG7223.I78 T627 002010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi6260657"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb9969551973506421",
+        "_score": 750.619,
+        "_source": {
+          "extent": [
+            "386 pages : map ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "editionStatement": [
+            "Wyd. 1."
+          ],
+          "publisherLiteral": [
+            "Wydawn. Czarne"
+          ],
+          "language": [
+            {
+              "id": "lang:pol",
+              "label": "Polish"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2010
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2010
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9969551973506421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9788375361940"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "8375361941"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocn671293997"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "671293997"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-1622764"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(PlWaKWL)lx2010024594"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)6955197-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocn671293997"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager6955197"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)671293997"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779628932640,
+          "publicationStatement": [
+            "Wołowiec : Wydawn. Czarne, 2010."
+          ],
+          "identifier": [
+            "urn:bnum:9969551973506421",
+            "urn:isbn:9788375361940",
+            "urn:isbn:8375361941",
+            "urn:oclc:ocn671293997",
+            "urn:oclc:671293997",
+            "urn:oclc:SCSB-1622764",
+            "urn:identifier:(PlWaKWL)lx2010024594",
+            "urn:identifier:(NjP)6955197-princetondb",
+            "urn:identifier:(OCoLC)ocn671293997",
+            "urn:identifier:(NjP)Voyager6955197",
+            "urn:identifier:(OCoLC)671293997"
+          ],
+          "creators_displayPacked": [
+            "Górecki, Wojciech, 1970-||Górecki, Wojciech, 1970-"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2011",
+                "gte": "2010"
+              },
+              "raw": "101021s2010    pl b     b    000 0 pol  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Caucasus.",
+            "Caucasus -- Civilization."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PG7223.I78 T627 2010"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "386 pages : map ; 20 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "seriesUniformTitle_displayPacked": [
+            "Seria Reportaż.||Seria Reportaż."
+          ],
+          "subjectLiteral_exploded": [
+            "Caucasus",
+            "Caucasus -- Civilization"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast za przodków"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2010"
+          ],
+          "creatorLiteral": [
+            "Górecki, Wojciech, 1970-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocn671293997",
+            "671293997",
+            "SCSB-1622764"
+          ],
+          "seriesUniformTitle": [
+            "Seria Reportaż."
+          ],
+          "idIsbn": [
+            "9788375361940",
+            "8375361941"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2010"
+          ],
+          "titleDisplay": [
+            "Toast za przodków / Wojciech Górecki."
+          ],
+          "uri": "pb9969551973506421",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Wołowiec"
+          ],
+          "series": [
+            "Reportaż"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Reportaż||Reportaż"
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "9788375361940",
+            "8375361941"
+          ]
+        },
+        "sort": [
+          750.619,
+          "pb9969551973506421"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb9969551973506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PG7223.I78 T627 2010",
+                      "urn:barcode:32101072287822"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PG7223.I78 T627 2010",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101072287822",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101072287822"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PG7223.I78 T627 2010"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PG7223.I78 T627 2010"
+                    ],
+                    "shelfMark_sort": "aPG7223.I78 T627 002010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi23652743930006421"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b15868157",
+        "_score": 722.9889,
+        "_source": {
+          "extent": [
+            "64 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Hope Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "sc"
+          ],
+          "createdYear": [
+            2002
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "Sc D 13-57 no. 1"
+          ],
+          "idLccn": [
+            "2004352407"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2002
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 13-57 no. 1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15868157"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9783654845 (pbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9789783654846 (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "54955577"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2004352407"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)54955577"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779429767620,
+          "publicationStatement": [
+            "Ibadan, Nigeria : Hope Publications, 2002."
+          ],
+          "identifier": [
+            "urn:shelfmark:Sc D 13-57 no. 1",
+            "urn:bnum:15868157",
+            "urn:isbn:9783654845 (pbk.)",
+            "urn:isbn:9789783654846 (pbk.)",
+            "urn:oclc:54955577",
+            "urn:lccn:2004352407",
+            "urn:identifier:(OCoLC)54955577"
+          ],
+          "creators_displayPacked": [
+            "Odeleye, Biodun||Odeleye, Biodun"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2003",
+                "gte": "2002"
+              },
+              "raw": "040130s2002    nr a          000 p eng  cam a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Conduct of life -- Poetry.",
+            "Nigeria -- Poetry."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PR9387.9.O3115 T63 2002"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "scf"
+          ],
+          "titleAlt": [
+            "Toast to life and vision"
+          ],
+          "physicalDescription": [
+            "64 p. : ill. ; 21 cm."
+          ],
+          "tableOfContents": [
+            "Moon among stars -- Vampires on rampage -- The dangling visionary saw -- Much to a name -- Dear mother -- La Rambla -- Personifying death -- Success turns albatross in the hall of nobility."
+          ],
+          "subjectLiteral_exploded": [
+            "Conduct of life",
+            "Conduct of life -- Poetry",
+            "Nigeria",
+            "Nigeria -- Poetry"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast to life & vision"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2002"
+          ],
+          "creatorLiteral": [
+            "Odeleye, Biodun"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "54955577"
+          ],
+          "popularity": 1,
+          "idIsbn": [
+            "9783654845 (pbk.)",
+            "9789783654846 (pbk.)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2002"
+          ],
+          "titleDisplay": [
+            "Toast to life & vision / Biodun Odeleye."
+          ],
+          "uri": "b15868157",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Ibadan, Nigeria"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "9783654845",
+            "9789783654846"
+          ]
+        },
+        "sort": [
+          722.9889,
+          "b15868157"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b15868157",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:61",
+                        "label": "pamphlet volumes, bound with"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:61||pamphlet volumes, bound with"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc D 13-57",
+                      "urn:barcode:33433089426146"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 13-57",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433089426146",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433089426146"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "physicalLocation": [
+                      "Sc D 13-57"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "Sc D 13-57"
+                    ],
+                    "shelfMark_sort": "aSc D 13-000057",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i29987107"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b12004445",
+        "_score": 717.7355,
+        "_source": {
+          "extent": [
+            "124 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Kneipp"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1993
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 94-21395"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1993
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 94-21395"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12004445"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3900696349"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "31256373"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGR31256373-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)31256373"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "LC 199410"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779342465834,
+          "publicationStatement": [
+            "Leoben : Kneipp, 1993."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 94-21395",
+            "urn:bnum:12004445",
+            "urn:isbn:3900696349",
+            "urn:oclc:31256373",
+            "urn:oclc:NYPGR31256373-B",
+            "urn:identifier:(OCoLC)31256373",
+            "urn:identifier:LC 199410"
+          ],
+          "creators_displayPacked": [
+            "Heindel, Gabriele||Heindel, Gabriele"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1994",
+                "gte": "1993"
+              },
+              "raw": "941011s1993    au            000 0 ger dnamua ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "124 p. ; 21 cm."
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Mein Lieblings-Toast : 300 heisse Tips für Toast-Fans"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1993"
+          ],
+          "creatorLiteral": [
+            "Heindel, Gabriele"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "31256373",
+            "NYPGR31256373-B"
+          ],
+          "idIsbn": [
+            "3900696349"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1993"
+          ],
+          "titleDisplay": [
+            "Mein Lieblings-Toast : 300 heisse Tips für Toast-Fans / Gabriele Heindel."
+          ],
+          "uri": "b12004445",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Leoben"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "3900696349"
+          ]
+        },
+        "sort": [
+          717.7355,
+          "b12004445"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b12004445",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 94-21395",
+                      "urn:barcode:33433041530118"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFD 94-21395",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433041530118",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433041530118"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "physicalLocation": [
+                      "JFD 94-21395"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFD 94-21395"
+                    ],
+                    "shelfMark_sort": "aJFD 94-021395",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i13317173"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b11294632",
+        "_score": 710.97174,
+        "_source": {
+          "extent": [
+            "xxi, 273 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "editionStatement": [
+            "1st Vintage Books ed."
+          ],
+          "publisherLiteral": [
+            "Vintage Books"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1990
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 90-6303"
+          ],
+          "idLccn": [
+            "89040281"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1990
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 90-6303"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11294632"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0679726861"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "70304237"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG90-B53168"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "89040281"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1302350"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)70304237"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779329441733,
+          "publicationStatement": [
+            "New York : Vintage Books, 1990, c1940."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 90-6303",
+            "urn:bnum:11294632",
+            "urn:isbn:0679726861",
+            "urn:oclc:70304237",
+            "urn:oclc:NYPG90-B53168",
+            "urn:lccn:89040281",
+            "urn:identifier:(WaOLN)nyp1302350",
+            "urn:identifier:(OCoLC)70304237"
+          ],
+          "creators_displayPacked": [
+            "Powell, Dawn||Powell, Dawn"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1991",
+                "gte": "1990"
+              },
+              "raw": "900615r19901940nyu           000 1 eng  cam8a ",
+              "tag": "r"
+            },
+            {
+              "range": {
+                "lt": "1941",
+                "gte": "1940"
+              },
+              "raw": "900615r19901940nyu           000 1 eng  cam8a ",
+              "tag": "r"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PS3531.O936 A83 1989"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "xxi, 273 p. ; 21 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Originally published ... by Charles Scribner's Sons ... in 1940\"--T.p. verso.",
+              "type": "bf:Note"
+            }
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1940"
+          ],
+          "title": [
+            "Angels on toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1990"
+          ],
+          "creatorLiteral": [
+            "Powell, Dawn"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "70304237",
+            "NYPG90-B53168"
+          ],
+          "popularity": 2,
+          "dateEndYear": [
+            1940
+          ],
+          "idIsbn": [
+            "0679726861"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1990"
+          ],
+          "titleDisplay": [
+            "Angels on toast / Dawn Powell ; with an introduction by Gore Vidal."
+          ],
+          "uri": "b11294632",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "0679726861"
+          ]
+        },
+        "sort": [
+          710.97174,
+          "b11294632"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b11294632",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 90-6303",
+                      "urn:barcode:33433040606604"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFD 90-6303",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433040606604",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433040606604"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "JFD 90-6303"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFD 90-6303"
+                    ],
+                    "shelfMark_sort": "aJFD 90-006303",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i13160245"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "cb15861113",
+        "_score": 700.619,
+        "_source": {
+          "extent": [
+            "288 pages ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "publisherLiteral": [
+            "Parthian"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2022
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "60002450032"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2022
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "15861113"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781912681877"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1912681870"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "on1263812851"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-13992812"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "60002450032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)on1263812851"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Edwards, Jonathan||Edwards, Jonathan, editor"
+          ],
+          "updatedAt": 1779429649371,
+          "publicationStatement": [
+            "Cardigan : Parthian, 2022."
+          ],
+          "identifier": [
+            "urn:bnum:15861113",
+            "urn:isbn:9781912681877",
+            "urn:isbn:1912681870",
+            "urn:oclc:on1263812851",
+            "urn:oclc:SCSB-13992812",
+            "urn:lccn:60002450032",
+            "urn:identifier:(OCoLC)on1263812851"
+          ],
+          "creators_displayPacked": [
+            "Mills, Tôpher||Mills, Tôpher, author"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2023",
+                "gte": "2022"
+              },
+              "raw": "210806s2022    wlk           000 p eng d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:undefined",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PR6113.I5865 S39 2022"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "288 pages ; 21 cm"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Sex on toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2022"
+          ],
+          "creatorLiteral": [
+            "Mills, Tôpher"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Edwards, Jonathan"
+          ],
+          "idOclc": [
+            "on1263812851",
+            "SCSB-13992812"
+          ],
+          "idIsbn": [
+            "9781912681877",
+            "1912681870"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2022"
+          ],
+          "titleDisplay": [
+            "Sex on toast / Tôpher Mills ; [editor, Jonathan Edwards]."
+          ],
+          "uri": "cb15861113",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Cardigan"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm"
+          ],
+          "idIsbn_clean": [
+            "9781912681877",
+            "1912681870"
+          ]
+        },
+        "sort": [
+          700.619,
+          "cb15861113"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb15861113",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR6113.I5865 S39 2022g",
+                      "urn:barcode:CU27972887"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PR6113.I5865 S39 2022g",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "CU27972887",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU27972887"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "PR6113.I5865 S39 2022g"
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PR6113.I5865 S39 2022g"
+                    ],
+                    "shelfMark_sort": "aPR6113.I5865 S39 2022g",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci10035633"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "cb1808514",
+        "_score": 700.619,
+        "_source": {
+          "extent": [
+            "1 score (3 unnumbered pages, 12 pages) ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "publisherLiteral": [
+            "Jalni Publications ; Boosey & Hawkes, sole selling agent"
+          ],
+          "language": [
+            {
+              "id": "lang:N/A",
+              "label": ""
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1984
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "1808514"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm11578466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-3364085"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "H.P.S. 976 Boosey & Hawkes"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm11578466"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)1808514"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "1808514"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779480345156,
+          "publicationStatement": [
+            "[Place of publication not identified] : Jalni Publications ; New York, N.Y. : Boosey & Hawkes, sole selling agent, 1984, ©1980."
+          ],
+          "identifier": [
+            "urn:bnum:1808514",
+            "urn:oclc:ocm11578466",
+            "urn:oclc:SCSB-3364085",
+            "urn:identifier:H.P.S. 976 Boosey & Hawkes",
+            "urn:identifier:(OCoLC)ocm11578466",
+            "urn:identifier:(NNC)1808514",
+            "urn:identifier:1808514"
+          ],
+          "creators_displayPacked": [
+            "Bernstein, Leonard, 1918-1990||Bernstein, Leonard, 1918-1990"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1985",
+                "gte": "1984"
+              },
+              "raw": "850114t19841980nyuzza   i     n    N/A d",
+              "tag": "t"
+            },
+            {
+              "range": {
+                "lt": "1981",
+                "gte": "1980"
+              },
+              "raw": "850114t19841980nyuzza   i     n    N/A d",
+              "tag": "t"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "c",
+          "collectionIds": [],
+          "titleAlt": [
+            "Musical toast"
+          ],
+          "physicalDescription": [
+            "1 score (3 unnumbered pages, 12 pages) ; 27 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes by Jack Gottlieb.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 2:30.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Recorded by the Israel Philharmonic, the composer conducting, on Deutsche Grammophon 2532 052.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Also available in a version for symphonic band.",
+              "type": "bf:Note"
+            }
+          ],
+          "seriesUniformTitle_displayPacked": [
+            "Hawkes pocket scores.||Hawkes pocket scores."
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1980"
+          ],
+          "title": [
+            "A musical toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [
+            "Bernstein, Leonard, 1918-1990"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocm11578466",
+            "SCSB-3364085"
+          ],
+          "uniformTitle": [
+            "Musical toast"
+          ],
+          "dateEndYear": [
+            1980
+          ],
+          "seriesUniformTitle": [
+            "Hawkes pocket scores."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "titleDisplay": [
+            "A musical toast / Leonard Bernstein."
+          ],
+          "uri": "cb1808514",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "[Place of publication not identified] : New York, N.Y."
+          ],
+          "series": [
+            "Hawkes pocket scores"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Hawkes pocket scores||Hawkes pocket scores"
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          700.619,
+          "cb1808514"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb1808514",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:61 B458 M9",
+                      "urn:barcode:MR61509485"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "61 B458 M9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "MR61509485",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "MR61509485"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "61 B458 M9"
+                    ],
+                    "recapCustomerCode": [
+                      "MR"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "61 B458 M9"
+                    ],
+                    "shelfMark_sort": "a61 B458 M000009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci2278358"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b16151201",
+        "_score": 672.9889,
+        "_source": {
+          "extent": [
+            "1 sound disc : analog, 33 1/3 rpm ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Seeco"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            19
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LZR 43109"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            19
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LZR 43109"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16151201"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "58387713"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "SCLP 9109 Seeco"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A070000038"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Aguilera, F.||Aguilera, F., performer, editor, arranger",
+            "García Matos, Manuel, 1912-||García Matos, Manuel, 1912-, conductor, editor, arranger"
+          ],
+          "updatedAt": 1779433889165,
+          "publicationStatement": [
+            "New York, N.Y. : Seeco, [19--?]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LZR 43109",
+            "urn:bnum:16151201",
+            "urn:oclc:58387713",
+            "urn:identifier:SCLP 9109 Seeco",
+            "urn:identifier:(WaOLN)A070000038"
+          ],
+          "creators_displayPacked": [
+            "Flores, Lola||Flores, Lola, performer"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2000",
+                "gte": "1900"
+              },
+              "raw": "050307s19uu    nyuppn   i          spa dnjmIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Popular music -- Spain."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "j",
+          "collectionIds": [
+            "pah"
+          ],
+          "physicalDescription": [
+            "1 sound disc : analog, 33 1/3 rpm ; 12 in."
+          ],
+          "tableOfContents": [
+            "Lola de España -- Concha veneno -- Tu cartel por las mũrallas -- Mi pelo negro -- Mi embajaora -- Valgame la Magdalena -- Remedios la de montilla -- Venga pronto el volapie -- Gritenme piedras del campo -- Me serenaste -- Pa su papa -- Maldigo tus ojos verdes."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Program notes in English and Spanish on container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in Spanish.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Popular music",
+            "Popular music -- Spain"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "The toast of Spain"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "19uu"
+          ],
+          "creatorLiteral": [
+            "Flores, Lola"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Aguilera, F.",
+            "García Matos, Manuel, 1912-"
+          ],
+          "idOclc": [
+            "58387713"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "19uu"
+          ],
+          "titleDisplay": [
+            "The toast of Spain [sound recording] / Lola Flores."
+          ],
+          "uri": "b16151201",
+          "parallelContributorLiteral": [
+            null,
+            null
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "New York, N.Y."
+          ],
+          "series": [
+            "Gold series"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Gold series||Gold series"
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          672.9889,
+          "b16151201"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16151201",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Flores%2C+Lola&CallNumber=*LZR+43109+%5BDisc%5D&Date=19uu&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16151201&ItemISxN=i155562502&ItemNumber=33433036075665&ItemPlace=New+York%2C+N.Y.&ItemPublisher=Seeco%2C+%5B19--%3F%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b16151201x&Site=LPAMRAMI&Title=The+toast+of+Spain"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LZR 43109 [Disc]",
+                      "urn:barcode:33433036075665"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LZR 43109 [Disc]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433036075665",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433036075665"
+                    ],
+                    "physicalLocation": [
+                      "*LZR 43109 [Disc]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LZR 43109 [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LZR 43109 [Disc]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15556250"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b16579957",
+        "_score": 672.9889,
+        "_source": {
+          "extent": [
+            "iv, 238 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "S.M.K. Taribo"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "sc"
+          ],
+          "createdYear": [
+            1991
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "Sc D 07-1829"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1991
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 07-1829"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16579957"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "35139639"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)35139639"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M180000413"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779468030069,
+          "publicationStatement": [
+            "[Nigeria?] : S.M.K. Taribo, c1991."
+          ],
+          "identifier": [
+            "urn:shelfmark:Sc D 07-1829",
+            "urn:bnum:16579957",
+            "urn:oclc:35139639",
+            "urn:identifier:(OCoLC)35139639",
+            "urn:identifier:(WaOLN)M180000413"
+          ],
+          "creators_displayPacked": [
+            "Taribo, Spiff Micah Kalaokpara||Taribo, Spiff Micah Kalaokpara"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1992",
+                "gte": "1991"
+              },
+              "raw": "941007s1991    nr            000 0 eng dcamIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Nigeria -- Social conditions -- 1960-",
+            "Nigeria -- Economic conditions -- 1960-",
+            "Nigeria -- Politics and government -- 1960-"
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PR9387.9.T37 T63 1991"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "scf"
+          ],
+          "physicalDescription": [
+            "iv, 238 p. ; 21 cm."
+          ],
+          "subjectLiteral_exploded": [
+            "Nigeria",
+            "Nigeria -- Social conditions",
+            "Nigeria -- Social conditions -- 1960-",
+            "Nigeria -- Economic conditions",
+            "Nigeria -- Economic conditions -- 1960-",
+            "Nigeria -- Politics and government",
+            "Nigeria -- Politics and government -- 1960-"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "A toast to Nigeria"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1991"
+          ],
+          "creatorLiteral": [
+            "Taribo, Spiff Micah Kalaokpara"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "35139639"
+          ],
+          "popularity": 1,
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1991"
+          ],
+          "titleDisplay": [
+            "A toast to Nigeria / by Spiff Micah Kalaokpara Taribo."
+          ],
+          "uri": "b16579957",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "[Nigeria?]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          672.9889,
+          "b16579957"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16579957",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc D 07-1829",
+                      "urn:barcode:33433074287149"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 07-1829",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433074287149",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433074287149"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "physicalLocation": [
+                      "Sc D 07-1829"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "Sc D 07-1829"
+                    ],
+                    "shelfMark_sort": "aSc D 07-001829",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17355861"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b21766784",
+        "_score": 672.9889,
+        "_source": {
+          "extent": [
+            "75 pages ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Quattro Poetry"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            2018
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 19-3255"
+          ],
+          "idLccn": [
+            "2018487509"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2018
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 19-3255"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "21766784"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781988254616"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1988254612"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1030339564"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2018487509"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1030484899"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1030339564"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779512068012,
+          "publicationStatement": [
+            "Toronto, Canada : Quattro Poetry, 2018."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 19-3255",
+            "urn:bnum:21766784",
+            "urn:isbn:9781988254616",
+            "urn:isbn:1988254612",
+            "urn:oclc:1030339564",
+            "urn:lccn:2018487509",
+            "urn:identifier:(OCoLC)1030484899",
+            "urn:identifier:(OCoLC)1030339564"
+          ],
+          "creators_displayPacked": [
+            "Paina, Corrado, 1954-||Paina, Corrado, 1954-, author"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2019",
+                "gte": "2018"
+              },
+              "raw": "190410s2018    onc           000 p eng  cam i ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PR9199.4.P34 T63 2018"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "75 pages ; 22 cm"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems.",
+              "type": "bf:Note"
+            }
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "A toast to illness"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2018"
+          ],
+          "creatorLiteral": [
+            "Paina, Corrado, 1954-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "1030339564"
+          ],
+          "summary": [
+            "\"This new poetry collection by Corrado Paina explores the induced meditations and considerations that illness imposes upon a body and mind.\"--"
+          ],
+          "genreForm": [
+            "Poetry."
+          ],
+          "idIsbn": [
+            "9781988254616",
+            "1988254612"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2018"
+          ],
+          "titleDisplay": [
+            "A toast to illness / Corrado Paina."
+          ],
+          "uri": "b21766784",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Toronto, Canada"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm"
+          ],
+          "idIsbn_clean": [
+            "9781988254616",
+            "1988254612"
+          ]
+        },
+        "sort": [
+          672.9889,
+          "b21766784"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b21766784",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 19-3255",
+                      "urn:barcode:33433129000943"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFD 19-3255",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433129000943",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433129000943"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "physicalLocation": [
+                      "JFD 19-3255"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFD 19-3255"
+                    ],
+                    "shelfMark_sort": "aJFD 19-003255",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i37241733"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b12227432",
+        "_score": 671.9889,
+        "_source": {
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Review of the New York City Ballet in Peter Martins' Sleeping beauty, New York State Theatre, April 24, 1991.",
+              "type": "bf:Note"
+            }
+          ],
+          "partOf": [
+            "Dance and dancers. London. June/July 1991, p. 33-36. ill."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Martins, Peter, 1946-",
+            "New York City Ballet",
+            "Sleeping beauty (Choreographic work : Martins after Petipa, M)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            1991
+          ],
+          "parallelSeriesAddedEntry": [],
+          "title": [
+            "A toast to Beauty."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "shelfMark": [
+            "*MGZA"
+          ],
+          "createdString": [
+            "1991"
+          ],
+          "creatorLiteral": [
+            "Barnes, Clive, 1927-2008"
+          ],
+          "parallelCreators_displayPacked": [],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1991
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "idOclc": [
+            "NYPY916066942-B"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*MGZA"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12227432"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPY916066942-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NN-PD)916066942"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp2214263"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779371797256,
+          "identifier": [
+            "urn:shelfmark:*MGZA",
+            "urn:bnum:12227432",
+            "urn:oclc:NYPY916066942-B",
+            "urn:identifier:(NN-PD)916066942",
+            "urn:identifier:(WaOLN)nyp2214263"
+          ],
+          "creators_displayPacked": [
+            "Barnes, Clive, 1927-2008||Barnes, Clive, 1927-2008"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1991"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1992",
+                "gte": "1991"
+              },
+              "raw": "911008s1991    enka    |    |0|| | eng dnabzi ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Martins, Peter, 1946-",
+            "New York City Ballet.",
+            "Sleeping beauty (Choreographic work : Martins after Petipa, M)"
+          ],
+          "titleDisplay": [
+            "A toast to Beauty."
+          ],
+          "uri": "b12227432",
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelContributorLiteral": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "recordTypeId": "a",
+          "collectionIds": [
+            "pad"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:b",
+              "label": "serial component part"
+            }
+          ]
+        },
+        "sort": [
+          671.9889,
+          "b12227432"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b21897112",
+        "_score": 671.9889,
+        "_source": {
+          "extent": [
+            "1 online resource (1 sound file)"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Rose Records"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            2014
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "TCABU1402840",
+            "TCABU1402841",
+            "TCABU1402843",
+            "TCABU1402846",
+            "TCABU1402849",
+            "TCABU1402851",
+            "TCABU1402852",
+            "TCABU1402858",
+            "TCABU1402862",
+            "TCABU1402864",
+            "TCABU1402869",
+            "TCABU1402872",
+            "TCABU1402874",
+            "TCABU1402878",
+            "TCABU1402880",
+            "TCABU1402883",
+            "TCABU1402887",
+            "TCABU1402889",
+            "TCABU1402890",
+            "TCABU1402892",
+            "TCABU1402893",
+            "TCABU1402894",
+            "TCABU1402895",
+            "TCABU1402896"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2014
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "21897112"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "911040673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402840"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402841"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402843"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402846"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402849"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402851"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402852"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402858"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402862"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402864"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402869"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402872"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402874"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402878"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402880"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402883"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402887"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402889"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402890"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402892"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402893"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402894"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402895"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "TCABU1402896"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Rose011 Rose Records"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)911040673"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Rose Ensemble||Rose Ensemble, performer"
+          ],
+          "updatedAt": 1779513628635,
+          "publicationStatement": [
+            "St. Paul, Minnesota : Rose Records, [2014]",
+            "©2014"
+          ],
+          "identifier": [
+            "urn:bnum:21897112",
+            "urn:oclc:911040673",
+            "urn:lccn:TCABU1402840",
+            "urn:lccn:TCABU1402841",
+            "urn:lccn:TCABU1402843",
+            "urn:lccn:TCABU1402846",
+            "urn:lccn:TCABU1402849",
+            "urn:lccn:TCABU1402851",
+            "urn:lccn:TCABU1402852",
+            "urn:lccn:TCABU1402858",
+            "urn:lccn:TCABU1402862",
+            "urn:lccn:TCABU1402864",
+            "urn:lccn:TCABU1402869",
+            "urn:lccn:TCABU1402872",
+            "urn:lccn:TCABU1402874",
+            "urn:lccn:TCABU1402878",
+            "urn:lccn:TCABU1402880",
+            "urn:lccn:TCABU1402883",
+            "urn:lccn:TCABU1402887",
+            "urn:lccn:TCABU1402889",
+            "urn:lccn:TCABU1402890",
+            "urn:lccn:TCABU1402892",
+            "urn:lccn:TCABU1402893",
+            "urn:lccn:TCABU1402894",
+            "urn:lccn:TCABU1402895",
+            "urn:lccn:TCABU1402896",
+            "urn:identifier:Rose011 Rose Records",
+            "urn:identifier:(OCoLC)911040673"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "lt": "2015",
+                "gte": "2014"
+              },
+              "raw": "150615t20142014mnuppnn o         n eng dnjmKi ",
+              "tag": "t"
+            },
+            {
+              "range": {
+                "lt": "2015",
+                "gte": "2014"
+              },
+              "raw": "150615t20142014mnuppnn o         n eng dnjmKi ",
+              "tag": "t"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Alcohol -- Songs and music.",
+            "Temperance -- Songs and music.",
+            "Prohibition -- Songs and music.",
+            "Choruses, Secular.",
+            "Popular music -- United States."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "w",
+          "collectionIds": [],
+          "physicalDescription": [
+            "1 online resource (1 sound file)"
+          ],
+          "tableOfContents": [
+            "Close up the booze shop (Brighten the corner, 1913) (2:44) -- I like my bootleg man (1928) (2:19) -- The moonshiner's dance, Part I (1927) (2:30) -- Sign the pledge for mother's sake (1867) (3:34) -- It must be settled to-night (1882) (3:18) -- That's a plenty (1914) (2:22) -- Under the Anheuser Bush (1903) (2:51) -- Always vote as you pray (Sweet by and by, 1868) (3:16) -- How are you going to wet your whistle (1919) (1:46) -- Queer people (1903) (2:30) -- King Alcohol (King Andrew, 1834) (1:49) -- At the Prohibition Ball (1919) (2:09) -- The reformed blacksmith (1880) (2:48) -- Just to pay our respects to Maguiness (1886) (3:32) -- Battle song of the Y's (1889) (5:01) -- The alcoholic blues (1919) (2:18) -- Drink from the mountain spring (1847) (2:48) -- A sober spouse for me (1844) (2:12) -- Brandy and water (1853) (2:30) -- Bugbey's champagne galop (1870) (2:19) -- Okay beer (1932) (1:54) -- Temperance is coming (1932) (3:54) -- Help just a little (1885) (3:22) -- A toast to prohibition (1930) (2:12)."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "All-American songs of temperance and temptation. A rich blend of Pro and Anti drinking songs for the human voice.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Alcohol",
+            "Alcohol -- Songs and music",
+            "Temperance",
+            "Temperance -- Songs and music",
+            "Prohibition",
+            "Prohibition -- Songs and music",
+            "Choruses, Secular",
+            "Popular music",
+            "Popular music -- United States"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "dateEndString": [
+            "2014"
+          ],
+          "title": [
+            "A toast to prohibition"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2014"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            1
+          ],
+          "contributorLiteral": [
+            "Rose Ensemble"
+          ],
+          "idOclc": [
+            "911040673"
+          ],
+          "dateEndYear": [
+            2014
+          ],
+          "genreForm": [
+            "Popular music."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2014"
+          ],
+          "titleDisplay": [
+            "A toast to prohibition / Rose Ensemble."
+          ],
+          "uri": "b21897112",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "electronicResources": [
+            {
+              "label": "Access Naxos Music Library",
+              "url": "https://nypl.naxosmusiclibrary.com/catalogue/item.asp?cid=Rose011"
+            }
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "St. Paul, Minnesota"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          671.9889,
+          "b21897112"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b22244189",
+        "_score": 671.9889,
+        "_source": {
+          "extent": [
+            "1 online resource (1 sound file)"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "ABC Classics"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            2018
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "AUAB01850190",
+            "AUAB01850191",
+            "AUAB01850192",
+            "AUAB01850193",
+            "AUAB01850194",
+            "AUAB01850195",
+            "AUAB01850196",
+            "AUAB01850197",
+            "AUAB01850198",
+            "AUAB01850199",
+            "AUAB01850200",
+            "AUAB01850201",
+            "AUAB01850202",
+            "AUAB01850203",
+            "AUAB01850204",
+            "AUAB01850205",
+            "AUAB01850206"
+          ],
+          "parallelCreators_displayPacked": [],
+          "addedAuthorTitle": [
+            "Roméo et Juliette.",
+            "Rigoletto.",
+            "Faust.",
+            "Manon.",
+            "Mireille.",
+            "Pêcheurs de perles.",
+            "Sadko (Opera).",
+            "Mignon.",
+            "Chanson triste.",
+            "Don César de Bazan."
+          ],
+          "dateStartYear": [
+            2018
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "22244189"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1176356131"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850190"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850191"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850192"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850193"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850194"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850195"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850196"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850197"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850198"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850199"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850200"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850201"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850202"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850203"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850204"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850205"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850206"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "00028948163625 ABC Classics"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1176356131"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Gore, Lorina||Gore, Lorina, singer",
+            "Letonja, Marko, 1961-||Letonja, Marko, 1961-, conductor",
+            "Gounod, Charles, 1818-1893||Container of (work): Gounod, Charles, 1818-1893. Roméo et Juliette. Je veux vivre dans le rêve",
+            "Verdi, Giuseppe, 1813-1901||Container of (work): Verdi, Giuseppe, 1813-1901. Rigoletto. Caro nome",
+            "Gounod, Charles, 1818-1893||Container of (work): Gounod, Charles, 1818-1893. Faust. Ballet. Selections",
+            "Gounod, Charles, 1818-1893||Container of (work): Gounod, Charles, 1818-1893. Faust. Je ris de me voir si belle",
+            "Massenet, Jules, 1842-1912||Container of (work): Massenet, Jules, 1842-1912. Manon. Obéissons quand leur voix appelle",
+            "Gounod, Charles, 1818-1893||Container of (work): Gounod, Charles, 1818-1893. Mireille. Heureux petit berger",
+            "Bizet, Georges, 1838-1875||Container of (work): Bizet, Georges, 1838-1875. Pêcheurs de perles. Comme autrefois dans la nuit sombre",
+            "Rimsky-Korsakov, Nikolay, 1844-1908||Container of (work): Rimsky-Korsakov, Nikolay, 1844-1908. Sadko (Opera). Pesni︠a︡ indiĭskogo gosti︠a︡",
+            "Thomas, Ambroise, 1811-1896||Container of (work): Thomas, Ambroise, 1811-1896. Mignon. Je suis Titania",
+            "Duparc, Henri, 1848-1933||Container of (work): Duparc, Henri, 1848-1933. Chanson triste",
+            "Massenet, Jules, 1842-1912||Container of (work): Massenet, Jules, 1842-1912. Don César de Bazan. Sevillana",
+            "Tasmanian Symphony Orchestra||Tasmanian Symphony Orchestra, instrumentalist"
+          ],
+          "updatedAt": 1779518129209,
+          "publicationStatement": [
+            "[Place of publication not identified] : ABC Classics, [2018]"
+          ],
+          "identifier": [
+            "urn:bnum:22244189",
+            "urn:oclc:1176356131",
+            "urn:lccn:AUAB01850190",
+            "urn:lccn:AUAB01850191",
+            "urn:lccn:AUAB01850192",
+            "urn:lccn:AUAB01850193",
+            "urn:lccn:AUAB01850194",
+            "urn:lccn:AUAB01850195",
+            "urn:lccn:AUAB01850196",
+            "urn:lccn:AUAB01850197",
+            "urn:lccn:AUAB01850198",
+            "urn:lccn:AUAB01850199",
+            "urn:lccn:AUAB01850200",
+            "urn:lccn:AUAB01850201",
+            "urn:lccn:AUAB01850202",
+            "urn:lccn:AUAB01850203",
+            "urn:lccn:AUAB01850204",
+            "urn:lccn:AUAB01850205",
+            "urn:lccn:AUAB01850206",
+            "urn:identifier:00028948163625 ABC Classics",
+            "urn:identifier:(OCoLC)1176356131"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "lt": "2019",
+                "gte": "2018"
+              },
+              "raw": "200722s2018    xx munn o         n fre dnjmKi ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Operas -- Excerpts.",
+            "Songs (High voice) with orchestra.",
+            "Orchestral music."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "w",
+          "collectionIds": [],
+          "physicalDescription": [
+            "1 online resource (1 sound file)"
+          ],
+          "tableOfContents": [
+            "Roméo et Juliette. Ah! Je veux vivre dans le reve / Gounod (3:38) -- Rigoletto. Caro nome / Verdi (5:07) -- Faust. Les nubiennes (2:46) ; Adagio (3:51) / Gounod --  Faust. O Dieu! Que de bijoux! / Gounod (4:53) -- Manon. Obeissons quand leur voix appelle / Massenet (3:07) -- Mireille. Heureux petit berger / Gounod (2:24) ; Faust. Danse antique (1:34) ; Variations de Cleopatre (1:41) / Gounod -- Les pêcheurs de perles. me voilà seule dans la nuit ; Comme autrefois dans la nuit sombre / Bizet (6:20) -- Sadko. Song of the Indian guest / Rimsky-Korsakov (3:47) -- Mignon. Oui, pour ce soir je suis reine des fees / Thomas (5:42) -- Faust. Les Troyens (2:39) ; Variations du Miroir (1:59) ; Danse de Phryne (2:53) / Gounod -- Chanson triste / Duparc (3:22) -- Don Cesar de Bazan. A Seville, belles senoras / Massenet (3:10)."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Sung in French.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts",
+            "Songs (High voice) with orchestra",
+            "Orchestral music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "title": [
+            "A toast to Melba"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2018"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            1
+          ],
+          "contributorLiteral": [
+            "Gore, Lorina",
+            "Letonja, Marko, 1961-",
+            "Gounod, Charles, 1818-1893",
+            "Verdi, Giuseppe, 1813-1901",
+            "Massenet, Jules, 1842-1912",
+            "Bizet, Georges, 1838-1875",
+            "Rimsky-Korsakov, Nikolay, 1844-1908",
+            "Thomas, Ambroise, 1811-1896",
+            "Duparc, Henri, 1848-1933",
+            "Tasmanian Symphony Orchestra"
+          ],
+          "idOclc": [
+            "1176356131"
+          ],
+          "genreForm": [
+            "Streaming audio."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2018"
+          ],
+          "titleDisplay": [
+            "A toast to Melba / Lorina Gore."
+          ],
+          "uri": "b22244189",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "electronicResources": [
+            {
+              "label": "Access Naxos Music Library",
+              "url": "https://nypl.naxosmusiclibrary.com/catalogue/item.asp?cid=00028948163625"
+            }
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[Place of publication not identified]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          671.9889,
+          "b22244189"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b22839633",
+        "_score": 671.9889,
+        "_source": {
+          "extent": [
+            "1 online resource (1 sound file)"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "ABC Classics"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            2018
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "AUAB01850190",
+            "AUAB01850191",
+            "AUAB01850192",
+            "AUAB01850193",
+            "AUAB01850194",
+            "AUAB01850195",
+            "AUAB01850196",
+            "AUAB01850197",
+            "AUAB01850198",
+            "AUAB01850199",
+            "AUAB01850200",
+            "AUAB01850201",
+            "AUAB01850202",
+            "AUAB01850203",
+            "AUAB01850204",
+            "AUAB01850205",
+            "AUAB01850206"
+          ],
+          "parallelCreators_displayPacked": [],
+          "addedAuthorTitle": [
+            "Roméo et Juliette.",
+            "Rigoletto.",
+            "Faust.",
+            "Manon.",
+            "Mireille.",
+            "Pêcheurs de perles.",
+            "Sadko (Opera).",
+            "Mignon.",
+            "Chanson triste.",
+            "Don César de Bazan."
+          ],
+          "dateStartYear": [
+            2018
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "22839633"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1336891241"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850190"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850191"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850192"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850193"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850194"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850195"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850196"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850197"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850198"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850199"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850200"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850201"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850202"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850203"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850204"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850205"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "AUAB01850206"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "028948163632 ABC Classics"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1336891241"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Gore, Lorina||Gore, Lorina, singer",
+            "Letonja, Marko, 1961-||Letonja, Marko, 1961-, conductor",
+            "Gounod, Charles, 1818-1893||Container of (work): Gounod, Charles, 1818-1893. Roméo et Juliette. Je veux vivre dans le rêve",
+            "Verdi, Giuseppe, 1813-1901||Container of (work): Verdi, Giuseppe, 1813-1901. Rigoletto. Caro nome",
+            "Gounod, Charles, 1818-1893||Container of (work): Gounod, Charles, 1818-1893. Faust. Ballet. Selections",
+            "Gounod, Charles, 1818-1893||Container of (work): Gounod, Charles, 1818-1893. Faust. Je ris de me voir si belle",
+            "Massenet, Jules, 1842-1912||Container of (work): Massenet, Jules, 1842-1912. Manon. Obéissons quand leur voix appelle",
+            "Gounod, Charles, 1818-1893||Container of (work): Gounod, Charles, 1818-1893. Mireille. Heureux petit berger",
+            "Bizet, Georges, 1838-1875||Container of (work): Bizet, Georges, 1838-1875. Pêcheurs de perles. Comme autrefois dans la nuit sombre",
+            "Rimsky-Korsakov, Nikolay, 1844-1908||Container of (work): Rimsky-Korsakov, Nikolay, 1844-1908. Sadko (Opera). Pesni︠a︡ indiĭskogo gosti︠a︡",
+            "Thomas, Ambroise, 1811-1896||Container of (work): Thomas, Ambroise, 1811-1896. Mignon. Je suis Titania",
+            "Duparc, Henri, 1848-1933||Container of (work): Duparc, Henri, 1848-1933. Chanson triste",
+            "Massenet, Jules, 1842-1912||Container of (work): Massenet, Jules, 1842-1912. Don César de Bazan. Sevillana",
+            "Tasmanian Symphony Orchestra||Tasmanian Symphony Orchestra, instrumentalist"
+          ],
+          "updatedAt": 1779524386943,
+          "publicationStatement": [
+            "[Australia] : ABC Classics, [2018]"
+          ],
+          "identifier": [
+            "urn:bnum:22839633",
+            "urn:oclc:1336891241",
+            "urn:lccn:AUAB01850190",
+            "urn:lccn:AUAB01850191",
+            "urn:lccn:AUAB01850192",
+            "urn:lccn:AUAB01850193",
+            "urn:lccn:AUAB01850194",
+            "urn:lccn:AUAB01850195",
+            "urn:lccn:AUAB01850196",
+            "urn:lccn:AUAB01850197",
+            "urn:lccn:AUAB01850198",
+            "urn:lccn:AUAB01850199",
+            "urn:lccn:AUAB01850200",
+            "urn:lccn:AUAB01850201",
+            "urn:lccn:AUAB01850202",
+            "urn:lccn:AUAB01850203",
+            "urn:lccn:AUAB01850204",
+            "urn:lccn:AUAB01850205",
+            "urn:lccn:AUAB01850206",
+            "urn:identifier:028948163632 ABC Classics",
+            "urn:identifier:(OCoLC)1336891241"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "lt": "2019",
+                "gte": "2018"
+              },
+              "raw": "220721s2018    at munn o         n fre dnjm7i ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Operas -- Excerpts.",
+            "Songs (High voice) with orchestra.",
+            "Orchestral music."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "w",
+          "collectionIds": [],
+          "physicalDescription": [
+            "1 online resource (1 sound file)"
+          ],
+          "tableOfContents": [
+            "Roméo et Juliette. Ah! Je veux vivre dans le reve / Gounod (3:38) -- Rigoletto. Caro nome / Verdi (5:07) -- Faust. Les nubiennes (2:46) ; Adagio (3:51) / Gounod -- Faust. O Dieu! Que de bijoux! / Gounod (4:53) -- Manon. Obeissons quand leur voix appelle / Massenet (3:07) -- Mireille. Heureux petit berger / Gounod (2:24) ; Faust. Danse antique (1:34) ; Variations de Cleopatre (1:41) / Gounod -- Les pêcheurs de perles. me voilà seule dans la nuit ; Comme autrefois dans la nuit sombre / Bizet (6:20) -- Sadko. Song of the Indian guest / Rimsky-Korsakov (3:47) -- Mignon. Oui, pour ce soir je suis reine des fees / Thomas (5:42) -- Faust. Les Troyens (2:39) ; Variations du Miroir (1:59) ; Danse de Phryne (2:53) / Gounod -- Chanson triste / Duparc (3:22) -- Don Cesar de Bazan. A Seville, belles senoras / Massenet (3:10)."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Sung in French.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts",
+            "Songs (High voice) with orchestra",
+            "Orchestral music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "title": [
+            "A toast to Melba"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2018"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            1
+          ],
+          "contributorLiteral": [
+            "Gore, Lorina",
+            "Letonja, Marko, 1961-",
+            "Gounod, Charles, 1818-1893",
+            "Verdi, Giuseppe, 1813-1901",
+            "Massenet, Jules, 1842-1912",
+            "Bizet, Georges, 1838-1875",
+            "Rimsky-Korsakov, Nikolay, 1844-1908",
+            "Thomas, Ambroise, 1811-1896",
+            "Duparc, Henri, 1848-1933",
+            "Tasmanian Symphony Orchestra"
+          ],
+          "idOclc": [
+            "1336891241"
+          ],
+          "genreForm": [
+            "Streaming audio."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2018"
+          ],
+          "titleDisplay": [
+            "A toast to Melba / Lorina Gore."
+          ],
+          "uri": "b22839633",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "electronicResources": [
+            {
+              "label": "Access Naxos Music Library",
+              "url": "https://nypl.naxosmusiclibrary.com/catalogue/item.asp?cid=028948163632"
+            }
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[Australia]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          671.9889,
+          "b22839633"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb5714692",
+        "_score": 662.63617,
+        "_source": {
+          "extent": [
+            "272 p. ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "publisherLiteral": [
+            "Pan Macmillan"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2008
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "2009351955"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2008
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "5714692"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781770100671"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1770100679"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocn301705470"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "301705470"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-1508353"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2009351955"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocn301705470"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)301705470"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779557854741,
+          "publicationStatement": [
+            "Northlands [South Africa] : Pan Macmillan, 2008."
+          ],
+          "identifier": [
+            "urn:bnum:5714692",
+            "urn:isbn:9781770100671",
+            "urn:isbn:1770100679",
+            "urn:oclc:ocn301705470",
+            "urn:oclc:301705470",
+            "urn:oclc:SCSB-1508353",
+            "urn:lccn:2009351955",
+            "urn:identifier:(OCoLC)ocn301705470",
+            "urn:identifier:(OCoLC)301705470"
+          ],
+          "creators_displayPacked": [
+            "Clemence, Laurian||Clemence, Laurian"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2009",
+                "gte": "2008"
+              },
+              "raw": "090204s2008    sa            000 1 eng  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PR9369.4.C54 M87 2008"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "272 p. ; 20 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A novel.",
+              "type": "bf:Note"
+            }
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Mushy peas on toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2008"
+          ],
+          "creatorLiteral": [
+            "Clemence, Laurian"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocn301705470",
+            "301705470",
+            "SCSB-1508353"
+          ],
+          "idIsbn": [
+            "9781770100671",
+            "1770100679"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2008"
+          ],
+          "titleDisplay": [
+            "Mushy peas on toast / Laurian Clemence."
+          ],
+          "uri": "pb5714692",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Northlands [South Africa]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "9781770100671",
+            "1770100679"
+          ]
+        },
+        "sort": [
+          662.63617,
+          "pb5714692"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb5714692",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR9369.4.C54M87 2008",
+                      "urn:barcode:32101069223301"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PR9369.4.C54M87 2008",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101069223301",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101069223301"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PR9369.4.C54M87 2008"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PR9369.4.C54M87 2008"
+                    ],
+                    "shelfMark_sort": "aPR9369.4.C54M87 002008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi5303659"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb9957146923506421",
+        "_score": 662.63617,
+        "_source": {
+          "extent": [
+            "272 p. ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "publisherLiteral": [
+            "Pan Macmillan"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2008
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "2009351955"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2008
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9957146923506421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781770100671"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1770100679"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocn301705470"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-1508353"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2009351955"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)5714692-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager5714692"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocn301705470"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779627449782,
+          "publicationStatement": [
+            "Northlands [South Africa] : Pan Macmillan, 2008."
+          ],
+          "identifier": [
+            "urn:bnum:9957146923506421",
+            "urn:isbn:9781770100671",
+            "urn:isbn:1770100679",
+            "urn:oclc:ocn301705470",
+            "urn:oclc:SCSB-1508353",
+            "urn:lccn:2009351955",
+            "urn:identifier:(NjP)5714692-princetondb",
+            "urn:identifier:(NjP)Voyager5714692",
+            "urn:identifier:(OCoLC)ocn301705470"
+          ],
+          "creators_displayPacked": [
+            "Clemence, Laurian||Clemence, Laurian"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2009",
+                "gte": "2008"
+              },
+              "raw": "090204s2008    sa            000 1 eng  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PR9369.4.C54 M87 2008"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "272 p. ; 20 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A novel.",
+              "type": "bf:Note"
+            }
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Mushy peas on toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2008"
+          ],
+          "creatorLiteral": [
+            "Clemence, Laurian"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocn301705470",
+            "SCSB-1508353"
+          ],
+          "genreForm": [
+            "Fiction."
+          ],
+          "idIsbn": [
+            "9781770100671",
+            "1770100679"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2008"
+          ],
+          "titleDisplay": [
+            "Mushy peas on toast / Laurian Clemence."
+          ],
+          "uri": "pb9957146923506421",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Northlands [South Africa]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "9781770100671",
+            "1770100679"
+          ]
+        },
+        "sort": [
+          662.63617,
+          "pb9957146923506421"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb9957146923506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR9369.4.C54 M87 2008",
+                      "urn:barcode:32101069223301"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PR9369.4.C54 M87 2008",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101069223301",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101069223301"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PR9369.4.C54 M87 2008"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PR9369.4.C54 M87 2008"
+                    ],
+                    "shelfMark_sort": "aPR9369.4.C54 M87 002008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi23713898730006421"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b17794539",
+        "_score": 657.1697,
+        "_source": {
+          "extent": [
+            "118 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Holiday House"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1999
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "98036883"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1999
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "17794539"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0823414302"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "39655664"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "98036883"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779478063667,
+          "publicationStatement": [
+            "New York : Holiday House, c1999."
+          ],
+          "identifier": [
+            "urn:bnum:17794539",
+            "urn:isbn:0823414302",
+            "urn:oclc:39655664",
+            "urn:lccn:98036883"
+          ],
+          "creators_displayPacked": [
+            "Stewart, Jennifer J.||Stewart, Jennifer J."
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2000",
+                "gte": "1999"
+              },
+              "raw": "980730s1999    nyu    j      000 1 eng  pam a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Dragons -- Fiction.",
+            "Moving, Household -- Fiction.",
+            "Arizona -- Fiction."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PZ7.S84895 If 1999"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "118 p. ; 22 cm."
+          ],
+          "subjectLiteral_exploded": [
+            "Dragons",
+            "Dragons -- Fiction",
+            "Moving, Household",
+            "Moving, Household -- Fiction",
+            "Arizona",
+            "Arizona -- Fiction"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "If that breathes fire, we're toast!"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1999"
+          ],
+          "creatorLiteral": [
+            "Stewart, Jennifer J."
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "39655664"
+          ],
+          "popularity": 11,
+          "summary": [
+            "When eleven-year-old Rick and his mother move from San Diego to Tucson he is not too happy about the change, but when they get a fire-breathing, time-traveling dragon to replace their broken furnace, his new life starts to get more interesting."
+          ],
+          "genreForm": [
+            "Time travel fiction."
+          ],
+          "idIsbn": [
+            "0823414302"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1999"
+          ],
+          "titleDisplay": [
+            "If that breathes fire, we're toast! / Jennifer J. Stewart."
+          ],
+          "uri": "b17794539",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ],
+          "idIsbn_clean": [
+            "0823414302"
+          ]
+        },
+        "sort": [
+          657.1697,
+          "b17794539"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "popularity >= 10",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b17794539",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:J FIC S",
+                      "urn:barcode:33333120986738"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J FIC S",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33333120986738",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33333120986738"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "physicalLocation": [
+                      "J FIC S"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "J FIC S"
+                    ],
+                    "shelfMark_sort": "aJ FIC S",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i18335641"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "hb990094818300203941",
+        "_score": 647.81696,
+        "_source": {
+          "extent": [
+            "64 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "publisherLiteral": [
+            "Hope Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2002
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2002
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990094818300203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9783654845"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "54955577"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "990094818300203941"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)54955577"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779598505797,
+          "publicationStatement": [
+            "Ibadan, Nigeria : Hope Publications, c2002."
+          ],
+          "identifier": [
+            "urn:bnum:990094818300203941",
+            "urn:isbn:9783654845",
+            "urn:oclc:54955577",
+            "urn:oclc:990094818300203941",
+            "urn:identifier:(OCoLC)54955577"
+          ],
+          "creators_displayPacked": [
+            "Odeleye, Biodun||Odeleye, Biodun"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2003",
+                "gte": "2002"
+              },
+              "raw": "040414s2002    nr a          000 p eng c",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Conduct of life -- Poetry.",
+            "Nigeria -- Poetry."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PR9387.9.O3115 T63 2002"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "titleAlt": [
+            "Toast to life and vision"
+          ],
+          "physicalDescription": [
+            "64 p. : ill. ; 20 cm."
+          ],
+          "tableOfContents": [
+            "Moon among stars -- Vampires on rampage -- The dangling visionary saw -- Much to a name -- Dear mother -- La Rambla -- Personifying death -- Success turns albatross in the hall of nobility."
+          ],
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain 20181001 in perpetuity ReCAP Shared Collection HUL 222089710600003941",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Conduct of life",
+            "Conduct of life -- Poetry",
+            "Nigeria",
+            "Nigeria -- Poetry"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast to life & vision / Biodun Odeleye."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2002"
+          ],
+          "creatorLiteral": [
+            "Odeleye, Biodun"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "54955577",
+            "990094818300203941"
+          ],
+          "genreForm": [
+            "Poetry"
+          ],
+          "idIsbn": [
+            "9783654845"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2002"
+          ],
+          "titleDisplay": [
+            "Toast to life & vision / Biodun Odeleye."
+          ],
+          "uri": "hb990094818300203941",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Ibadan, Nigeria"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "9783654845"
+          ]
+        },
+        "sort": [
+          647.81696,
+          "hb990094818300203941"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "hb990094818300203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR9387.9.O314 T63 2002 copy ",
+                      "urn:barcode:32044089630495"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PR9387.9.O314 T63 2002 copy ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32044089630495",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32044089630495"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "physicalLocation": [
+                      "PR9387.9.O314 T63 2002"
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PR9387.9.O314 T63 2002 copy "
+                    ],
+                    "shelfMark_sort": "aPR9387.9.O314 T63 2002 copy ",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "hi232089710580003941"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b18437590",
+        "_score": 638.9126,
+        "_source": {
+          "extent": [
+            "xii, 156 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Keynotes Publishers"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "sc"
+          ],
+          "createdYear": [
+            2008
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "Sc D 10-1128"
+          ],
+          "idLccn": [
+            "2009382032"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2008
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 10-1128"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "18437590"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "978375842X"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9789783758421"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "318127683"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2009382032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)318127683"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779483098824,
+          "publicationStatement": [
+            "Ilesa : Keynotes Publishers, c2008."
+          ],
+          "identifier": [
+            "urn:shelfmark:Sc D 10-1128",
+            "urn:bnum:18437590",
+            "urn:isbn:978375842X",
+            "urn:isbn:9789783758421",
+            "urn:oclc:318127683",
+            "urn:lccn:2009382032",
+            "urn:identifier:(OCoLC)318127683"
+          ],
+          "creators_displayPacked": [
+            "Fatubarin, Ayo||Fatubarin, Ayo"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2009",
+                "gte": "2008"
+              },
+              "raw": "090317s2008    |||           000 0 eng dcamIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Ijesa (African people) -- Biography.",
+            "Ilesa (Nigeria) -- Description and travel."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "DT515.45.I348 F384 2008"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "scf"
+          ],
+          "physicalDescription": [
+            "xii, 156 p. ; 21 cm."
+          ],
+          "seriesUniformTitle_displayPacked": [
+            "Patriotic reflections on Ijesaland ;||Patriotic reflections on Ijesaland ; no. 2."
+          ],
+          "subjectLiteral_exploded": [
+            "Ijesa (African people)",
+            "Ijesa (African people) -- Biography",
+            "Ilesa (Nigeria)",
+            "Ilesa (Nigeria) -- Description and travel"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "A toast of Ijesa people"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2008"
+          ],
+          "creatorLiteral": [
+            "Fatubarin, Ayo"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "318127683"
+          ],
+          "popularity": 1,
+          "seriesUniformTitle": [
+            "Patriotic reflections on Ijesaland ;"
+          ],
+          "idIsbn": [
+            "978375842X",
+            "9789783758421"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2008"
+          ],
+          "titleDisplay": [
+            "A toast of Ijesa people / Ayo Fatubarin."
+          ],
+          "uri": "b18437590",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Ilesa"
+          ],
+          "series": [
+            "Patriotic reflections on Ijesaland ;"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Patriotic reflections on Ijesaland ;||Patriotic reflections on Ijesaland ; no. 2"
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "978375842X",
+            "9789783758421"
+          ]
+        },
+        "sort": [
+          638.9126,
+          "b18437590"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b18437590",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc D 10-1128",
+                      "urn:barcode:33433089279883"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 10-1128",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433089279883",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433089279883"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "physicalLocation": [
+                      "Sc D 10-1128"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "Sc D 10-1128"
+                    ],
+                    "shelfMark_sort": "aSc D 10-001128",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i25227645"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b22185434",
+        "_score": 638.9126,
+        "_source": {
+          "extent": [
+            "166 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "editionStatement": [
+            "1st ed."
+          ],
+          "publisherLiteral": [
+            "Ecco"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            2010
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 10-2308"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2010
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 10-2308"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22185434"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "006182593X (hbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780061825934 (hbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "419859876"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)419859876"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779517168075,
+          "publicationStatement": [
+            "New York : Ecco, c2010."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 10-2308",
+            "urn:bnum:22185434",
+            "urn:isbn:006182593X (hbk.)",
+            "urn:isbn:9780061825934 (hbk.)",
+            "urn:oclc:419859876",
+            "urn:identifier:(OCoLC)419859876"
+          ],
+          "creators_displayPacked": [
+            "Rosenblatt, Roger||Rosenblatt, Roger"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2011",
+                "gte": "2010"
+              },
+              "raw": "091127s2010    nyu           000 0 eng  camIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Rosenblatt, Roger -- Family.",
+            "Grandparent and child.",
+            "Bereavement.",
+            "Parenting.",
+            "Grandparents as parents.",
+            "Daughters -- Death.",
+            "Grandparents."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "166 p. ; 22 cm."
+          ],
+          "subjectLiteral_exploded": [
+            "Rosenblatt, Roger",
+            "Rosenblatt, Roger -- Family",
+            "Grandparent and child",
+            "Bereavement",
+            "Parenting",
+            "Grandparents as parents",
+            "Daughters",
+            "Daughters -- Death",
+            "Grandparents"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Making toast : a family story"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2010"
+          ],
+          "creatorLiteral": [
+            "Rosenblatt, Roger"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "419859876"
+          ],
+          "popularity": 1,
+          "idIsbn": [
+            "006182593X (hbk.)",
+            "9780061825934 (hbk.)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2010"
+          ],
+          "titleDisplay": [
+            "Making toast : a family story / Roger Rosenblatt."
+          ],
+          "uri": "b22185434",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ],
+          "idIsbn_clean": [
+            "006182593X",
+            "9780061825934"
+          ]
+        },
+        "sort": [
+          638.9126,
+          "b22185434"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b22185434",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 10-2308",
+                      "urn:barcode:33433087759761"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFD 10-2308",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433087759761",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433087759761"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "physicalLocation": [
+                      "JFD 10-2308"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFD 10-2308"
+                    ],
+                    "shelfMark_sort": "aJFD 10-002308",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i37905601"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b13111567",
+        "_score": 637.9126,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "The Nation Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1909
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "NBI (Rowe, W. H. Verse and toast)"
+          ],
+          "idLccn": [
+            "09014147"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1909
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NBI (Rowe, W. H. Verse and toast)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13111567"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "12310878"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "09014147"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3090092"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779387175635,
+          "publicationStatement": [
+            "New York, The Nation Press, 1909-"
+          ],
+          "identifier": [
+            "urn:shelfmark:NBI (Rowe, W. H. Verse and toast)",
+            "urn:bnum:13111567",
+            "urn:oclc:12310878",
+            "urn:lccn:09014147",
+            "urn:identifier:(WaOLN)nyp3090092"
+          ],
+          "creators_displayPacked": [
+            "Rowe, William H., Jr||Rowe, William H., Jr"
+          ],
+          "dates": [
+            {
+              "range": {
+                "gte": "1909",
+                "lte": "9999"
+              },
+              "raw": "850726m19099999nyu           000 p eng  namI  ",
+              "tag": "m"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "v. ; 19 cm."
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "title": [
+            "Verse and toast. Series 1-"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1909"
+          ],
+          "creatorLiteral": [
+            "Rowe, William H., Jr"
+          ],
+          "numElectronicResources": [
+            2
+          ],
+          "idOclc": [
+            "12310878"
+          ],
+          "popularity": 6,
+          "dateEndYear": [
+            9999
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1909"
+          ],
+          "titleDisplay": [
+            "Verse and toast. Series 1- By Col. William H. Rowe, Jr."
+          ],
+          "uri": "b13111567",
+          "parallelContributorLiteral": [],
+          "electronicResources": [
+            {
+              "label": "Full text available via HathiTrust--ser. 1",
+              "url": "http://babel.hathitrust.org/cgi/pt?id=nyp.33433066644091"
+            },
+            {
+              "label": "Full text available via HathiTrust--ser. 2",
+              "url": "http://babel.hathitrust.org/cgi/pt?id=nyp.33433066644109"
+            }
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          637.9126,
+          "b13111567"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b13111567",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "enumerationChronology": [
+                      "ser. 2"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NBI (Rowe, W. H. Verse and toast)",
+                      "urn:barcode:33433066644109"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "NBI (Rowe, W. H. Verse and toast)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433066644109",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433066644109"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "physicalLocation": [
+                      "NBI (Rowe, W. H. Verse and toast)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "NBI (Rowe, W. H. Verse and toast)"
+                    ],
+                    "shelfMark_sort": "aNBI (Rowe, W. H. Verse and toast)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i16815166"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b13111567",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "enumerationChronology": [
+                      "ser. 1"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2",
+                      "urn:barcode:33433066644091"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433066644091",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433066644091"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "physicalLocation": [
+                      "NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2"
+                    ],
+                    "shelfMark_sort": "aNBI (Rowe, W. H. Verse and toast) Library has: Series 1-000002",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i16257903"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b20569949",
+        "_score": 629.2938,
+        "_source": {
+          "extent": [
+            "1 online resource."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "editionStatement": [
+            "1st electronic ed."
+          ],
+          "publisherLiteral": [
+            "Alexander Street Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            2007
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2007
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "20569949"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ssj0001177068"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaSeSS)ssj0001177068"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Josephson, Matthew, 1899-1978||Josephson, Matthew, 1899-1978",
+            "Twist, John, 1898-1976||Twist, John, 1898-1976",
+            "Sayre, Joel, 1900-1979||Sayre, Joel, 1900-1979"
+          ],
+          "updatedAt": 1779499269033,
+          "publicationStatement": [
+            "Alexandria, VA : Alexander Street Press, 2007."
+          ],
+          "identifier": [
+            "urn:bnum:20569949",
+            "urn:oclc:ssj0001177068",
+            "urn:identifier:(WaSeSS)ssj0001177068"
+          ],
+          "creators_displayPacked": [
+            "Nichols, Dudley, 1895-1960||Nichols, Dudley, 1895-1960"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2008",
+                "gte": "2007"
+              },
+              "raw": "080405s2007    vau     o|||||||||||eng|dnam3i ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "w",
+          "collectionIds": [],
+          "titleAlt": [
+            "Toast of New York (1937 : Online)"
+          ],
+          "physicalDescription": [
+            "1 online resource."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title from HTML t.p. (viewed May 1, 2009).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access restricted to authorized users.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "Mode of access: World Wide Web.",
+              "type": "bf:Note"
+            }
+          ],
+          "seriesUniformTitle_displayPacked": [
+            "American film scripts online.||American film scripts online."
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "title": [
+            "Toast of New York (1937) shooting script"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2007"
+          ],
+          "creatorLiteral": [
+            "Nichols, Dudley, 1895-1960"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "contributorLiteral": [
+            "Josephson, Matthew, 1899-1978",
+            "Twist, John, 1898-1976",
+            "Sayre, Joel, 1900-1979"
+          ],
+          "idOclc": [
+            "ssj0001177068"
+          ],
+          "uniformTitle": [
+            "Toast of New York (1937 : Online)"
+          ],
+          "seriesUniformTitle": [
+            "American film scripts online."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2007"
+          ],
+          "titleDisplay": [
+            "Toast of New York (1937) [electronic resource] : shooting script / story by Matthew Josephson ; screenplay by Dudley Nichols, John Twist and Joel Sayre."
+          ],
+          "uri": "b20569949",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null
+          ],
+          "electronicResources": [
+            {
+              "label": "Available onsite at NYPL",
+              "url": "http://WU9FB9WH4A.search.serialssolutions.com/?V=1.0&L=WU9FB9WH4A&S=JCs&C=TC0001177068&T=marc&tab=BOOKS"
+            }
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Alexandria, VA"
+          ],
+          "series": [
+            "American film scripts online"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "American film scripts online||American film scripts online"
+          ]
+        },
+        "sort": [
+          629.2938,
+          "b20569949"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b22202337",
+        "_score": 608.1697,
+        "_source": {
+          "extent": [
+            "xiii, 218 p. : col. ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Fairfax Books"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            2012
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFE 15-2837"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2012
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 15-2837"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22202337"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781742379418"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1742379419"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "809151984"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)809151984"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779517482922,
+          "publicationStatement": [
+            "Crows Nest, N.S.W. : Fairfax Books, 2012."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFE 15-2837",
+            "urn:bnum:22202337",
+            "urn:isbn:9781742379418",
+            "urn:isbn:1742379419",
+            "urn:oclc:809151984",
+            "urn:identifier:(OCoLC)809151984"
+          ],
+          "creators_displayPacked": [
+            "Gibbs, Kate||Gibbs, Kate"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2013",
+                "gte": "2012"
+              },
+              "raw": "120521s2012    xnaa   e      001 0 eng  camMa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Cooking."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "TX714 .G53155 2012"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "xiii, 218 p. : col. ill. ; 24 cm"
+          ],
+          "tableOfContents": [
+            "To start -- Breakfast -- Snacks -- Lunch -- Dinner -- Dessert -- Parties & friends."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Cooking"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "After toast : recipes for aspiring cooks"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2012"
+          ],
+          "creatorLiteral": [
+            "Gibbs, Kate"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "809151984"
+          ],
+          "summary": [
+            "A lot of good things start out with a piece of toast. Breakfast, for one. But toast is also the entree into the kitchen for many of us. It's the dish we first learn not to burn, or what we make when there is nobody around to cook for us. It's a reliable culinary introduction. But what comes next? After Toast takes aspiring cooks into the kitchen fray. Kate Gibbs, whose grandmother Margaret Fulton had her making pizza from scratch before she could see over the kitchen bench, shows young adults what to eat and how to cook. Distilling culinary advice from her own upbringing, Kate offers must-know tricks for the new-to-cooking, modernises classics and inspires an interest in healthy cooking. Basically, this is a guide to real, really awesome, food. Recipes for crunchy, fried Mozzarella-stuffed croquettes, French roast chicken, mini Cheeseburgers and proper salads meet ideas for sprawling weekend feasts. This book raises the bar for the packed lunch, serves up new ideas on snacks, shows teens and twenty-somethings what to cook for mates or Mum, and puts an end to endless fridge searches by answering the perpetual question, 'What can I eat?'",
+            "Cooking for Beginners."
+          ],
+          "genreForm": [
+            "Cookbooks."
+          ],
+          "idIsbn": [
+            "9781742379418",
+            "1742379419"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2012"
+          ],
+          "titleDisplay": [
+            "After toast : recipes for aspiring cooks / Kate Gibbs."
+          ],
+          "uri": "b22202337",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Crows Nest, N.S.W."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm"
+          ],
+          "idIsbn_clean": [
+            "9781742379418",
+            "1742379419"
+          ]
+        },
+        "sort": [
+          608.1697,
+          "b22202337"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b22202337",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFE 15-2837",
+                      "urn:barcode:33433114669116"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 15-2837",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433114669116",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433114669116"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "physicalLocation": [
+                      "JFE 15-2837"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFE 15-2837"
+                    ],
+                    "shelfMark_sort": "aJFE 15-002837",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i37923125"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b22904468",
+        "_score": 608.1697,
+        "_source": {
+          "extent": [
+            "189 pages : color illustrations ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Bloomsbury Publishing"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            2022
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 22-2706"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2022
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 22-2706"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22904468"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781639730711"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1639730710"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781526654236"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1526654237"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1348882624"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1295805556 (OCoLC)1296085459 (OCoLC)1296118057"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1348882624"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779525127537,
+          "publicationStatement": [
+            "New York : Bloomsbury Publishing, 2022.",
+            "©2022"
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 22-2706",
+            "urn:bnum:22904468",
+            "urn:isbn:9781639730711",
+            "urn:isbn:1639730710",
+            "urn:isbn:9781526654236",
+            "urn:isbn:1526654237",
+            "urn:oclc:1348882624",
+            "urn:identifier:(OCoLC)1295805556 (OCoLC)1296085459 (OCoLC)1296118057",
+            "urn:identifier:(OCoLC)1348882624"
+          ],
+          "creators_displayPacked": [
+            "Leith, Prue||Leith, Prue, author"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2023",
+                "gte": "2022"
+              },
+              "raw": "221026s2022    nyua          001 0 eng dcam i ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Toast (Bread)",
+            "Cooking (Bread)"
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "TX769 .L39 2022"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "189 pages : color illustrations ; 22 cm"
+          ],
+          "tableOfContents": [
+            "Introduction -- Cheese & eggs -- Vegetarian & vegan -- Fish -- Meat & poultry -- Desserts -- Keen cooks."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Toast (Bread)",
+            "Cooking (Bread)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Bliss on toast : 75 simple recipes"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2022"
+          ],
+          "creatorLiteral": [
+            "Leith, Prue"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "1348882624"
+          ],
+          "summary": [
+            "\"Prue Leith toasts sourdoughs, focaccias, baguettes, flatbreads and more, then pairs them with everything from seasonal vegetables to meat and fish. The collection spans healthy, hearty, salty, and sometimes sweet. Ideal for a busy home cook who loves a full and balanced plate, the recipes are incredibly versatile and perfect for any time of the day: tomatoes, shallots, and oregano on black olive toast; grilled chicken tikka with yogurt on naan; smoked salmon, wasabi, and avocado on multigrain bread; and bananas and ice cream with brandy syrup on panettone\"--"
+          ],
+          "genreForm": [
+            "Cookbooks.",
+            "Recipes."
+          ],
+          "idIsbn": [
+            "9781639730711",
+            "1639730710",
+            "9781526654236",
+            "1526654237"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2022"
+          ],
+          "titleDisplay": [
+            "Bliss on toast : 75 simple recipes / Prue Leith."
+          ],
+          "uri": "b22904468",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm"
+          ],
+          "idIsbn_clean": [
+            "9781639730711",
+            "1639730710",
+            "9781526654236",
+            "1526654237"
+          ]
+        },
+        "sort": [
+          608.1697,
+          "b22904468"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b22904468",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 22-2706",
+                      "urn:barcode:33433135837288"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFD 22-2706",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433135837288",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433135837288"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "physicalLocation": [
+                      "JFD 22-2706"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFD 22-2706"
+                    ],
+                    "shelfMark_sort": "aJFD 22-002706",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i39826201"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "cb11446537",
+        "_score": 597.81696,
+        "_source": {
+          "extent": [
+            "viii, 82 pages ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "editionStatement": [
+            "First edition."
+          ],
+          "publisherLiteral": [
+            "Oxford University Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2014
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "2014355883"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2014
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "11446537"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780198098607 (pbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "019809860X (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocn869791542"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "869791542"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-5805984"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2014355883"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocn869791542"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)869791542"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)11446537"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "11446537"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779332358767,
+          "publicationStatement": [
+            "New Delhi : Oxford University Press, 2014."
+          ],
+          "identifier": [
+            "urn:bnum:11446537",
+            "urn:isbn:9780198098607 (pbk.)",
+            "urn:isbn:019809860X (pbk.)",
+            "urn:oclc:ocn869791542",
+            "urn:oclc:869791542",
+            "urn:oclc:SCSB-5805984",
+            "urn:lccn:2014355883",
+            "urn:identifier:(OCoLC)ocn869791542",
+            "urn:identifier:(OCoLC)869791542",
+            "urn:identifier:(NNC)11446537",
+            "urn:identifier:11446537"
+          ],
+          "creators_displayPacked": [
+            "Karnad, Girish Raghunath, 1938-||Karnad, Girish Raghunath, 1938-, author"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2015",
+                "gte": "2014"
+              },
+              "raw": "140123s2014    ii            000 d eng d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Bangalore (India) -- Drama."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PL4659.K325 B65 2014"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "titleAlt": [
+            "Benda kạḷu ān ṭōsṭ."
+          ],
+          "physicalDescription": [
+            "viii, 82 pages ; 22 cm"
+          ],
+          "subjectLiteral_exploded": [
+            "Bangalore (India)",
+            "Bangalore (India) -- Drama"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Boiled beans on toast : a play"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2014"
+          ],
+          "creatorLiteral": [
+            "Karnad, Girish Raghunath, 1938-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocn869791542",
+            "869791542",
+            "SCSB-5805984"
+          ],
+          "uniformTitle": [
+            "Benda kạḷu ān ṭōsṭ. English"
+          ],
+          "genreForm": [
+            "Drama."
+          ],
+          "idIsbn": [
+            "9780198098607 (pbk.)",
+            "019809860X (pbk.)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2014"
+          ],
+          "titleDisplay": [
+            "Boiled beans on toast : a play / Girish Karnad."
+          ],
+          "uri": "cb11446537",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm"
+          ],
+          "idIsbn_clean": [
+            "9780198098607",
+            "019809860X"
+          ]
+        },
+        "sort": [
+          597.81696,
+          "cb11446537"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb11446537",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PL4659.K33 B4613 2014g",
+                      "urn:barcode:CU24576484"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PL4659.K33 B4613 2014g",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "CU24576484",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU24576484"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "PL4659.K33 B4613 2014g"
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PL4659.K33 B4613 2014g"
+                    ],
+                    "shelfMark_sort": "aPL4659.K33 B4613 2014g",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci8752018"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "cb13686426",
+        "_score": 594.5491,
+        "_source": {
+          "extent": [
+            "volume : color illustrations ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "publisherLiteral": [
+            "Éditions Coiffard"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2018
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2018
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "13686426"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9782919339556 (paperback : v. 1)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1087129277"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "on1087129277"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-9262298"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1087129277"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)on1087129277"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(Fr-PaAMA)AAL0797185-0001"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)13686426"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "13686426"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779396564986,
+          "publicationStatement": [
+            "[Nantes] : Éditions Coiffard, [2018-]"
+          ],
+          "identifier": [
+            "urn:bnum:13686426",
+            "urn:isbn:9782919339556 (paperback : v. 1)",
+            "urn:oclc:1087129277",
+            "urn:oclc:on1087129277",
+            "urn:oclc:SCSB-9262298",
+            "urn:identifier:(OCoLC)1087129277",
+            "urn:identifier:(OCoLC)on1087129277",
+            "urn:identifier:(Fr-PaAMA)AAL0797185-0001",
+            "urn:identifier:(NNC)13686426",
+            "urn:identifier:13686426"
+          ],
+          "creators_displayPacked": [
+            "Buachidze, G. S.||Buachidze, G. S., author"
+          ],
+          "dates": [
+            {
+              "range": {
+                "gte": "2018",
+                "lte": "9999"
+              },
+              "raw": "181112m20189999fr a          000 0 fre d",
+              "tag": "m"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Pʻirosmanašvili, Niko, 1862?-1918 -- Criticism and interpretation.",
+            "Painting, Georgian (South Caucasian) -- 19th century -- History and criticism.",
+            "Painting, Georgian (South Caucasian) -- 20th century -- History and criticism."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "ND992.9 .B83 2018"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "volume : color illustrations ; 24 cm"
+          ],
+          "tableOfContents": [
+            "Voume 1 : Pirosmani, ou, La promenade du cerf"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes glossary.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Pʻirosmanašvili, Niko, 1862?-1918",
+            "Pʻirosmanašvili, Niko, 1862?-1918 -- Criticism and interpretation",
+            "Painting, Georgian (South Caucasian)",
+            "Painting, Georgian (South Caucasian) -- 19th century",
+            "Painting, Georgian (South Caucasian) -- 19th century -- History and criticism",
+            "Painting, Georgian (South Caucasian) -- 20th century",
+            "Painting, Georgian (South Caucasian) -- 20th century -- History and criticism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "title": [
+            "Toast au poisson : récits de la peinture géorgienne"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "2018"
+          ],
+          "creatorLiteral": [
+            "Buachidze, G. S."
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "1087129277",
+            "on1087129277",
+            "SCSB-9262298"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "idIsbn": [
+            "9782919339556 (paperback : v. 1)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2018"
+          ],
+          "titleDisplay": [
+            "Toast au poisson : récits de la peinture géorgienne / Gaston Bouatchidzé."
+          ],
+          "uri": "cb13686426",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "[Nantes]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm"
+          ],
+          "idIsbn_clean": [
+            "97829193395561"
+          ]
+        },
+        "sort": [
+          594.5491,
+          "cb13686426"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb13686426",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "enumerationChronology_sort": "         1-",
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:ND992.9 .B83 2018g",
+                      "urn:barcode:AR02401576"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "ND992.9 .B83 2018g",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "AR02401576",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "AR02401576"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "ND992.9 .B83 2018g"
+                    ],
+                    "recapCustomerCode": [
+                      "AR"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "ND992.9 .B83 2018g"
+                    ],
+                    "shelfMark_sort": "aND992.9 .B83 2018g",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci9545552",
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b16478384",
+        "_score": 580.2938,
+        "_source": {
+          "extent": [
+            "xi, 353 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "John Murray"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            2006
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 07-1588"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2006
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 07-1588"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16478384"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0719561264 (hbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780719561269 (hbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "64313449"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)64313449"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M060000409"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Games, Stephen||Games, Stephen"
+          ],
+          "updatedAt": 1779437419032,
+          "publicationStatement": [
+            "London : John Murray, 2006."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 07-1588",
+            "urn:bnum:16478384",
+            "urn:isbn:0719561264 (hbk.)",
+            "urn:isbn:9780719561269 (hbk.)",
+            "urn:oclc:64313449",
+            "urn:identifier:(OCoLC)64313449",
+            "urn:identifier:(WaOLN)M060000409"
+          ],
+          "creators_displayPacked": [
+            "Betjeman, John, 1906-1984||Betjeman, John, 1906-1984"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2007",
+                "gte": "2006"
+              },
+              "raw": "051207s2006    enk           001 0 eng  cam a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Radio programs -- Great Britain."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PN1991.3.G7 B4 2006"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "xi, 353 p. ; 23 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Radio programs",
+            "Radio programs -- Great Britain"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Trains and buttered toast : selected radio talks"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2006"
+          ],
+          "creatorLiteral": [
+            "Betjeman, John, 1906-1984"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Games, Stephen"
+          ],
+          "idOclc": [
+            "64313449"
+          ],
+          "idIsbn": [
+            "0719561264 (hbk.)",
+            "9780719561269 (hbk.)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2006"
+          ],
+          "titleDisplay": [
+            "Trains and buttered toast : selected radio talks / John Betjeman ; edited and introduced by Stephen Games."
+          ],
+          "uri": "b16478384",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ],
+          "idIsbn_clean": [
+            "0719561264",
+            "9780719561269"
+          ]
+        },
+        "sort": [
+          580.2938,
+          "b16478384"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16478384",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 07-1588",
+                      "urn:barcode:33433076591738"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFD 07-1588",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433076591738",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433076591738"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "physicalLocation": [
+                      "JFD 07-1588"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFD 07-1588"
+                    ],
+                    "shelfMark_sort": "aJFD 07-001588",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17277151"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b19838551",
+        "_score": 580.2938,
+        "_source": {
+          "extent": [
+            "112 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Kraft Books"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "sc"
+          ],
+          "createdYear": [
+            2006
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "Sc D 13-1045 no. 1"
+          ],
+          "idLccn": [
+            "2008435857"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2006
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 13-1045 no. 1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "19838551"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780391738"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9789780391737"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "277051218"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2008435857"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)277051218"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779492079967,
+          "publicationStatement": [
+            "Ibadan, Oyo State, Nigeria : Kraft Books, 2006."
+          ],
+          "identifier": [
+            "urn:shelfmark:Sc D 13-1045 no. 1",
+            "urn:bnum:19838551",
+            "urn:isbn:9780391738",
+            "urn:isbn:9789780391737",
+            "urn:oclc:277051218",
+            "urn:lccn:2008435857",
+            "urn:identifier:(OCoLC)277051218"
+          ],
+          "creators_displayPacked": [
+            "Gimba, Abubakar||Gimba, Abubakar"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2007",
+                "gte": "2006"
+              },
+              "raw": "081027s2006    nr            000 j eng dcam a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Short stories, Nigerian (English)",
+            "Nigerians -- Conduct of life -- Fiction.",
+            "Nigeria -- Social conditions -- Fiction."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PR9387.9.G55 T63 2006"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "scf"
+          ],
+          "physicalDescription": [
+            "112 p. ; 22 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Kraftgriots.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"First published 2006\"--T.p. verso.",
+              "type": "bf:Note"
+            }
+          ],
+          "seriesUniformTitle_displayPacked": [
+            "Short stories (Ibadan, Nigeria)||Short stories (Ibadan, Nigeria)"
+          ],
+          "subjectLiteral_exploded": [
+            "Short stories, Nigerian (English)",
+            "Nigerians",
+            "Nigerians -- Conduct of life",
+            "Nigerians -- Conduct of life -- Fiction",
+            "Nigeria",
+            "Nigeria -- Social conditions",
+            "Nigeria -- Social conditions -- Fiction"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "A toast in the cemetery : short stories"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "2006"
+          ],
+          "creatorLiteral": [
+            "Gimba, Abubakar"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "277051218"
+          ],
+          "popularity": 1,
+          "seriesUniformTitle": [
+            "Short stories (Ibadan, Nigeria)"
+          ],
+          "genreForm": [
+            "Nigerian fiction (English)"
+          ],
+          "idIsbn": [
+            "9780391738",
+            "9789780391737"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2006"
+          ],
+          "titleDisplay": [
+            "A toast in the cemetery : short stories / Abubakar Gimba."
+          ],
+          "uri": "b19838551",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Ibadan, Oyo State, Nigeria"
+          ],
+          "series": [
+            "Short stories"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Short stories||Short stories"
+          ],
+          "dimensions": [
+            "22 cm."
+          ],
+          "idIsbn_clean": [
+            "9780391738",
+            "9789780391737"
+          ]
+        },
+        "sort": [
+          580.2938,
+          "b19838551"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b19838551",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:61",
+                        "label": "pamphlet volumes, bound with"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:61||pamphlet volumes, bound with"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-4"
+                    ],
+                    "enumerationChronology_sort": "         1-",
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc D 13-1045",
+                      "urn:barcode:33433073344230"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 13-1045",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433073344230",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433073344230"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "physicalLocation": [
+                      "Sc D 13-1045"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "Sc D 13-1045"
+                    ],
+                    "shelfMark_sort": "aSc D 13-001045",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i30498572",
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 4
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b18036289",
+        "_score": 579.2938,
+        "_source": {
+          "extent": [
+            "1 score (14 p.) + 2 parts : port. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "T. Presser"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2005
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JNG 09-190"
+          ],
+          "idLccn": [
+            "2005562075",
+            "680160018024"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2005
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNG 09-190"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "18036289"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "62276021"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2005562075"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "680160018024"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "114-41247 T. Presser"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)62276021"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779479969661,
+          "publicationStatement": [
+            "King of Prussia, PA : T. Presser, c2005."
+          ],
+          "identifier": [
+            "urn:shelfmark:JNG 09-190",
+            "urn:bnum:18036289",
+            "urn:oclc:62276021",
+            "urn:lccn:2005562075",
+            "urn:lccn:680160018024",
+            "urn:identifier:114-41247 T. Presser",
+            "urn:identifier:(OCoLC)62276021"
+          ],
+          "creators_displayPacked": [
+            "Schocker, Gary, 1959-||Schocker, Gary, 1959-"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2006",
+                "gte": "2005"
+              },
+              "raw": "051222s2005    pauuua   e     n    zxx dccm a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Trios (Piano, flutes (2)) -- Scores and parts."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "M317.S35 F74 2005"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "c",
+          "collectionIds": [
+            "pam"
+          ],
+          "physicalDescription": [
+            "1 score (14 p.) + 2 parts : port. ; 31 cm."
+          ],
+          "tableOfContents": [
+            "Deux moutons -- Les bouffons -- L'amour perdu -- Le printemps -- Le ballet russe."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Biographical notes, p. [4] of cover.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 8:30.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "At end: September 29, 2003.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Trios (Piano, flutes (2))",
+            "Trios (Piano, flutes (2)) -- Scores and parts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "French toast : for two flutes and piano"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2005"
+          ],
+          "creatorLiteral": [
+            "Schocker, Gary, 1959-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "62276021"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2005"
+          ],
+          "titleDisplay": [
+            "French toast : for two flutes and piano / Gary Schocker."
+          ],
+          "uri": "b18036289",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "King of Prussia, PA"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          579.2938,
+          "b18036289"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b18036289",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:57",
+                        "label": "printed music limited circ MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:57||printed music limited circ MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JNG 09-190",
+                      "urn:barcode:33433083720965"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JNG 09-190",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433083720965",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433083720965"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "physicalLocation": [
+                      "JNG 09-190"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JNG 09-190"
+                    ],
+                    "shelfMark_sort": "aJNG 09-000190",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i23188106"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "hb990092192200203941",
+        "_score": 571.3231,
+        "_source": {
+          "extent": [
+            "247 p. ;"
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "publisherLiteral": [
+            "Fourth Estate"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2003
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "^^2005533920"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2003
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990092192200203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1841152897"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "52396085"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-12424988"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "^^2005533920"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(MH)009219220HVD01-Aleph"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)52396085"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779597479953,
+          "publicationStatement": [
+            "London ; New York : Fourth Estate, 2003."
+          ],
+          "identifier": [
+            "urn:bnum:990092192200203941",
+            "urn:isbn:1841152897",
+            "urn:oclc:52396085",
+            "urn:oclc:SCSB-12424988",
+            "urn:lccn:^^2005533920",
+            "urn:identifier:(MH)009219220HVD01-Aleph",
+            "urn:identifier:(OCoLC)52396085"
+          ],
+          "creators_displayPacked": [
+            "Slater, Nigel||Slater, Nigel"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2004",
+                "gte": "2003"
+              },
+              "raw": "030609s2003    enk           000 0aeng  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Slater, Nigel -- Childhood and youth.",
+            "Food habits -- England -- History -- 20th century."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "TX357 .S53 2003"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "titleAlt": [
+            "Story of a boy's hunger"
+          ],
+          "physicalDescription": [
+            "247 p. ; 20 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain 20181001 in perpetuity ReCAP Shared Collection HUL 222073168680003941",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Slater, Nigel",
+            "Slater, Nigel -- Childhood and youth",
+            "Food habits",
+            "Food habits -- England",
+            "Food habits -- England -- History",
+            "Food habits -- England -- History -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Toast : the story of a boy's hunger / Nigel Slater."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2003"
+          ],
+          "creatorLiteral": [
+            "Slater, Nigel"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "52396085",
+            "SCSB-12424988"
+          ],
+          "idIsbn": [
+            "1841152897"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2003"
+          ],
+          "titleDisplay": [
+            "Toast : the story of a boy's hunger / Nigel Slater."
+          ],
+          "uri": "hb990092192200203941",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London ; New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ],
+          "idIsbn_clean": [
+            "1841152897"
+          ]
+        },
+        "sort": [
+          571.3231,
+          "hb990092192200203941"
+        ],
+        "matched_queries": [
+          "prefix title.keywordLowercasedStripped",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "hb990092192200203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:TX649.S5 A3 2003 copy ",
+                      "urn:barcode:HXSKRU"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TX649.S5 A3 2003 copy ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "HXSKRU",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "HXSKRU"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "physicalLocation": [
+                      "TX649.S5 A3 2003"
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "TX649.S5 A3 2003 copy "
+                    ],
+                    "shelfMark_sort": "aTX649.S5 A3 2003 copy ",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "hi232073168660003941"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "cb5358913",
+        "_score": 569.94104,
+        "_source": {
+          "extent": [
+            "80 pages ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "publisherLiteral": [
+            "Bloodaxe"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2005
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2005
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "5358913"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1852246774 (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm57065346"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-5192151"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm57065346"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)5358913"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "5358913"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779556066541,
+          "publicationStatement": [
+            "Tarset : Bloodaxe, 2005."
+          ],
+          "identifier": [
+            "urn:bnum:5358913",
+            "urn:isbn:1852246774 (pbk.)",
+            "urn:oclc:ocm57065346",
+            "urn:oclc:SCSB-5192151",
+            "urn:identifier:(OCoLC)ocm57065346",
+            "urn:identifier:(NNC)5358913",
+            "urn:identifier:5358913"
+          ],
+          "creators_displayPacked": [
+            "France, Linda, 1958-||France, Linda, 1958-"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2006",
+                "gte": "2005"
+              },
+              "raw": "040315s2005    enk    e      000 p eng  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "80 pages ; 22 cm"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "The toast of the Kit-Cat Club"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2005"
+          ],
+          "creatorLiteral": [
+            "France, Linda, 1958-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocm57065346",
+            "SCSB-5192151"
+          ],
+          "idIsbn": [
+            "1852246774 (pbk.)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2005"
+          ],
+          "titleDisplay": [
+            "The toast of the Kit-Cat Club / Linda France."
+          ],
+          "uri": "cb5358913",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Tarset"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm"
+          ],
+          "idIsbn_clean": [
+            "1852246774"
+          ]
+        },
+        "sort": [
+          569.94104,
+          "cb5358913"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb5358913",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR6056.R262 T63 2005g",
+                      "urn:barcode:CU71435093"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PR6056.R262 T63 2005g",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "CU71435093",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU71435093"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "PR6056.R262 T63 2005g"
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PR6056.R262 T63 2005g"
+                    ],
+                    "shelfMark_sort": "aPR6056.R262 T63 2005g",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci5619937"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "hb990074688990203941",
+        "_score": 569.94104,
+        "_source": {
+          "extent": [
+            "359 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "publisherLiteral": [
+            "Harper Collins"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1995
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "^^^96981253^"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1995
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990074688990203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1779040105"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "35948776"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "990074688990203941"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "^^^96981253^"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)35948776"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779591318478,
+          "publicationStatement": [
+            "Harare, Zimbabwe : Harper Collins, 1995."
+          ],
+          "identifier": [
+            "urn:bnum:990074688990203941",
+            "urn:isbn:1779040105",
+            "urn:oclc:35948776",
+            "urn:oclc:990074688990203941",
+            "urn:lccn:^^^96981253^",
+            "urn:identifier:(OCoLC)35948776"
+          ],
+          "creators_displayPacked": [
+            "Hill, Roland||Hill, Roland"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1996",
+                "gte": "1995"
+              },
+              "raw": "961114s1995    rh            000|0 eng  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "MLCS 96/01149 (P)"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "359 p. : ill. ; 18 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain 20181001 in perpetuity ReCAP Shared Collection HUL 222023010340003941",
+              "type": "bf:Note"
+            }
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Burnt toast on Sundays / Roland K. Hill."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1995"
+          ],
+          "creatorLiteral": [
+            "Hill, Roland"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "35948776",
+            "990074688990203941"
+          ],
+          "idIsbn": [
+            "1779040105"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1995"
+          ],
+          "titleDisplay": [
+            "Burnt toast on Sundays / Roland K. Hill."
+          ],
+          "uri": "hb990074688990203941",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Harare, Zimbabwe"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ],
+          "idIsbn_clean": [
+            "1779040105"
+          ]
+        },
+        "sort": [
+          569.94104,
+          "hb990074688990203941"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "hb990074688990203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:MLCS 96/01149 (P) copy ",
+                      "urn:barcode:HNGRR7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "MLCS 96/01149 (P) copy ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "HNGRR7",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "HNGRR7"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "physicalLocation": [
+                      "MLCS 96/01149 (P)"
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "MLCS 96/01149 (P) copy "
+                    ],
+                    "shelfMark_sort": "aMLCS 96/01149 (P) copy ",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "hi232023010330003941"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "hb990088521070203941",
+        "_score": 569.94104,
+        "_source": {
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "editionStatement": [
+            "1st ed."
+          ],
+          "publisherLiteral": [
+            "Heirloom Books"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2001
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2001
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990088521070203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0968979203"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "48230114"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-11966847"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)48230114"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779596232045,
+          "publicationStatement": [
+            "Sidney, B.C. : Heirloom Books, 2001."
+          ],
+          "identifier": [
+            "urn:bnum:990088521070203941",
+            "urn:isbn:0968979203",
+            "urn:oclc:48230114",
+            "urn:oclc:SCSB-11966847",
+            "urn:identifier:(OCoLC)48230114"
+          ],
+          "creators_displayPacked": [
+            "Schiller, Jeannette, 1911-||Schiller, Jeannette, 1911-"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2002",
+                "gte": "2001"
+              },
+              "raw": "020301s2001    bcc           000|0 eng d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Schiller, Jeannette, 1911-",
+            "Teachers -- Saskatchewan -- Biography.",
+            "Teachers -- British Columbia -- Biography."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "LA2325.S34 A3 2001"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain 20181001 in perpetuity ReCAP Shared Collection HUL 222074350610003941",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Schiller, Jeannette, 1911-",
+            "Teachers",
+            "Teachers -- Saskatchewan",
+            "Teachers -- Saskatchewan -- Biography",
+            "Teachers -- British Columbia",
+            "Teachers -- British Columbia -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "A toast to bygone days / Jeannette Schiller."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2001"
+          ],
+          "creatorLiteral": [
+            "Schiller, Jeannette, 1911-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "48230114",
+            "SCSB-11966847"
+          ],
+          "idIsbn": [
+            "0968979203"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2001"
+          ],
+          "titleDisplay": [
+            "A toast to bygone days / Jeannette Schiller."
+          ],
+          "uri": "hb990088521070203941",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Sidney, B.C."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "0968979203"
+          ]
+        },
+        "sort": [
+          569.94104,
+          "hb990088521070203941"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "hb990088521070203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:LA2325.S34 A3 2001 copy ",
+                      "urn:barcode:HXL53Z"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "LA2325.S34 A3 2001 copy ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "HXL53Z",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "HXL53Z"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "physicalLocation": [
+                      "LA2325.S34 A3 2001"
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "LA2325.S34 A3 2001 copy "
+                    ],
+                    "shelfMark_sort": "aLA2325.S34 A3 2001 copy ",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "hi232074350580003941"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "hb990094315110203941",
+        "_score": 569.94104,
+        "_source": {
+          "extent": [
+            "271 p. ;"
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "editionStatement": [
+            "1st ed."
+          ],
+          "publisherLiteral": [
+            "HarperCollins"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2004
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2004
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990094315110203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0002005840"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780002005845"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "55596486"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-10712614"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1060700968"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)55596486"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779598338026,
+          "publicationStatement": [
+            "Toronto : HarperCollins, c2004."
+          ],
+          "identifier": [
+            "urn:bnum:990094315110203941",
+            "urn:isbn:0002005840",
+            "urn:isbn:9780002005845",
+            "urn:oclc:55596486",
+            "urn:oclc:SCSB-10712614",
+            "urn:identifier:(OCoLC)1060700968",
+            "urn:identifier:(OCoLC)55596486"
+          ],
+          "creators_displayPacked": [
+            "Itani, Frances, 1942-||Itani, Frances, 1942-"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2005",
+                "gte": "2004"
+              },
+              "raw": "040526s2004    onc           000 j eng  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Short stories, Canadian."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PR9199.3.I83 P63 2004"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "271 p. ; 23 cm."
+          ],
+          "tableOfContents": [
+            "Clayton -- An August wind -- Megan -- Marx & Co. -- Pack ice -- P'tit village -- Truth or lies -- Separation -- An evening in the café -- Scenes from a pension -- Messages -- Accident -- Touches -- Foolery -- Earthman pointing -- The eyes have it -- Man without face -- Sarajevo -- In the name of love -- The thickness of one sheet of paper -- What we are capable of -- Poached egg on toast."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"A Phyllis Bruce book\".",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain 20181001 in perpetuity ReCAP Shared Collection HUL 222083339720003941",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Short stories, Canadian"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Poached egg on toast : stories / Frances Itani."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2004"
+          ],
+          "creatorLiteral": [
+            "Itani, Frances, 1942-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "55596486",
+            "SCSB-10712614"
+          ],
+          "summary": [
+            "A collection of stories representing the author's extensive writing career."
+          ],
+          "genreForm": [
+            "short stories.",
+            "Short stories",
+            "Nouvelles."
+          ],
+          "idIsbn": [
+            "0002005840",
+            "9780002005845"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2004"
+          ],
+          "titleDisplay": [
+            "Poached egg on toast : stories / Frances Itani."
+          ],
+          "uri": "hb990094315110203941",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Toronto"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ],
+          "idIsbn_clean": [
+            "0002005840",
+            "9780002005845"
+          ]
+        },
+        "sort": [
+          569.94104,
+          "hb990094315110203941"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "hb990094315110203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PR9199.3.I83 P63 2004 copy ",
+                      "urn:barcode:32044105914865"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PR9199.3.I83 P63 2004 copy ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32044105914865",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32044105914865"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "physicalLocation": [
+                      "PR9199.3.I83 P63 2004"
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PR9199.3.I83 P63 2004 copy "
+                    ],
+                    "shelfMark_sort": "aPR9199.3.I83 P63 2004 copy ",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "hi232083339710003941"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "hb990117890200203941",
+        "_score": 569.94104,
+        "_source": {
+          "extent": [
+            "62 p. ;"
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "publisherLiteral": [
+            "Samuel French"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            2008
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2008
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990117890200203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780573663772"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0573663777"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "259742094"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "990117890200203941"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)259742094"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779602923730,
+          "publicationStatement": [
+            "New York, NY : Samuel French, c2008."
+          ],
+          "identifier": [
+            "urn:bnum:990117890200203941",
+            "urn:isbn:9780573663772",
+            "urn:isbn:0573663777",
+            "urn:oclc:259742094",
+            "urn:oclc:990117890200203941",
+            "urn:identifier:(OCoLC)259742094"
+          ],
+          "creators_displayPacked": [
+            "Kaminsky, Stuart M.||Kaminsky, Stuart M."
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2009",
+                "gte": "2008"
+              },
+              "raw": "081001s2008    nyu           000 d eng d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Holmes, Sherlock (Fictitious character) -- Drama.",
+            "Holmes, Sherlock -- Drama.",
+            "Watson, John H. (Fictitious character) -- Drama.",
+            "Chaplin, Charlie, 1889-1977 -- Drama.",
+            "London (England) -- Drama."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PS3561.A43 F497 2008"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "62 p. ; 21 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain 20181001 in perpetuity ReCAP Shared Collection HUL 222119612490003941",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Holmes, Sherlock (Fictitious character)",
+            "Holmes, Sherlock (Fictitious character) -- Drama",
+            "Holmes, Sherlock",
+            "Holmes, Sherlock -- Drama",
+            "Watson, John H. (Fictitious character)",
+            "Watson, John H. (Fictitious character) -- Drama",
+            "Chaplin, Charlie, 1889-1977",
+            "Chaplin, Charlie, 1889-1977 -- Drama",
+            "London (England)",
+            "London (England) -- Drama"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "The final toast / by Stuart M. Kaminsky."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2008"
+          ],
+          "creatorLiteral": [
+            "Kaminsky, Stuart M."
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "259742094",
+            "990117890200203941"
+          ],
+          "summary": [
+            "\"The Edgar Prize-winning author Kaminsky tells the tale of one of literature's most famous detectives: Sherlock Holmes. In a witty, imaginative story filled with twists and unexpected surprises, Detective Holmes unravels a murder only to find himself the unwilling target of the killer-at-large. Along with the aid of his loyal and inquisitive companion, Dr. Watson, Sherlock Holmes uses his masterful power of deduction to make a nebulous situation seem \"simply elementary.\" The Final Toast is an exciting new take on the classic characters of fiction we know and love, and its ending will please even the most savvy mystery connoisseurs\"--Publisher's website."
+          ],
+          "genreForm": [
+            "Drama"
+          ],
+          "idIsbn": [
+            "9780573663772",
+            "0573663777"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2008"
+          ],
+          "titleDisplay": [
+            "The final toast / by Stuart M. Kaminsky."
+          ],
+          "uri": "hb990117890200203941",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York, NY"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ],
+          "idIsbn_clean": [
+            "9780573663772",
+            "0573663777"
+          ]
+        },
+        "sort": [
+          569.94104,
+          "hb990117890200203941"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "hb990117890200203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PS3561.A43 F56 2008 copy ",
+                      "urn:barcode:32044108950577"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PS3561.A43 F56 2008 copy ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32044108950577",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32044108950577"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "physicalLocation": [
+                      "PS3561.A43 F56 2008"
+                    ],
+                    "recapCustomerCode": [
+                      "HW"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PS3561.A43 F56 2008 copy "
+                    ],
+                    "shelfMark_sort": "aPS3561.A43 F56 2008 copy ",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "hi232119612460003941"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb2139151",
+        "_score": 569.94104,
+        "_source": {
+          "extent": [
+            "ix, 226 p. : ill., ports. ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "publisherLiteral": [
+            "André Deutsch"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1997
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1997
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "2139151"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm41333062"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-506538"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm41333062"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779507859772,
+          "publicationStatement": [
+            "London : André Deutsch, 1997."
+          ],
+          "identifier": [
+            "urn:bnum:2139151",
+            "urn:oclc:ocm41333062",
+            "urn:oclc:SCSB-506538",
+            "urn:identifier:(OCoLC)ocm41333062"
+          ],
+          "creators_displayPacked": [
+            "Booth, John||Booth, John"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1998",
+                "gte": "1997"
+              },
+              "raw": "990510s1997    enka          000 0 eng d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Drinking in literature -- Collections.",
+            "Drinking -- Literary collections."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "ix, 226 p. : ill., ports. ; 25 cm."
+          ],
+          "subjectLiteral_exploded": [
+            "Drinking in literature",
+            "Drinking in literature -- Collections",
+            "Drinking",
+            "Drinking -- Literary collections"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Creative spirits : a toast to literary drinkers"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1997"
+          ],
+          "creatorLiteral": [
+            "Booth, John"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocm41333062",
+            "SCSB-506538"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1997"
+          ],
+          "titleDisplay": [
+            "Creative spirits : a toast to literary drinkers / John Booth."
+          ],
+          "uri": "pb2139151",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          569.94104,
+          "pb2139151"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb2139151",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PN56.D8B6 1997",
+                      "urn:barcode:32101085641676"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PN56.D8B6 1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101085641676",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101085641676"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PN56.D8B6 1997"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PN56.D8B6 1997"
+                    ],
+                    "shelfMark_sort": "aPN56.D8B6 001997",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi2301446"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb9911624953506421",
+        "_score": 569.94104,
+        "_source": {
+          "extent": [
+            "1 score (9 pages) ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "publisherLiteral": [
+            "AdLar Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1994
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "M706002064"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1994
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9911624953506421"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocn666197888"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "666197888"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-2121535"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "M706002064"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(CStRLIN)NJPG97-C408"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)1162495-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)37469199"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocn666197888"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager1162495"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)666197888"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Bertolino, James, 1942-||Bertolino, James, 1942-"
+          ],
+          "updatedAt": 1779613258235,
+          "publicationStatement": [
+            "Victoria, B.C. : AdLar Publications, ©1994."
+          ],
+          "identifier": [
+            "urn:bnum:9911624953506421",
+            "urn:oclc:ocn666197888",
+            "urn:oclc:666197888",
+            "urn:oclc:SCSB-2121535",
+            "urn:lccn:M706002064",
+            "urn:identifier:(CStRLIN)NJPG97-C408",
+            "urn:identifier:(NjP)1162495-princetondb",
+            "urn:identifier:(OCoLC)37469199",
+            "urn:identifier:(OCoLC)ocn666197888",
+            "urn:identifier:(NjP)Voyager1162495",
+            "urn:identifier:(OCoLC)666197888"
+          ],
+          "creators_displayPacked": [
+            "Adaskin, Murray, 1906-2002||Adaskin, Murray, 1906-2002"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1995",
+                "gte": "1994"
+              },
+              "raw": "950914s1994    bccsga         n    eng d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Songs (High voice) with instrumental ensemble -- Scores.",
+            "Bertolino, James, 1942- -- Musical settings."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "M1613.3.A32 W4 1994"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "c",
+          "collectionIds": [],
+          "titleAlt": [
+            "Wedding toast;"
+          ],
+          "physicalDescription": [
+            "1 score (9 pages) ; 28 cm"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Originally for soprano and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 3:30.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Songs (High voice) with instrumental ensemble",
+            "Songs (High voice) with instrumental ensemble -- Scores",
+            "Bertolino, James, 1942-",
+            "Bertolino, James, 1942- -- Musical settings"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "A wedding toast : for soprano & string quartet"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1994"
+          ],
+          "creatorLiteral": [
+            "Adaskin, Murray, 1906-2002"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Bertolino, James, 1942-"
+          ],
+          "idOclc": [
+            "ocn666197888",
+            "666197888",
+            "SCSB-2121535"
+          ],
+          "uniformTitle": [
+            "Wedding toast; arranged"
+          ],
+          "genreForm": [
+            "Scores.",
+            "Musical settings.",
+            "Partitions (Musique)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1994"
+          ],
+          "titleDisplay": [
+            "A wedding toast : for soprano & string quartet / [music by] Murray Adaskin ; poem by James Bertolino."
+          ],
+          "uri": "pb9911624953506421",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "Victoria, B.C."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm"
+          ]
+        },
+        "sort": [
+          569.94104,
+          "pb9911624953506421"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb9911624953506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:M1613.3.A32 W4 1994q Oversize",
+                      "urn:barcode:32101069496063"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M1613.3.A32 W4 1994q Oversize",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101069496063",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101069496063"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "M1613.3.A32 W4 1994q Oversize"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "M1613.3.A32 W4 1994q Oversize"
+                    ],
+                    "shelfMark_sort": "aM1613.3.A32 W4 1994q Oversize",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi23608241160006421"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb9921391513506421",
+        "_score": 569.94104,
+        "_source": {
+          "extent": [
+            "ix, 226 pages : illustrations, portraits ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "publisherLiteral": [
+            "André Deutsch"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1997
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1997
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "9921391513506421"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0233991840"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780233991849"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm41333062"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "41333062"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-506538"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)2139151-princetondb"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm41333062"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NjP)Voyager2139151"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)41333062"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779618785782,
+          "publicationStatement": [
+            "London : André Deutsch, 1997."
+          ],
+          "identifier": [
+            "urn:bnum:9921391513506421",
+            "urn:isbn:0233991840",
+            "urn:isbn:9780233991849",
+            "urn:oclc:ocm41333062",
+            "urn:oclc:41333062",
+            "urn:oclc:SCSB-506538",
+            "urn:identifier:(NjP)2139151-princetondb",
+            "urn:identifier:(OCoLC)ocm41333062",
+            "urn:identifier:(NjP)Voyager2139151",
+            "urn:identifier:(OCoLC)41333062"
+          ],
+          "creators_displayPacked": [
+            "Booth, John||Booth, John"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1998",
+                "gte": "1997"
+              },
+              "raw": "990510s1997    enkac         000 0 eng d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Drinking in literature.",
+            "Drinking -- Literary collections."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PN56.D8 B6 1997x"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "ix, 226 pages : illustrations, portraits ; 25 cm"
+          ],
+          "subjectLiteral_exploded": [
+            "Drinking in literature",
+            "Drinking",
+            "Drinking -- Literary collections"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Creative spirits : a toast to literary drinkers"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1997"
+          ],
+          "creatorLiteral": [
+            "Booth, John"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocm41333062",
+            "41333062",
+            "SCSB-506538"
+          ],
+          "genreForm": [
+            "Literary collections."
+          ],
+          "idIsbn": [
+            "0233991840",
+            "9780233991849"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1997"
+          ],
+          "titleDisplay": [
+            "Creative spirits : a toast to literary drinkers / John Booth."
+          ],
+          "uri": "pb9921391513506421",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm"
+          ],
+          "idIsbn_clean": [
+            "0233991840",
+            "9780233991849"
+          ]
+        },
+        "sort": [
+          569.94104,
+          "pb9921391513506421"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb9921391513506421",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PN56.D8 B6 1997",
+                      "urn:barcode:32101085641676"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PN56.D8 B6 1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101085641676",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101085641676"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "PN56.D8 B6 1997"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PN56.D8 B6 1997"
+                    ],
+                    "shelfMark_sort": "aPN56.D8 B6 001997",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi23519521580006421"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b13555237",
+        "_score": 554.9018,
+        "_source": {
+          "extent": [
+            "257 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "editionStatement": [
+            "1st ed."
+          ],
+          "publisherLiteral": [
+            "Doubleday"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "sc",
+            "ma"
+          ],
+          "createdYear": [
+            1998
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFE 98-5504",
+            "Sc E 98-933"
+          ],
+          "idLccn": [
+            "97047429"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1998
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 98-5504"
+            },
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc E 98-933"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13555237"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0385485247"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "38081631"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "97047429"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3530217"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779394505199,
+          "publicationStatement": [
+            "New York : Doubleday, 1998."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFE 98-5504",
+            "urn:shelfmark:Sc E 98-933",
+            "urn:bnum:13555237",
+            "urn:isbn:0385485247",
+            "urn:oclc:38081631",
+            "urn:lccn:97047429",
+            "urn:identifier:(WaOLN)nyp3530217"
+          ],
+          "creators_displayPacked": [
+            "Edwards, Grace F. (Grace Frederica)||Edwards, Grace F. (Grace Frederica)"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1999",
+                "gte": "1998"
+              },
+              "raw": "971201s1998    nyu           000 1 eng  cam a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "African Americans -- New York (State) -- New York -- Fiction.",
+            "Harlem (New York, N.Y.) -- Fiction."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PS3555.D99 T63 1998"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "scf",
+            "mal"
+          ],
+          "physicalDescription": [
+            "257 p. ; 25 cm."
+          ],
+          "subjectLiteral_exploded": [
+            "African Americans",
+            "African Americans -- New York (State)",
+            "African Americans -- New York (State) -- New York",
+            "African Americans -- New York (State) -- New York -- Fiction",
+            "Harlem (New York, N.Y.)",
+            "Harlem (New York, N.Y.) -- Fiction"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "title": [
+            "A toast before dying : a Mali Anderson Mystery"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1998"
+          ],
+          "creatorLiteral": [
+            "Edwards, Grace F. (Grace Frederica)"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "38081631"
+          ],
+          "idIsbn": [
+            "0385485247"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1998"
+          ],
+          "titleDisplay": [
+            "A toast before dying : a Mali Anderson Mystery / Grace F. Edwards."
+          ],
+          "uri": "b13555237",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ],
+          "idIsbn_clean": [
+            "0385485247"
+          ]
+        },
+        "sort": [
+          554.9018,
+          "b13555237"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b13555237",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc E 98-933",
+                      "urn:barcode:33433059013205"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc E 98-933",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433059013205",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433059013205"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "physicalLocation": [
+                      "Sc E 98-933"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "Sc E 98-933"
+                    ],
+                    "shelfMark_sort": "aSc E 98-000933",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i10699418"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b13555237",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFE 98-5504",
+                      "urn:barcode:33433069269284"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 98-5504",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433069269284",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433069269284"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "physicalLocation": [
+                      "JFE 98-5504"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFE 98-5504"
+                    ],
+                    "shelfMark_sort": "aJFE 98-005504",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i10699417"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b18012067",
+        "_score": 554.9018,
+        "_source": {
+          "extent": [
+            "97 p. : ill. (chiefly col.) ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "editionStatement": [
+            "1st ed."
+          ],
+          "publisherLiteral": [
+            "Coffee House Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "sc",
+            "ma"
+          ],
+          "createdYear": [
+            2009
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFE 09-1080",
+            "Sc D 10-1178 "
+          ],
+          "idLccn": [
+            "2008012531"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2009
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 09-1080"
+            },
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 10-1178 "
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "18012067"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781566892223 (alk. paper)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1566892228 (alk. paper)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "214934641"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2008012531"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)214934641"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779479601828,
+          "publicationStatement": [
+            "Minneapolis, Minn. : Coffee House Press, 2009."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFE 09-1080",
+            "urn:shelfmark:Sc D 10-1178 ",
+            "urn:bnum:18012067",
+            "urn:isbn:9781566892223 (alk. paper)",
+            "urn:isbn:1566892228 (alk. paper)",
+            "urn:oclc:214934641",
+            "urn:lccn:2008012531",
+            "urn:identifier:(OCoLC)214934641"
+          ],
+          "creators_displayPacked": [
+            "Oliver, Akilah||Oliver, Akilah"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2010",
+                "gte": "2009"
+              },
+              "raw": "080319s2009    mnua          000 p eng  cam4a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PS3565.L4575 T63 2009"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "scf",
+            "mal"
+          ],
+          "physicalDescription": [
+            "97 p. : ill. (chiefly col.) ; 23 cm."
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "title": [
+            "A toast in the house of friends : poems"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2009"
+          ],
+          "creatorLiteral": [
+            "Oliver, Akilah"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "214934641"
+          ],
+          "popularity": 4,
+          "idIsbn": [
+            "9781566892223 (alk. paper)",
+            "1566892228 (alk. paper)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2009"
+          ],
+          "titleDisplay": [
+            "A toast in the house of friends : poems / Akilah Oliver."
+          ],
+          "uri": "b18012067",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Minneapolis, Minn."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ],
+          "idIsbn_clean": [
+            "9781566892223",
+            "1566892228"
+          ]
+        },
+        "sort": [
+          554.9018,
+          "b18012067"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b18012067",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:Sc D 10-1178",
+                      "urn:barcode:33433089303840"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 10-1178",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433089303840",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433089303840"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "physicalLocation": [
+                      "Sc D 10-1178"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "Sc D 10-1178"
+                    ],
+                    "shelfMark_sort": "aSc D 10-001178",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i25242885"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b18012067",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFE 09-1080",
+                      "urn:barcode:33433083328249"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 09-1080",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433083328249",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433083328249"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "physicalLocation": [
+                      "JFE 09-1080"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFE 09-1080"
+                    ],
+                    "shelfMark_sort": "aJFE 09-001080",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i23125020"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b21091000",
+        "_score": 554.9018,
+        "_source": {
+          "extent": [
+            "vii, 216 pages : color illustrations ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Abrams Image"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            2016
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JFD 16-5390"
+          ],
+          "idLccn": [
+            "2015955674"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            2016
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 16-5390"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "21091000"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781419722301"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1419722301"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "938991316"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2015955674"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)943677509"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)938991316"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779504665093,
+          "publicationStatement": [
+            "New York : Abrams Image, 2016."
+          ],
+          "identifier": [
+            "urn:shelfmark:JFD 16-5390",
+            "urn:bnum:21091000",
+            "urn:isbn:9781419722301",
+            "urn:isbn:1419722301",
+            "urn:oclc:938991316",
+            "urn:lccn:2015955674",
+            "urn:identifier:(OCoLC)943677509",
+            "urn:identifier:(OCoLC)938991316"
+          ],
+          "creators_displayPacked": [
+            "Grasse, Steven||Grasse, Steven, author"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2017",
+                "gte": "2016"
+              },
+              "raw": "160211s2016    nyua     b    001 0 eng dcamIi ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Alcoholic beverages -- United States -- History.",
+            "Drinking of alcoholic beverages -- United States -- History.",
+            "Cocktails."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "HV5292 .G67 2016"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "vii, 216 pages : color illustrations ; 21 cm"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Being: a revolutionary drinking guide to brewing and batching, mixing and serving, imbibing and jibing, fighting and freedom in the ruins of the ancient civilization known as America.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (pages 203-204) and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Alcoholic beverages",
+            "Alcoholic beverages -- United States",
+            "Alcoholic beverages -- United States -- History",
+            "Drinking of alcoholic beverages",
+            "Drinking of alcoholic beverages -- United States",
+            "Drinking of alcoholic beverages -- United States -- History",
+            "Cocktails"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Colonial spirits : a toast to our drunken history"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2016"
+          ],
+          "creatorLiteral": [
+            "Grasse, Steven"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "938991316"
+          ],
+          "popularity": 1,
+          "idIsbn": [
+            "9781419722301",
+            "1419722301"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2016"
+          ],
+          "titleDisplay": [
+            "Colonial spirits : a toast to our drunken history / by Steven Grasse."
+          ],
+          "uri": "b21091000",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm"
+          ],
+          "idIsbn_clean": [
+            "9781419722301",
+            "1419722301"
+          ]
+        },
+        "sort": [
+          554.9018,
+          "b21091000"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b21091000",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JFD 16-5390",
+                      "urn:barcode:33433120132745"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFD 16-5390",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433120132745",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433120132745"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "physicalLocation": [
+                      "JFD 16-5390"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JFD 16-5390"
+                    ],
+                    "shelfMark_sort": "aJFD 16-005390",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i34513730"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "pb1162495",
+        "_score": 544.5491,
+        "_source": {
+          "extent": [
+            "1 score (9 p.) ;"
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "publisherLiteral": [
+            "AdLar Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1994
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "M706002064"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1994
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "1162495"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "37469199"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-2121535"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "M706002064"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)37469199"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(CStRLIN)NJPG97-C408"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779335691151,
+          "publicationStatement": [
+            "Victoria, British Columbia : AdLar Publications, c1994."
+          ],
+          "identifier": [
+            "urn:bnum:1162495",
+            "urn:oclc:37469199",
+            "urn:oclc:SCSB-2121535",
+            "urn:lccn:M706002064",
+            "urn:identifier:(OCoLC)37469199",
+            "urn:identifier:(CStRLIN)NJPG97-C408"
+          ],
+          "creators_displayPacked": [
+            "Adaskin, Murray, 1906-2002||Adaskin, Murray, 1906-2002"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1995",
+                "gte": "1994"
+              },
+              "raw": "970730s1994    bccsga         n    eng d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Bertolino, James, 1942- -- Musical settings.",
+            "Songs (High voice) with instrumental ensemble -- Scores."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "M1613.3.A32 W4 1994"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "c",
+          "collectionIds": [],
+          "titleAlt": [
+            "Wedding toast;"
+          ],
+          "physicalDescription": [
+            "1 score (9 p.) ; 28 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Originally for soprano and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 3:30.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Bertolino, James, 1942-",
+            "Bertolino, James, 1942- -- Musical settings",
+            "Songs (High voice) with instrumental ensemble",
+            "Songs (High voice) with instrumental ensemble -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "A wedding toast : for soprano and string quartet"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1994"
+          ],
+          "creatorLiteral": [
+            "Adaskin, Murray, 1906-2002"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "37469199",
+            "SCSB-2121535"
+          ],
+          "uniformTitle": [
+            "Wedding toast; arr."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1994"
+          ],
+          "titleDisplay": [
+            "A wedding toast : for soprano and string quartet / Murray Adaskin ; poem by James Bertolino."
+          ],
+          "uri": "pb1162495",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "Victoria, British Columbia"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          544.5491,
+          "pb1162495"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "pb1162495",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:M1613.3.A32 W4 1994q",
+                      "urn:barcode:32101069496063"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M1613.3.A32 W4 1994q",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32101069496063",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101069496063"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "physicalLocation": [
+                      "M1613.3.A32 W4 1994q"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "M1613.3.A32 W4 1994q"
+                    ],
+                    "shelfMark_sort": "aM1613.3.A32 W4 1994q",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "pi1420607"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-c998fca623555f9e1eae87b0a6ccea44.json
+++ b/test/fixtures/query-c998fca623555f9e1eae87b0a6ccea44.json
@@ -1,0 +1,18 @@
+{
+  "took": 39,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 0,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": []
+  }
+}

--- a/test/fixtures/query-eb3f0b94c98ecbfd6a91df106eeee641.json
+++ b/test/fixtures/query-eb3f0b94c98ecbfd6a91df106eeee641.json
@@ -1,0 +1,11294 @@
+{
+  "took": 1918,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 29,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "cb1808514",
+        "_score": 699.77405,
+        "_source": {
+          "extent": [
+            "1 score (3 unnumbered pages, 12 pages) ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "publisherLiteral": [
+            "Jalni Publications ; Boosey & Hawkes, sole selling agent"
+          ],
+          "language": [
+            {
+              "id": "lang:N/A",
+              "label": ""
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1984
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "1808514"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm11578466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-3364085"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "H.P.S. 976 Boosey & Hawkes"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm11578466"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)1808514"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "1808514"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779480345156,
+          "publicationStatement": [
+            "[Place of publication not identified] : Jalni Publications ; New York, N.Y. : Boosey & Hawkes, sole selling agent, 1984, ©1980."
+          ],
+          "identifier": [
+            "urn:bnum:1808514",
+            "urn:oclc:ocm11578466",
+            "urn:oclc:SCSB-3364085",
+            "urn:identifier:H.P.S. 976 Boosey & Hawkes",
+            "urn:identifier:(OCoLC)ocm11578466",
+            "urn:identifier:(NNC)1808514",
+            "urn:identifier:1808514"
+          ],
+          "creators_displayPacked": [
+            "Bernstein, Leonard, 1918-1990||Bernstein, Leonard, 1918-1990"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1985",
+                "gte": "1984"
+              },
+              "raw": "850114t19841980nyuzza   i     n    N/A d",
+              "tag": "t"
+            },
+            {
+              "range": {
+                "lt": "1981",
+                "gte": "1980"
+              },
+              "raw": "850114t19841980nyuzza   i     n    N/A d",
+              "tag": "t"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "c",
+          "collectionIds": [],
+          "titleAlt": [
+            "Musical toast"
+          ],
+          "physicalDescription": [
+            "1 score (3 unnumbered pages, 12 pages) ; 27 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes by Jack Gottlieb.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 2:30.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Recorded by the Israel Philharmonic, the composer conducting, on Deutsche Grammophon 2532 052.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Also available in a version for symphonic band.",
+              "type": "bf:Note"
+            }
+          ],
+          "seriesUniformTitle_displayPacked": [
+            "Hawkes pocket scores.||Hawkes pocket scores."
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1980"
+          ],
+          "title": [
+            "A musical toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [
+            "Bernstein, Leonard, 1918-1990"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocm11578466",
+            "SCSB-3364085"
+          ],
+          "uniformTitle": [
+            "Musical toast"
+          ],
+          "dateEndYear": [
+            1980
+          ],
+          "seriesUniformTitle": [
+            "Hawkes pocket scores."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "titleDisplay": [
+            "A musical toast / Leonard Bernstein."
+          ],
+          "uri": "cb1808514",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "[Place of publication not identified] : New York, N.Y."
+          ],
+          "series": [
+            "Hawkes pocket scores"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Hawkes pocket scores||Hawkes pocket scores"
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          699.77405,
+          "cb1808514"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb1808514",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:61 B458 M9",
+                      "urn:barcode:MR61509485"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "61 B458 M9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "MR61509485",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "MR61509485"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "61 B458 M9"
+                    ],
+                    "recapCustomerCode": [
+                      "MR"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "61 B458 M9"
+                    ],
+                    "shelfMark_sort": "a61 B458 M000009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci2278358"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b16151201",
+        "_score": 672.0904,
+        "_source": {
+          "extent": [
+            "1 sound disc : analog, 33 1/3 rpm ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Seeco"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            19
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LZR 43109"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            19
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LZR 43109"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16151201"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "58387713"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "SCLP 9109 Seeco"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A070000038"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Aguilera, F.||Aguilera, F., performer, editor, arranger",
+            "García Matos, Manuel, 1912-||García Matos, Manuel, 1912-, conductor, editor, arranger"
+          ],
+          "updatedAt": 1779433889165,
+          "publicationStatement": [
+            "New York, N.Y. : Seeco, [19--?]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LZR 43109",
+            "urn:bnum:16151201",
+            "urn:oclc:58387713",
+            "urn:identifier:SCLP 9109 Seeco",
+            "urn:identifier:(WaOLN)A070000038"
+          ],
+          "creators_displayPacked": [
+            "Flores, Lola||Flores, Lola, performer"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2000",
+                "gte": "1900"
+              },
+              "raw": "050307s19uu    nyuppn   i          spa dnjmIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Popular music -- Spain."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "j",
+          "collectionIds": [
+            "pah"
+          ],
+          "physicalDescription": [
+            "1 sound disc : analog, 33 1/3 rpm ; 12 in."
+          ],
+          "tableOfContents": [
+            "Lola de España -- Concha veneno -- Tu cartel por las mũrallas -- Mi pelo negro -- Mi embajaora -- Valgame la Magdalena -- Remedios la de montilla -- Venga pronto el volapie -- Gritenme piedras del campo -- Me serenaste -- Pa su papa -- Maldigo tus ojos verdes."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Program notes in English and Spanish on container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in Spanish.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Popular music",
+            "Popular music -- Spain"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "The toast of Spain"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "19uu"
+          ],
+          "creatorLiteral": [
+            "Flores, Lola"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Aguilera, F.",
+            "García Matos, Manuel, 1912-"
+          ],
+          "idOclc": [
+            "58387713"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "19uu"
+          ],
+          "titleDisplay": [
+            "The toast of Spain [sound recording] / Lola Flores."
+          ],
+          "uri": "b16151201",
+          "parallelContributorLiteral": [
+            null,
+            null
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "New York, N.Y."
+          ],
+          "series": [
+            "Gold series"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Gold series||Gold series"
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          672.0904,
+          "b16151201"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16151201",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Flores%2C+Lola&CallNumber=*LZR+43109+%5BDisc%5D&Date=19uu&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16151201&ItemISxN=i155562502&ItemNumber=33433036075665&ItemPlace=New+York%2C+N.Y.&ItemPublisher=Seeco%2C+%5B19--%3F%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b16151201x&Site=LPAMRAMI&Title=The+toast+of+Spain"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LZR 43109 [Disc]",
+                      "urn:barcode:33433036075665"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LZR 43109 [Disc]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433036075665",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433036075665"
+                    ],
+                    "physicalLocation": [
+                      "*LZR 43109 [Disc]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LZR 43109 [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LZR 43109 [Disc]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15556250"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b13111567",
+        "_score": 637.0519,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "The Nation Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1909
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "NBI (Rowe, W. H. Verse and toast)"
+          ],
+          "idLccn": [
+            "09014147"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1909
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NBI (Rowe, W. H. Verse and toast)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13111567"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "12310878"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "09014147"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3090092"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779387175635,
+          "publicationStatement": [
+            "New York, The Nation Press, 1909-"
+          ],
+          "identifier": [
+            "urn:shelfmark:NBI (Rowe, W. H. Verse and toast)",
+            "urn:bnum:13111567",
+            "urn:oclc:12310878",
+            "urn:lccn:09014147",
+            "urn:identifier:(WaOLN)nyp3090092"
+          ],
+          "creators_displayPacked": [
+            "Rowe, William H., Jr||Rowe, William H., Jr"
+          ],
+          "dates": [
+            {
+              "range": {
+                "gte": "1909",
+                "lte": "9999"
+              },
+              "raw": "850726m19099999nyu           000 p eng  namI  ",
+              "tag": "m"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "v. ; 19 cm."
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "title": [
+            "Verse and toast. Series 1-"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1909"
+          ],
+          "creatorLiteral": [
+            "Rowe, William H., Jr"
+          ],
+          "numElectronicResources": [
+            2
+          ],
+          "idOclc": [
+            "12310878"
+          ],
+          "popularity": 6,
+          "dateEndYear": [
+            9999
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1909"
+          ],
+          "titleDisplay": [
+            "Verse and toast. Series 1- By Col. William H. Rowe, Jr."
+          ],
+          "uri": "b13111567",
+          "parallelContributorLiteral": [],
+          "electronicResources": [
+            {
+              "label": "Full text available via HathiTrust--ser. 1",
+              "url": "http://babel.hathitrust.org/cgi/pt?id=nyp.33433066644091"
+            },
+            {
+              "label": "Full text available via HathiTrust--ser. 2",
+              "url": "http://babel.hathitrust.org/cgi/pt?id=nyp.33433066644109"
+            }
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          637.0519,
+          "b13111567"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b13111567",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "enumerationChronology": [
+                      "ser. 2"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NBI (Rowe, W. H. Verse and toast)",
+                      "urn:barcode:33433066644109"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "NBI (Rowe, W. H. Verse and toast)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433066644109",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433066644109"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "physicalLocation": [
+                      "NBI (Rowe, W. H. Verse and toast)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "NBI (Rowe, W. H. Verse and toast)"
+                    ],
+                    "shelfMark_sort": "aNBI (Rowe, W. H. Verse and toast)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i16815166"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b13111567",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "enumerationChronology": [
+                      "ser. 1"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2",
+                      "urn:barcode:33433066644091"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433066644091",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433066644091"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "physicalLocation": [
+                      "NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "NBI (Rowe, W. H. Verse and toast) Library has: Series 1-2"
+                    ],
+                    "shelfMark_sort": "aNBI (Rowe, W. H. Verse and toast) Library has: Series 1-000002",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i16257903"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b10861042",
+        "_score": 530.9364,
+        "_source": {
+          "extent": [
+            "24 p. : ill., ports. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Fraunces Tavern Museum"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*ZI-437 no. 20"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1984
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZI-437 no. 20"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10861042"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG84-B40685"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0868084"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Fraunces Tavern Museum||Fraunces Tavern Museum",
+            "Sons of the American Revolution. Empire State Society||Sons of the American Revolution. Empire State Society"
+          ],
+          "updatedAt": 1779322320011,
+          "publicationStatement": [
+            "New York : Fraunces Tavern Museum, 1984."
+          ],
+          "identifier": [
+            "urn:shelfmark:*ZI-437 no. 20",
+            "urn:bnum:10861042",
+            "urn:oclc:NYPG84-B40685",
+            "urn:identifier:(WaOLN)nyp0868084"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "lt": "1985",
+                "gte": "1984"
+              },
+              "raw": "840604s1984    nyuac    bc   000 0 eng dcam i ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Evacuation Day, New York, N.Y., 1783.",
+            "New York (N.Y.) -- History -- Revolution, 1775-1783."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "h",
+          "collectionIds": [
+            "mag"
+          ],
+          "physicalDescription": [
+            "24 p. : ill., ports. ; 28 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"A publication commemorating the bicentennial of the evacuation of the British from New York City on November 25, 1783, at the end of the Revolutionary War.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 24.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm. New York : New York Public Library, 1986. 1 microfilm reel ; 35 mm. (MN *ZZ-26376)",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Evacuation Day, New York, N.Y., 1783",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- History",
+            "New York (N.Y.) -- History -- Revolution, 1775-1783"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "title": [
+            "A toast to freedom New York celebrates Evacuation Day."
+          ],
+          "numItemVolumesParsed": [
+            2
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Fraunces Tavern Museum",
+            "Sons of the American Revolution. Empire State Society"
+          ],
+          "idOclc": [
+            "NYPG84-B40685"
+          ],
+          "popularity": 2,
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "titleDisplay": [
+            "A toast to freedom [microform] :  New York celebrates Evacuation Day."
+          ],
+          "uri": "b10861042",
+          "parallelContributorLiteral": [
+            null,
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          530.9364,
+          "b10861042"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b10861042",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "enumerationChronology": [
+                      "r. 2"
+                    ],
+                    "enumerationChronology_sort": "         2-",
+                    "formatLiteral": [
+                      "Microform"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag82",
+                        "label": "Schwarzman Building - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag82||Schwarzman Building - Milstein Division Room 121"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*ZI-437",
+                      "urn:barcode:33433110534520"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZI-437",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433110534520",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433110534520"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "physicalLocation": [
+                      "*ZI-437"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "*ZI-437"
+                    ],
+                    "shelfMark_sort": "a*ZI-000437",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i31168756",
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 2
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b10861042",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "enumerationChronology": [
+                      "r. 1"
+                    ],
+                    "enumerationChronology_sort": "         1-",
+                    "formatLiteral": [
+                      "Microform"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag82",
+                        "label": "Schwarzman Building - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag82||Schwarzman Building - Milstein Division Room 121"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*ZI-437",
+                      "urn:barcode:33433110534512"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZI-437",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433110534512",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433110534512"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "physicalLocation": [
+                      "*ZI-437"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "*ZI-437"
+                    ],
+                    "shelfMark_sort": "a*ZI-000437",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i24076491",
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b18106748",
+        "_score": 530.9364,
+        "_source": {
+          "extent": [
+            "24 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Fraunces Tavern Museum"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "NYGB N.Y. L M314.43 F73"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1984
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "NYGB N.Y. L M314.43 F73"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "18106748"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "15527116"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)15527116"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Fraunces Tavern Museum||Fraunces Tavern Museum",
+            "Sons of the American Revolution. New York State Society||Sons of the American Revolution. New York State Society",
+            "New York Genealogical and Biographical Society Collection||New York Genealogical and Biographical Society Collection"
+          ],
+          "updatedAt": 1779480610652,
+          "publicationStatement": [
+            "New York : Fraunces Tavern Museum, 1984."
+          ],
+          "identifier": [
+            "urn:shelfmark:NYGB N.Y. L M314.43 F73",
+            "urn:bnum:18106748",
+            "urn:oclc:15527116",
+            "urn:identifier:(OCoLC)15527116"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "lt": "1985",
+                "gte": "1984"
+              },
+              "raw": "870414s1984    nyua     b    000 0 eng dcamIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Evacuation Day, New York, N.Y., 1783 -- Anniversaries, etc.",
+            "New York (N.Y.) -- History -- Revolution, 1775-1783."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mag"
+          ],
+          "physicalDescription": [
+            "24 p. : ill. ; 28 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"A publication commemorating the bicentennial of the evacuation of the British from New York City on November 25, 1783, ...\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "The research and implementation of this project ... with the assistance of the Sons of the Revolution in the State of New York.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "\"Selected bibliography\": p. 24.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Gift; New York Genealogical and Biographical Society; 2008.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Evacuation Day, New York, N.Y., 1783",
+            "Evacuation Day, New York, N.Y., 1783 -- Anniversaries, etc",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- History",
+            "New York (N.Y.) -- History -- Revolution, 1775-1783"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "A Toast to freedom : New York celebrates Evacuation Day."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Fraunces Tavern Museum",
+            "Sons of the American Revolution. New York State Society",
+            "New York Genealogical and Biographical Society Collection"
+          ],
+          "donor": [
+            "Gift of the New York Genealogical and Biographical Society."
+          ],
+          "idOclc": [
+            "15527116"
+          ],
+          "popularity": 4,
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "titleDisplay": [
+            "A Toast to freedom : New York celebrates Evacuation Day."
+          ],
+          "uri": "b18106748",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          530.9364,
+          "b18106748"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "match_phrase title.folded",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b18106748",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building - Milstein Division Room 121"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NYGB N.Y. L M314.43 F73",
+                      "urn:barcode:33433086370503"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "NYGB N.Y. L M314.43 F73",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433086370503",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433086370503"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "NYGB N.Y. L M314.43 F73"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "NYGB N.Y. L M314.43 F73"
+                    ],
+                    "shelfMark_sort": "aNYGB N.Y. L M314.43 F000073",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i24199542"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "hb990002994230203941",
+        "_score": 301.81772,
+        "_source": {
+          "extent": [
+            "xi, 105 p., [1] folded leaf of plates : ill. ;"
+          ],
+          "nyplSource": [
+            "recap-hl"
+          ],
+          "publisherLiteral": [
+            "Wheeler Productions"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1985
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "^^^84091414^"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1985
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "990002994230203941"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0961436212 (pbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0961436204 (hard)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "12314723"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-10060378"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "^^^84091414^"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)12272687 (OCoLC)12282112 (OCoLC)12282122 (OCoLC)12321773 (OCoLC)28021603 (OCoLC)1298901854"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)12314723"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Wheeler, Ardis Hillman||Wheeler, Ardis Hillman"
+          ],
+          "updatedAt": 1779572382973,
+          "publicationStatement": [
+            "St. Paul, MN : Wheeler Productions, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:990002994230203941",
+            "urn:isbn:0961436212 (pbk.)",
+            "urn:isbn:0961436204 (hard)",
+            "urn:oclc:12314723",
+            "urn:oclc:SCSB-10060378",
+            "urn:lccn:^^^84091414^",
+            "urn:identifier:(OCoLC)12272687 (OCoLC)12282112 (OCoLC)12282122 (OCoLC)12321773 (OCoLC)28021603 (OCoLC)1298901854",
+            "urn:identifier:(OCoLC)12314723"
+          ],
+          "creators_displayPacked": [
+            "Wheeler, Robert C., 1913-1986||Wheeler, Robert C., 1913-1986"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1986",
+                "gte": "1985"
+              },
+              "raw": "850617s1985    mnuaf    b    00010 eng  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Fur trade -- Northwestern States.",
+            "Fur trade -- Northwest, Canadian.",
+            "Material culture -- Northwestern States.",
+            "Material culture -- Northwest, Canadian.",
+            "Northwestern States -- Antiquities.",
+            "Northwest, Canadian -- Antiquities."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "F597 .W57 1985"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "xi, 105 p., [1] folded leaf of plates : ill. ; 28 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 103-105.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "committed to retain 20181001 in perpetuity ReCAP Shared Collection HUL 221754796340003941",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Fur trade",
+            "Fur trade -- Northwestern States",
+            "Fur trade -- Northwest, Canadian",
+            "Material culture",
+            "Material culture -- Northwestern States",
+            "Material culture -- Northwest, Canadian",
+            "Northwestern States",
+            "Northwestern States -- Antiquities",
+            "Northwest, Canadian",
+            "Northwest, Canadian -- Antiquities"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "A toast to the fur trade : a picture essay on its material culture / by Robert C. Wheeler ; illustrations by David Christofferson ; edited by Ardis Hillman Wheeler."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "creatorLiteral": [
+            "Wheeler, Robert C., 1913-1986"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Wheeler, Ardis Hillman"
+          ],
+          "idOclc": [
+            "12314723",
+            "SCSB-10060378"
+          ],
+          "summary": [
+            "Includes an introduction to the fur trade, many illustrations of artifacts, sections on fur trade accidents, food and drink, and a listing of fur trade sites in Canada and the United States."
+          ],
+          "genreForm": [
+            "History"
+          ],
+          "idIsbn": [
+            "0961436212 (pbk.)",
+            "0961436204 (hard)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "titleDisplay": [
+            "A toast to the fur trade : a picture essay on its material culture / by Robert C. Wheeler ; illustrations by David Christofferson ; edited by Ardis Hillman Wheeler."
+          ],
+          "uri": "hb990002994230203941",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "St. Paul, MN"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ],
+          "idIsbn_clean": [
+            "0961436212",
+            "0961436204"
+          ]
+        },
+        "sort": [
+          301.81772,
+          "hb990002994230203941"
+        ],
+        "matched_queries": [
+          "match_phrase title.folded",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "hb990002994230203941",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:N.A.ARC. W 565 t Some ill. on lining papers. copy ",
+                      "urn:barcode:32044042656827"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "N.A.ARC. W 565 t Some ill. on lining papers. copy ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "32044042656827",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32044042656827"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0004",
+                        "label": "Harvard Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0004||Harvard Library"
+                    ],
+                    "physicalLocation": [
+                      "N.A.ARC. W 565 t Some ill. on lining papers."
+                    ],
+                    "recapCustomerCode": [
+                      "TZ"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "N.A.ARC. W 565 t Some ill. on lining papers. copy "
+                    ],
+                    "shelfMark_sort": "aN.A.ARC. W 565 t Some ill. on lining papers. copy ",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "hi231754796330003941"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b15774363",
+        "_score": 261.45102,
+        "_source": {
+          "extent": [
+            "37.8 (75 boxes)"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa",
+            "rc"
+          ],
+          "createdYear": [
+            1911
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*T-Mss 2000-012"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1911
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*T-Mss 2000-012"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15774363"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPT03-A1"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)T170000001"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Bricusse, Leslie||Bricusse, Leslie",
+            "Charlot, André, 1882-1956||Charlot, André, 1882-1956",
+            "Churchill, Winston, 1874-1965||Churchill, Winston, 1874-1965",
+            "Coward, Noël, 1899-1973||Coward, Noël, 1899-1973",
+            "Dietz, Howard, 1896-1983||Dietz, Howard, 1896-1983",
+            "Hamilton, Nancy, 1908-1985||Hamilton, Nancy, 1908-1985",
+            "Hart, Lorenz, 1895-1943||Hart, Lorenz, 1895-1943",
+            "Hope, Bob, 1903-2003||Hope, Bob, 1903-2003",
+            "Novello, Ivor, 1893-1951||Novello, Ivor, 1893-1951",
+            "Peel, Robert, 1909-1992||Peel, Robert, 1909-1992",
+            "Porter, Cole, 1891-1964||Porter, Cole, 1891-1964",
+            "Rodgers, Richard, 1902-1979||Rodgers, Richard, 1902-1979",
+            "Schwartz, Arthur, 1900-1984||Schwartz, Arthur, 1900-1984"
+          ],
+          "updatedAt": 1779428368058,
+          "identifier": [
+            "urn:shelfmark:*T-Mss 2000-012",
+            "urn:bnum:15774363",
+            "urn:oclc:NYPT03-A1",
+            "urn:identifier:(WaOLN)T170000001"
+          ],
+          "creators_displayPacked": [
+            "Lillie, Beatrice, 1894-1989||Lillie, Beatrice, 1894-1989"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1996",
+                "gte": "1911"
+              },
+              "raw": "030502i19111995nyu     |           eng dcpczaa",
+              "tag": "i"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Lillie, Beatrice, 1894-1989.",
+            "Performing arts.",
+            "Women comedians.",
+            "Actresses.",
+            "Entertainers."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "p",
+          "collectionIds": [
+            "pat"
+          ],
+          "physicalDescription": [
+            "37.8 (75 boxes)"
+          ],
+          "note": [
+            {
+              "noteType": "Access",
+              "label": "Collection is open to the public. Library policy on photography and photocopying will apply. Advance notice may be required.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Beatrice Lillie, comedienne, actress, singer and author, was born May 29, 1894 in Toronto, Ontario. She left school for the stage at age 15 to tour Canada in The Lillie Trio with her mother Lucy and sister Muriel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "After coming to London in 1914, Lillie joined Andre Charlot's Revue, where she later made her Broadway debut in 1924. With a career spanning more than 50 years, she performed in revues, plays, film, on radio and television and also enjoyed a successful recording career. Lillie frequently performed both in London and the United States, earning her fame as \"The Toast of Two Continents.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "In 1920 Beatrice married Sir Robert Peel, gaining the title Lady Peel. The couple had one son, Robert Peel Jr., in 1934. She was widowed in 1934 and lost her son to the war in 1942.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Lillie traveled to the Middle East, Africa, France and Germany to perform for the troops during WWII, an effort for which she received a decoration from General Charles de Gaulle. She developed close friendships with other famous figures, including Noel Coward, Winston Churchill, George Bernard Shaw and Charlie Chaplin. During the war Beatrice Lillie met John Phillip Huck who would become her manager and life-long companion.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Ms. Lillie starred in shows by Noel Coward, George Bernard Shaw, Rogers & Hart, Schwartz & Dietz and Cole Porter. Lillie became best known for starring in This year of grace (1928), written for her by Noel Coward, and received equal recognition for her version of Coward's song, \"Mad dogs and Englishmen.\" Other notable Broadway performances include The Seven lively arts (1947), Inside USA (1948), Ziegfeld follies of 1957 and High spirits (1964). She toured the world with her one-woman show An evening with Beatrice Lillie from 1952-1956, winning a Tony Award in 1953. Lady Peel made a handful of films, which met with varying degrees of success. Beginning with an early silent film Exit smiling (1926) and ending on a high note with her role as a Mrs. Meers in Thoroughly modern Millie (1967). Beatrice Lillie published her autobiography, Every other inch a lady, in 1973.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Beatrice Lillie retired to England to recover from a stroke in 1977. She died January 20, 1989 at her home, Henley-on-Thames, England. She was 94 years old.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Lillie, Beatrice, 1894-1989",
+            "Performing arts",
+            "Women comedians",
+            "Actresses",
+            "Entertainers"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            75
+          ],
+          "dateEndString": [
+            "1995"
+          ],
+          "title": [
+            "Beatrice Lillie papers"
+          ],
+          "numItemVolumesParsed": [
+            75
+          ],
+          "createdString": [
+            "1911"
+          ],
+          "creatorLiteral": [
+            "Lillie, Beatrice, 1894-1989"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Bricusse, Leslie",
+            "Charlot, André, 1882-1956",
+            "Churchill, Winston, 1874-1965",
+            "Coward, Noël, 1899-1973",
+            "Dietz, Howard, 1896-1983",
+            "Hamilton, Nancy, 1908-1985",
+            "Hart, Lorenz, 1895-1943",
+            "Hope, Bob, 1903-2003",
+            "Novello, Ivor, 1893-1951",
+            "Peel, Robert, 1909-1992",
+            "Porter, Cole, 1891-1964",
+            "Rodgers, Richard, 1902-1979",
+            "Schwartz, Arthur, 1900-1984"
+          ],
+          "idOclc": [
+            "NYPT03-A1"
+          ],
+          "popularity": 24,
+          "dateEndYear": [
+            1995
+          ],
+          "summary": [
+            "The Beatrice Lillie papers consist of 37.8 linear feet spanning the 1910s to the 1990s. The collection has been divided into ten series: Correspondence, Personal Papers, Legal and Financial Papers, Professional Work Files, Clippings, Photographs, Ephemera, Artwork, and Oversize Materials. The first three series: Correspondence, Personal Papers and Legal and Financial Papers also include items belonging to Beatrice Lillie's long-time companion John Phillip Huck and his sister Georgina M. Huck. The collection is strong in biographical works, including two unpublished works. It effectively reveals the performer's humor and colorful persona through lyrics and skits. A large collection of photographs illuminates a professional and personal Beatrice Lillie."
+          ],
+          "genreForm": [
+            "Biographies.",
+            "Clippings.",
+            "Correspondence.",
+            "Financial records.",
+            "Legal documents.",
+            "Personal papers.",
+            "Photographs.",
+            "Scrapbooks.",
+            "Sheet music."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mix",
+              "label": "Mixed material"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1911"
+          ],
+          "titleDisplay": [
+            "Beatrice Lillie papers, 1911-1995"
+          ],
+          "uri": "b15774363",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "recordTypeId": "p",
+          "issuance": [
+            {
+              "id": "urn:biblevel:c",
+              "label": "collection"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Finding Aid",
+              "url": "http://www.nypl.org/archives/4489"
+            }
+          ]
+        },
+        "sort": [
+          261.45102,
+          "b15774363"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "popularity >= 10",
+          "popularity >= 20",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 75,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b15774363",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Lillie%2C+Beatrice%2C+1894-1989&CallNumber=*T-Mss+2000-012&Date=1911&Form=30&Genre=archival+material&ItemInfo1=Supervised+use&ItemInfo2=Collection+is+open+to+the+public.+Library+policy+on+photography+and+photocopying+will+apply.+Advance+notice+may+be+required.&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15774363&ItemISxN=i153520644&ItemNumber=33433036090011&ItemVolume=Box+1&Location=Performing+Arts+Theatre+Division&ReferenceNumber=b157743639&Site=LPATH&Title=Beatrice+Lillie+papers%2C+1911-1995"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:21",
+                        "label": "archival material"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:21||archival material"
+                    ],
+                    "enumerationChronology": [
+                      "Box 1"
+                    ],
+                    "enumerationChronology_sort": "      9999-",
+                    "formatLiteral": [
+                      "Archival mix"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pat38",
+                        "label": "Performing Arts Research Collections - Theatre"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pat38||Performing Arts Research Collections - Theatre"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*T-Mss 2000-012",
+                      "urn:barcode:33433036090011"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*T-Mss 2000-012",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433036090011",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433036090011"
+                    ],
+                    "physicalLocation": [
+                      "*T-Mss 2000-012"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*T-Mss 2000-012"
+                    ],
+                    "shelfMark_sort": "a*T-Mss 2000-000012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15352064",
+                    "volumeRange": [
+                      {
+                        "gte": 9999,
+                        "lte": 9999
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "      9999-"
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b15774363",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Lillie%2C+Beatrice%2C+1894-1989&CallNumber=*T-Mss+2000-012&Date=1911&Form=30&Genre=archival+material&ItemInfo1=Supervised+use&ItemInfo2=Collection+is+open+to+the+public.+Library+policy+on+photography+and+photocopying+will+apply.+Advance+notice+may+be+required.&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15774363&ItemISxN=i153520656&ItemNumber=33433036090029&ItemVolume=Box+2&Location=Performing+Arts+Theatre+Division&ReferenceNumber=b157743639&Site=LPATH&Title=Beatrice+Lillie+papers%2C+1911-1995"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:21",
+                        "label": "archival material"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:21||archival material"
+                    ],
+                    "enumerationChronology": [
+                      "Box 2"
+                    ],
+                    "enumerationChronology_sort": "      9998-",
+                    "formatLiteral": [
+                      "Archival mix"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pat38",
+                        "label": "Performing Arts Research Collections - Theatre"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pat38||Performing Arts Research Collections - Theatre"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*T-Mss 2000-012",
+                      "urn:barcode:33433036090029"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*T-Mss 2000-012",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433036090029",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433036090029"
+                    ],
+                    "physicalLocation": [
+                      "*T-Mss 2000-012"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*T-Mss 2000-012"
+                    ],
+                    "shelfMark_sort": "a*T-Mss 2000-000012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15352065",
+                    "volumeRange": [
+                      {
+                        "gte": 9998,
+                        "lte": 9998
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "      9998-"
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b15774363",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Lillie%2C+Beatrice%2C+1894-1989&CallNumber=*T-Mss+2000-012&Date=1911&Form=30&Genre=archival+material&ItemInfo1=Supervised+use&ItemInfo2=Collection+is+open+to+the+public.+Library+policy+on+photography+and+photocopying+will+apply.+Advance+notice+may+be+required.&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15774363&ItemISxN=i153520668&ItemNumber=33433036090037&ItemVolume=Box+3&Location=Performing+Arts+Theatre+Division&ReferenceNumber=b157743639&Site=LPATH&Title=Beatrice+Lillie+papers%2C+1911-1995"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:21",
+                        "label": "archival material"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:21||archival material"
+                    ],
+                    "enumerationChronology": [
+                      "Box 3"
+                    ],
+                    "enumerationChronology_sort": "      9997-",
+                    "formatLiteral": [
+                      "Archival mix"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pat38",
+                        "label": "Performing Arts Research Collections - Theatre"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pat38||Performing Arts Research Collections - Theatre"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*T-Mss 2000-012",
+                      "urn:barcode:33433036090037"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*T-Mss 2000-012",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433036090037",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433036090037"
+                    ],
+                    "physicalLocation": [
+                      "*T-Mss 2000-012"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*T-Mss 2000-012"
+                    ],
+                    "shelfMark_sort": "a*T-Mss 2000-000012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15352066",
+                    "volumeRange": [
+                      {
+                        "gte": 9997,
+                        "lte": 9997
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "      9997-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b10685709",
+        "_score": 261.14557,
+        "_source": {
+          "extent": [
+            "volumes <1-12> : illustrations ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "University of Tennessee Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "ma"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "IAW (Jackson) 80-3099"
+          ],
+          "idLccn": [
+            "79015078"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1980
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "IAW (Jackson) 80-3099"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10685709"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0870492195"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780870492198"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0870494414"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780870494413"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0870496506"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780870496509"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0870497782"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780870497780"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0870498975"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780870498978"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1572331747"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781572331747"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781572335936"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1572335939"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781572337152"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "157233715X"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781621900047"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1621900045"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781621902676"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1621902676"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781621905387"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1621905381"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9781621907558"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1621907554"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "5029597"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79015078"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)609560879 (OCoLC)769265853 (OCoLC)769850561 (OCoLC)770876143 (OCoLC)777774362 (OCoLC)807573070 (OCoLC)876110400 (OCoLC)890078391 (OCoLC)890280620 (OCoLC)894132413 (OCoLC)913850526 (OCoLC)914132651 (OCoLC)922670928 (OCoLC)958221171 (OCoLC)1101360978 (OCoLC)1114108948 (OCoLC)1131934218 (OCoLC)1164180119 (OCoLC)1222878957 (OCoLC)1225660295"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)5029597"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Smith, Sam B., 1929-2003||Smith, Sam B., 1929-2003, editor",
+            "Owsley, Harriet Chappell, 1901-1999||Owsley, Harriet Chappell, 1901-1999, editor",
+            "Macpherson, Sharon C.||Macpherson, Sharon C., editor",
+            "Remini, Robert V. (Robert Vincent), 1921-2013||Remini, Robert V. (Robert Vincent), 1921-2013, editor",
+            "Moser, Harold D.||Moser, Harold D., editor",
+            "Feller, Daniel, 1950-||Feller, Daniel, 1950-, editor",
+            "Roth, David H.||Roth, David H., editor",
+            "Hoemann, George H., 1952-||Hoemann, George H., 1952-, editor",
+            "Coens, Thomas, 1974-||Coens, Thomas, 1974-, editor",
+            "Moss, Laura-Eve||Moss, Laura-Eve, editor",
+            "Alexander, Erik B.||Alexander, Erik B., editor",
+            "Crawford, Aaron||Crawford, Aaron, editor"
+          ],
+          "updatedAt": 1779319267839,
+          "publicationStatement": [
+            "Knoxville : University of Tennessee Press, [1980-]",
+            "©1980"
+          ],
+          "identifier": [
+            "urn:shelfmark:IAW (Jackson) 80-3099",
+            "urn:bnum:10685709",
+            "urn:isbn:0870492195",
+            "urn:isbn:9780870492198",
+            "urn:isbn:0870494414",
+            "urn:isbn:9780870494413",
+            "urn:isbn:0870496506",
+            "urn:isbn:9780870496509",
+            "urn:isbn:0870497782",
+            "urn:isbn:9780870497780",
+            "urn:isbn:0870498975",
+            "urn:isbn:9780870498978",
+            "urn:isbn:1572331747",
+            "urn:isbn:9781572331747",
+            "urn:isbn:9781572335936",
+            "urn:isbn:1572335939",
+            "urn:isbn:9781572337152",
+            "urn:isbn:157233715X",
+            "urn:isbn:9781621900047",
+            "urn:isbn:1621900045",
+            "urn:isbn:9781621902676",
+            "urn:isbn:1621902676",
+            "urn:isbn:9781621905387",
+            "urn:isbn:1621905381",
+            "urn:isbn:9781621907558",
+            "urn:isbn:1621907554",
+            "urn:oclc:5029597",
+            "urn:lccn:79015078",
+            "urn:identifier:(OCoLC)609560879 (OCoLC)769265853 (OCoLC)769850561 (OCoLC)770876143 (OCoLC)777774362 (OCoLC)807573070 (OCoLC)876110400 (OCoLC)890078391 (OCoLC)890280620 (OCoLC)894132413 (OCoLC)913850526 (OCoLC)914132651 (OCoLC)922670928 (OCoLC)958221171 (OCoLC)1101360978 (OCoLC)1114108948 (OCoLC)1131934218 (OCoLC)1164180119 (OCoLC)1222878957 (OCoLC)1225660295",
+            "urn:identifier:(OCoLC)5029597"
+          ],
+          "creators_displayPacked": [
+            "Jackson, Andrew, 1767-1845||Jackson, Andrew, 1767-1845, author"
+          ],
+          "dates": [
+            {
+              "range": {
+                "gte": "1980",
+                "lte": "9999"
+              },
+              "raw": "790511m19809999tnua     b    001 0aeng  cam i ",
+              "tag": "m"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Jackson, Andrew, 1767-1845.",
+            "United States -- Politics and government -- 1829-1837 -- Sources.",
+            "Presidents -- United States -- Correspondence."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "E302 .J35 1980"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mag"
+          ],
+          "titleAlt": [
+            "Works"
+          ],
+          "physicalDescription": [
+            "volumes <1-12> : illustrations ; 25 cm"
+          ],
+          "tableOfContents": [
+            "Volume I: 1770-1803 -- Volume II: 1804-1813 -- Volume III: 1814-1815 -- Volume IV: 1816-1820 -- Volume V: 1825-1828 -- Volume VI: 1825-1828 -- Volume VII: 1829 -- Volume VIII: 1830 -- Volume IX: 1831 -- Volume X: 1832 -- Volume XI: 1833 -- Volume XII: 1834"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Volume 2 edited by Harold D. Moser and Sharon Macpherson.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Volume 5 edited by Harold D. Moser, David H. Roth, and George H. Hoemann.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Volume 6 edited by Harold D. Moser, J. Clint Clifft and assistant editor Wyatt C. Wells.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Volume 7 edited by Daniel Feller, Harold D. Moser, Laura-Eve Moss, and Thomas Coens.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Volume 8 edited by Daniel Feller, Thomas Coens, and Laura-Eve Moss.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Volume 9 edited by Daniel Feller, Laura-Eve Moss, Thomas Coens, and Erik B. Alexander.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Volumes 10-11 edited by Daniel Feller, Thomas Coens, and Laura-Eve Moss.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Volume 12 edited by Daniel Feller, Thomas Coens, Laura-Eve Moss, and Aaron Crawford.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Jackson, Andrew, 1767-1845",
+            "United States",
+            "United States -- Politics and government",
+            "United States -- Politics and government -- 1829-1837",
+            "United States -- Politics and government -- 1829-1837 -- Sources",
+            "Presidents",
+            "Presidents -- United States",
+            "Presidents -- United States -- Correspondence"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            9
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "title": [
+            "The papers of Andrew Jackson"
+          ],
+          "numItemVolumesParsed": [
+            9
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "creatorLiteral": [
+            "Jackson, Andrew, 1767-1845"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Smith, Sam B., 1929-2003",
+            "Owsley, Harriet Chappell, 1901-1999",
+            "Macpherson, Sharon C.",
+            "Remini, Robert V. (Robert Vincent), 1921-2013",
+            "Moser, Harold D.",
+            "Feller, Daniel, 1950-",
+            "Roth, David H.",
+            "Hoemann, George H., 1952-",
+            "Coens, Thomas, 1974-",
+            "Moss, Laura-Eve",
+            "Alexander, Erik B.",
+            "Crawford, Aaron"
+          ],
+          "idOclc": [
+            "5029597"
+          ],
+          "popularity": 47,
+          "uniformTitle": [
+            "Works"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "checkInBoxes": [
+                {
+                  "coverage": "No. 5 (1821 - 1824)",
+                  "position": 1,
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "IAW (Jackson) 80-3099"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "No. 6 (1825 - 1828)",
+                  "position": 2,
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "IAW (Jackson) 80-3099"
+                  ],
+                  "status": "Bound"
+                }
+              ],
+              "holdingStatement": [
+                "1-7,10,12"
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "IAW (Jackson) 80-3099"
+                }
+              ],
+              "physicalLocation": [
+                "IAW (Jackson) 80-3099"
+              ],
+              "location": [
+                {
+                  "code": "loc:mag92",
+                  "label": "Schwarzman Building - Milstein Division Room 121"
+                }
+              ],
+              "shelfMark": [
+                "IAW (Jackson) 80-3099"
+              ],
+              "uri": "h1030920"
+            }
+          ],
+          "summary": [
+            "\"Andrew Jackson is one of the most critical and controversial figures in American history.  A dominant actor on the American scene in the period between the Revolution and Civil War, he stamped his name first on a mass political movement and then an era.  At the same time Jackson's ascendancy accelerated the dispossession and death of Native Americans and spurred the expansion of slavery. 'The Papers of Andrew Jackson' is a project to collect and publish Jackson's entire extant literary record. The project is now producing a series of seventeen volumes that will bring Jackson's most important papers to the public in easily readable form.\"--",
+            "V. 6. This sixth volume of The Papers of Andrew Jackson documents the election on Andrew Jackson, the first westerner and the last veteran of the American Revolution, to the presidency. The four years of this volume chronicle the presidential campaign of 1828. Jackson, winner of the popular vote in 1824 but loser of the election, was once again the reluctant candidate, called into service by the voice of the voters. The campaign, one of the longest in American history, pitted Jackson against the incumbent John Quincy Adams; it was also one of the dirtiest campaigns in American history. The brunt of the mudslinging was aimed at Jackson, and it is covered in detail in this volume. Every aspect of the public and private life of the fifty-eight-year-old former major general in the United States Army came under scrutiny, and in both his opponents found him deficient. According to his detractors, he lacked the moral principles, the temperament, the education, and the family background requisite for a president of the United States. In sum, Jackson resembled the devil incarnate, to use his own words. The mudslinging left Jackson livid, anxious for retribution but constrained by the cause in which he was engaged. The presidential campaign of 1828, in the minds of Jackson and his supporters, was for the cause of truth and democracy against corrupt, self-seeking politicians, an aristocracy of power built upon bargains and dubious political alliances dedicated to its perpetuation in office. The four years covered in this volume were some of the most trying in Jackson s life, but the one event that hurt Jackson the most was the death of his wife. Until his dying day, Jackson contended that her death had been hastened by the slanders of his opponents in the campaign. As great as the loss was for him personally, Jackson nonetheless rejoiced in the results of the election for, in his eyes, the voice of the people had finally been heard. Liberty, not power, had triumphed. Reform was at hand, and retribution would surely follow.",
+            "V. 7. With this seventh volume, The Papers of Andrew Jackson enters the heart of Jackson's career: his tumultuous two terms as president of the United States. The year 1829 began with Jackson fresh from a triumphant victory over incumbent John Quincy Adams in the 1828 campaign, yet mourning the sudden death of his beloved wife, Rachel. In January, having hired an overseer for his Hermitage plantation and arranged for Rachel's tomb, he left Tennessee for Washington. Jackson assumed the presidency with two objectives already fixed in mind: purging the federal bureaucracy of recreant officeholders and removing the southern Indian tribes westward beyond state authority. By year's end he had added two more: purchasing Texas and destroying the Bank of the United States. But meanwhile he found himself diverted, and nearly consumed, by the notorious Peggy Eaton affair--a burgeoning scandal which pitted the president, his Secretary of War John Eaton, and the latter's vivacious wife against the Washington guardians of feminine propriety. This first presidential volume reveals all these stories, and many more, in a depth never seen before. It presents full texts of more than four hundred documents, most printed for the first time. Gathered from a vast array of libraries, archives, and individual owners, they include Jackson's intimate exchanges with family and friends, private notes and musings, and formative drafts of public addresses. Administrative papers range from presidential pardons to military promotions to plans for discharging the public debt. They exhibit Jackson's daily conduct of the executive office in close and sometimes startling detail, and cast new light on such controversial matters as Indian removal and political patronage. Included also are letters to the president from people in every corner of the country and every walk of life: Indian delegations presenting grievances, distraught mothers pleading help for wayward sons, aged veterans begging pensions, politicians offering advice and seeking jobs. Embracing a broad spectrum of actors and events, this volume offers an incomparable window not only into Jackson and his presidency, but into America itself in 1829.",
+            "V. 8. This eighth volume of Andrew Jackson s papers presents more than five hundred documents, many appearing here for the first time, from a core year in Jackson s tumultuous presidency. They include Jackson s handwritten drafts of his presidential messages, private notes and memoranda, and correspondence with government officials, Army and Navy officers, friends and family, Indian leaders, foreign diplomats, and ordinary citizens throughout the country. In 1830 Jackson pursued his controversial Indian removal policy, concluding treaties to compel the Choctaws and Chickasaws west of the Mississippi and refusing protection for the Cherokees against encroachments by Georgia. Jackson nurtured his opposition to the Bank of the United States and entered into an escalating confrontation with the Senate over presidential appointments to office. In April, Jackson pronounced his ban on nullification with the famous toast to Our Federal Union, and in May he began an explosive quarrel with Vice-President John C. Calhoun over the latter s conduct as secretary of war during Jackson s Seminole campaign of 1818. Also in May, Jackson delivered his first presidential veto, stopping federal funding for the Maysville Road and declaring opposition to Henry Clay s American System. In July, Jackson s refusal to use his pardoning power to save an Irish-born mail robber from the gallows provoked a near-riot in Philadelphia. By the end of the year, Jackson was preparing for his reelection campaign in 1832. Meanwhile the sex scandal surrounding Peggy Eaton, wife of the secretary of war, lurked throughout, dividing Jackson s cabinet, sundering his own family and household, and threatening to wreck the administration. Embracing all these stories and many more, this volume offers an incomparable window not only into Andrew Jackson and his presidency but into 1830s America itself.",
+            "V. 9. This volume presents more than five hundred original documents, many newly discovered, from Andrew Jackson s third presidential year. They include Jackson s private memoranda, intimate family letters, and correspondence with government and military officers, diplomats, Indians, political friends and foes, and ordinary citizens throughout the country. In 1831 Jackson finally cleared his contentious Cabinet, reluctantly accepting the resignations of Martin Van Buren and John Eaton and demanding that the other members follow. But in the aftermath, animosities among them boiled over, as Eaton sought duels with outgoing secretaries Samuel Ingham and John Berrien. The affair ended with gangs of armed high-government officers stalking each other in the Washington streets, and with Ingham publicly accusing Jackson of countenancing a plot to assassinate him. Meanwhile, Jackson pursued his feud with Vice-President John C. Calhoun, whom he had come to view as the diabolical manipulator of all his enemies. Enlisting a favorite Supreme Court justice to gather evidence, Jackson crafted an exposition, intended for publication, that leveled nearly fantastic charges against Calhoun and others. Through all this, the business of government ploughed on. Jackson pursued his drive to remove the Cherokees and other Indians west of the Mississippi and to undercut tribal leaders who dared resist. To squelch sectional controversy, Jackson moved to retire the national debt and reduce the tariff, while reiterating his ban on nullification and his opposition to the Bank of the United States. Nat Turner's Virginia slave revolt in August drew a quick administration response. By year s end, the dust over the Cabinet implosion was settling, as Jackson prepared to stand for reelection against his old nemesis Henry Clay. Embracing all these stories and many more, this volume offers an incomparable window not only into Andrew Jackson and his presidency but into America itself in 1831.",
+            "V. 10. This volume presents more than four hundred documents from Andrew Jackson s fourth presidential year. It includes private memoranda, intimate family letters, drafts of official messages, and correspondence with government and military officers, diplomats, Indians, political friends and foes, and ordinary citizens throughout the country. The year 1832 began with Jackson still pursuing his feud with Vice President John C. Calhoun, whom Jackson accused of secretly siding against him in the 1818 controversy over Jackson s Seminole campaign in Florida. The episode ended embarrassingly for Jackson when a key witness, called on to prove his charges, instead directly contradicted them. Indian removal remained a preoccupation for Jackson. The Choctaws began emigrating westward, the Creeks and Chickasaws signed but then immediately protested removal treaties, and the Cherokees won what proved to be an empty victory against removal in the Supreme Court. Illinois Indians mounted armed resistance in the Black Hawk War. In midsummer, a cholera epidemic swept the country, and Jackson was urged to proclaim a day of fasting and prayer. He refused, saying it would intermingle church and state. A bill to recharter the Bank of the United States passed Congress in July, and Jackson vetoed it with a ringing message that became the signature document of his presidency. In November, Jackson, with new running mate Martin Van Buren, won triumphant reelection over Henry Clay. But only days later, South Carolina nullified the federal tariff law and began preparing for armed resistance. Jackson answered with an official proclamation that disunion by armed force is treason. The year closed with Jackson immersed in plans to suppress nullification and destroy the Bank of the United States. Embracing all these stories and many more, this volume offers an incomparable window into Andrew Jackson, his presidency, and America itself in 1832.",
+            "V. 11. This volume presents full annotated text of five hundred documents from Andrew Jackson's fifth presidential year. They include his private memoranda, intimate family letters, presidential message drafts, and correspondence with government and military officers, diplomats, Indian leaders, political friends and foes, and citizens throughout the country.The year 1833 began with a crisis in South Carolina, where a state convention had declared the federal tariff law null and void and pledged resistance by armed force if necessary. Jackson countered by rallying public opinion against the nullifiers, quietly positioning troops and warships, and procuring a \"force bill\" from Congress to compel collection of customs duties. The episode ended peaceably after South Carolina accepted a compromise tariff devised by Jackson's arch-rival Henry Clay. But Clay's surprise cooperation with South Carolina's John C. Calhoun foretold a new opposition coalition against Jackson.With nullification checked, Jackson embarked in June on a triumphal tour to cement his newfound popularity in the North. Ecstatic crowds greeted him in Philadelphia, New York, and Boston, and Harvard awarded him a degree. But Jackson's fragile health broke under the strain, forcing him to cut the tour short. Meanwhile Jackson pursued his campaign against the Bank of the United States, whose recharter he had vetoed in 1832. Charging the Bank with political meddling and corruption, Jackson determined to cripple it by removing federal deposits to state banks. But Treasury secretary William John Duane refused either to give the necessary order or resign. In September Jackson dismissed him and installed Roger Taney to implement the removal. Jackson's bold assumption of authority energized supporters but outraged opponents, prompting Clay to introduce a Senate resolution of censure.The year closed with Jackson girding for further battle over the Bank, pursuing schemes to pry the province of Texas loose from Mexico, and trying to stem rampant land frauds that his own Indian removal policy had unleashed against Creek Indians in Alabama. Unfolding these stories and many more, this volume offers an incomparable window into Andrew Jackson, his presidency, and America itself in 1833.",
+            "V. 12. This volume presents more than five hundred annotated original documents from Andrew Jackson's sixth presidential year. They include his private memoranda, intimate family letters, official messages, and correspondence with government and military officers, diplomats, Indian leaders, political friends and foes, and plain citizens throughout the country.  The year 1834 began with Jackson battling the United States Senate. Pursuing his campaign against the federally chartered Bank of the United States, Jackson in 1833 had installed Roger Taney as interim Treasury secretary to transfer the government's deposits to selected state-chartered \"pet\" banks. The Bank retaliated by curtailing its business, setting off a commercial crisis and a political frenzy. In 1834 the Senate, controlled by the new opposition Whig Party led by Jackson's old nemeses Henry Clay and John C. Calhoun, rejected a slew of Jackson's nominees for office, including Taney, and adopted an unprecedented (and still unparalleled) resolution of censure against Jackson himself. Jackson returned a scathing protest, which the Senate rejected. Meanwhile the administration struggled to implement its \"experiment\" of conducting government finances through state banks.  Throughout the year Jackson pursued his aim of compelling eastern Indians to remove west of the Mississippi. In May the Chickasaws signed a removal treaty. But brazen frauds complicated the administration's scheme to induce individual Creeks to emigrate from Alabama, while the Cherokees, led by Principal Chief John Ross, stood fast in resistance. In June some unauthorized dissident Cherokees signed a removal treaty, but it died in the Senate.  In 1834 Jackson continued his longstanding effort to pry the province of Texas loose from Mexico, while the U.S. hurtled toward confrontation with France over French failure to pay an indemnity due under an 1831 treaty. Other matters engaging Jackson included corruption scandals in the Post Office Department and at Mississippi land offices, fractious disputes over rank and seniority among Army and Navy officers, and a fire that gutted Jackson's Hermitage home in Tennessee. Unfolding these stories and many more, this volume offers a revelatory window into Andrew Jackson, his presidency, and America itself in 1834."
+          ],
+          "genreForm": [
+            "Personal correspondence.",
+            "Sources.",
+            "Correspondence."
+          ],
+          "idIsbn": [
+            "0870492195",
+            "9780870492198",
+            "0870494414",
+            "9780870494413",
+            "0870496506",
+            "9780870496509",
+            "0870497782",
+            "9780870497780",
+            "0870498975",
+            "9780870498978",
+            "1572331747",
+            "9781572331747",
+            "9781572335936",
+            "1572335939",
+            "9781572337152",
+            "157233715X",
+            "9781621900047",
+            "1621900045",
+            "9781621902676",
+            "1621902676",
+            "9781621905387",
+            "1621905381",
+            "9781621907558",
+            "1621907554"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "titleDisplay": [
+            "The papers of Andrew Jackson / Sam B. Smith and Harriet Chappell Owsley, editors ; Robert V. Remini, consulting editor ; Sharon C. Macpherson, associate editor ; Linda D. Keeton, staff assistant."
+          ],
+          "uri": "b10685709",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Knoxville"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Book review (H-Net)",
+              "url": "http://www.h-net.org/review/hrev-a0c8q7-aa"
+            },
+            {
+              "label": "Book review (H-Net)",
+              "url": "http://www.h-net.org/reviews/showrev.php?id=25345"
+            },
+            {
+              "label": "Book review (H-Net)",
+              "url": "http://www.h-net.org/reviews/showrev.php?id=7356"
+            }
+          ],
+          "dimensions": [
+            "25 cm"
+          ],
+          "idIsbn_clean": [
+            "0870492195",
+            "9780870492198",
+            "0870494414",
+            "9780870494413",
+            "0870496506",
+            "9780870496509",
+            "0870497782",
+            "9780870497780",
+            "0870498975",
+            "9780870498978",
+            "1572331747",
+            "9781572331747",
+            "9781572335936",
+            "1572335939",
+            "9781572337152",
+            "157233715X",
+            "9781621900047",
+            "1621900045",
+            "9781621902676",
+            "1621902676",
+            "9781621905387",
+            "1621905381",
+            "9781621907558",
+            "1621907554"
+          ]
+        },
+        "sort": [
+          261.14557,
+          "b10685709"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "popularity >= 10",
+          "popularity >= 20",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 9,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b10685709",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "enumerationChronology": [
+                      "v. 12"
+                    ],
+                    "enumerationChronology_sort": "        12-",
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building - Milstein Division Room 121"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:IAW (Jackson) 80-3099",
+                      "urn:barcode:33433137385237"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "IAW (Jackson) 80-3099",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433137385237",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433137385237"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "IAW (Jackson) 80-3099"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "IAW (Jackson) 80-3099"
+                    ],
+                    "shelfMark_sort": "aIAW (Jackson) 80-003099",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i40826956",
+                    "volumeRange": [
+                      {
+                        "gte": 12,
+                        "lte": 12
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "        12-"
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b10685709",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "enumerationChronology": [
+                      "v. 10"
+                    ],
+                    "enumerationChronology_sort": "        10-",
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building - Milstein Division Room 121"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:IAW (Jackson) 80-3099",
+                      "urn:barcode:33433119383762"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "IAW (Jackson) 80-3099",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433119383762",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433119383762"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "IAW (Jackson) 80-3099"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "IAW (Jackson) 80-3099"
+                    ],
+                    "shelfMark_sort": "aIAW (Jackson) 80-003099",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i34456277",
+                    "volumeRange": [
+                      {
+                        "gte": 10,
+                        "lte": 10
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "        10-"
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b10685709",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "enumerationChronology": [
+                      "v. 7"
+                    ],
+                    "enumerationChronology_sort": "         7-",
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building - Milstein Division Room 121"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:IAW (Jackson) 80-3099",
+                      "urn:barcode:33433079269134"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "IAW (Jackson) 80-3099",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433079269134",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433079269134"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "IAW (Jackson) 80-3099"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "IAW (Jackson) 80-3099"
+                    ],
+                    "shelfMark_sort": "aIAW (Jackson) 80-003099",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17468525",
+                    "volumeRange": [
+                      {
+                        "gte": 7,
+                        "lte": 7
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         7-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b15525663",
+        "_score": 24.086899,
+        "_source": {
+          "extent": [
+            "v. ill. (part col.) ports."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "1st-      1887?-"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc",
+            "ma"
+          ],
+          "createdYear": [
+            1887
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "IAA (New York Southern Society. Account of proceedings at the annual banquet)"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1887
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "IAA (New York Southern Society. Account of proceedings at the annual banquet)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15525663"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "10936985"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)Z040000001"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "New York Genealogical and Biographical Society Collection||New York Genealogical and Biographical Society Collection"
+          ],
+          "updatedAt": 1779425270812,
+          "publicationStatement": [
+            "New York."
+          ],
+          "identifier": [
+            "urn:shelfmark:IAA (New York Southern Society. Account of proceedings at the annual banquet)",
+            "urn:bnum:15525663",
+            "urn:oclc:10936985",
+            "urn:identifier:(WaOLN)Z040000001"
+          ],
+          "creators_displayPacked": [
+            "New York Southern Society||New York Southern Society"
+          ],
+          "dates": [
+            {
+              "range": {
+                "gte": "1887",
+                "lte": "9999"
+              },
+              "raw": "840711u1887uuuunyuar         0   a0eng dnasI  ",
+              "tag": "u"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "New York Southern Society.",
+            "Societies -- New York (State) -- New York."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mag"
+          ],
+          "physicalDescription": [
+            "v. : ill. (part col.) ports. ; 19-31 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Some nos. issued with variant title: Annual dinner.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Gift; New York Genealogical and Biographical Society; 2008.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "New York Southern Society",
+            "Societies",
+            "Societies -- New York (State)",
+            "Societies -- New York (State) -- New York"
+          ],
+          "numItemDatesParsed": [
+            3
+          ],
+          "numItemsTotal": [
+            3
+          ],
+          "dateEndString": [
+            "uuuu"
+          ],
+          "title": [
+            "Annual banquet."
+          ],
+          "numItemVolumesParsed": [
+            3
+          ],
+          "createdString": [
+            "1887"
+          ],
+          "creatorLiteral": [
+            "New York Southern Society"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "New York Genealogical and Biographical Society Collection"
+          ],
+          "donor": [
+            "Gift of New York Genealogical and Biographical Society."
+          ],
+          "idOclc": [
+            "10936985"
+          ],
+          "popularity": 5,
+          "dateEndYear": [
+            null
+          ],
+          "summary": [
+            "Consists of menu, toasts, officers, songs, etc."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1887"
+          ],
+          "titleDisplay": [
+            "Annual banquet."
+          ],
+          "uri": "b15525663",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "19-31 cm."
+          ]
+        },
+        "sort": [
+          24.086899,
+          "b15525663"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 3,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b15525663",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:29",
+                        "label": "bundled materials (vols.)"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:29||bundled materials (vols.)"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1924",
+                        "lte": "1927"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "no. 39-42 (1924-27)"
+                    ],
+                    "enumerationChronology_sort": "        39-1924",
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmg2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmg2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:IAA (New York Southern Society. Account of proceedings at the annual banquet)",
+                      "urn:barcode:33433084518764"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "IAA (New York Southern Society. Account of proceedings at the annual banquet)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433084518764",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433084518764"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "physicalLocation": [
+                      "IAA (New York Southern Society. Account of proceedings at the annual banquet)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "IAA (New York Southern Society. Account of proceedings at the annual banquet)"
+                    ],
+                    "shelfMark_sort": "aIAA (New York Southern Society. Account of proceedings at the annual banquet)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i23238207",
+                    "volumeRange": [
+                      {
+                        "gte": 39,
+                        "lte": 42
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "        39-1924"
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b15525663",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1889",
+                        "lte": "1889"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "no. 3 (1889)"
+                    ],
+                    "enumerationChronology_sort": "         3-1889",
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building - Milstein Division Room 121"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:NYGB N.Y. L M314.77 S68",
+                      "urn:barcode:33433087266205"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "NYGB N.Y. L M314.77 S68",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433087266205",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433087266205"
+                    ],
+                    "m2CustomerCode": [
+                      "XA"
+                    ],
+                    "physicalLocation": [
+                      "NYGB N.Y. L M314.77 S68"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "NYGB N.Y. L M314.77 S68"
+                    ],
+                    "shelfMark_sort": "aNYGB N.Y. L M314.77 S000068",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i24792528",
+                    "volumeRange": [
+                      {
+                        "gte": 3,
+                        "lte": 3
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         3-1889"
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b15525663",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1887",
+                        "lte": "1887"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "no. 1 (1887)"
+                    ],
+                    "enumerationChronology_sort": "         1-1887",
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmg2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmg2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:IAA (New York Southern Society. Account of proceedings at the annual banquet)",
+                      "urn:barcode:33433084518756"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "IAA (New York Southern Society. Account of proceedings at the annual banquet)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433084518756",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433084518756"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "physicalLocation": [
+                      "IAA (New York Southern Society. Account of proceedings at the annual banquet)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "IAA (New York Southern Society. Account of proceedings at the annual banquet)"
+                    ],
+                    "shelfMark_sort": "aIAA (New York Southern Society. Account of proceedings at the annual banquet)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i23238206",
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         1-1887"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b15994132",
+        "_score": 20.451763,
+        "_source": {
+          "extent": [
+            "1 videocassette (VHS, NTSC) (58 min.) : sd., col. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*MGZIA 4-4451"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1984
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*MGZIA 4-4451"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15994132"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPT04-F167"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)t280000016"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Champion, Marge||Champion, Marge",
+            "Thompson, Caro||Thompson, Caro, videographer",
+            "Jacob's Pillow Dance Festival||Jacob's Pillow Dance Festival"
+          ],
+          "updatedAt": 1779431654198,
+          "publicationStatement": [
+            "1984."
+          ],
+          "identifier": [
+            "urn:shelfmark:*MGZIA 4-4451",
+            "urn:bnum:15994132",
+            "urn:oclc:NYPT04-F167",
+            "urn:identifier:(WaOLN)t280000016"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "lt": "1985",
+                "gte": "1984"
+              },
+              "raw": "040929s1984    mau058            vleng dngm a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Morris dance.",
+            "Break dancing."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "s",
+          "collectionIds": [
+            "pad"
+          ],
+          "physicalDescription": [
+            "1 videocassette (VHS, NTSC) (58 min.) : sd., col. ; 1/2 in."
+          ],
+          "tableOfContents": [
+            "June, 1984. Opening night: Morris dancers (11 min.) -- Audience toast (4 min.)",
+            "June 23, 1984. Gala festivities (19 min.)",
+            "Aug. 3, 1984. Hubbard Street raffle (8 min.)",
+            "[n.d.] Breakdancers from Pittsfield (16 min.)"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title from original container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Camera: Caro Thompson.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Videotaped at Jacob's Pillow, Becket, Mass., June 23, Aug. 3 and other dates in summer 1984.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Morris dance",
+            "Break dancing"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Jacob's Pillow. special events."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Champion, Marge",
+            "Thompson, Caro",
+            "Jacob's Pillow Dance Festival"
+          ],
+          "donor": [
+            "Gift of Jacob's Pillow Dance Festival."
+          ],
+          "idOclc": [
+            "NYPT04-F167"
+          ],
+          "summary": [
+            "This tape is a compilation of footage from special events during the 1984 season at Jacob's Pillow. The first segment includes footage from opening night festivities, including performances by the Pokingbrook Morris dancers and female garland dancers. The second segment records a brief presentation by Jacob's Pillow director Liz Thompson and dance patron Irene Hunter. Thompson speaks about the first appearance by the Martha Graham company at Jacob's Pillow and her own experience as a Graham dancer, and announces the naming of a building at Jacob's Pillow for Irene Hunter. Thompson proposes an audience toast to Hunter and Graham, and Hunter proposes a toast to Thompson. The third segment on the tape includes footage from outdoor daytime Gala festivities, including performances by two clowns making balloon sculptures, stilt-walkers, and breakdancers from the Rockwell Association. The fourth segment records a raffle held after a performance by the Hubbard Street Dance Company. The segment starts with the curtain calls following the performance; Marge Champion draws seat numbers and announces prizes for members of the audience. The last segment of the tape records breakdancing by a group of children and teenagers from Pittsfield."
+          ],
+          "genreForm": [
+            "Dance.",
+            "Video."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mov",
+              "label": "Moving image"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "titleDisplay": [
+            "Jacob's Pillow. 1984 [videorecording] : special events."
+          ],
+          "uri": "b15994132",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null
+          ],
+          "recordTypeId": "g",
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "1/2 in."
+          ]
+        },
+        "sort": [
+          20.451763,
+          "b15994132"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b15994132",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&CallNumber=*MGZIA+4-4451&Date=1984&Form=30&Genre=archival+video+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15994132&ItemISxN=i154045846&ItemNumber=33433064016748&ItemPublisher=1984.&Location=Performing+Arts+Dance+Division&ReferenceNumber=b159941325&Site=LPADNAMI&Title=Jacob%27s+Pillow.+special+events."
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:24",
+                        "label": "archival video recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:24||archival video recording"
+                    ],
+                    "formatLiteral": [
+                      "VHS"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pad22",
+                        "label": "Performing Arts Research Collections - Dance"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pad22||Performing Arts Research Collections - Dance"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*MGZIA 4-4451",
+                      "urn:barcode:33433064016748"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*MGZIA 4-4451",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433064016748",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433064016748"
+                    ],
+                    "physicalLocation": [
+                      "*MGZIA 4-4451"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*MGZIA 4-4451"
+                    ],
+                    "shelfMark_sort": "a*MGZIA 4-004451",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15404584"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b15316446",
+        "_score": 19.72424,
+        "_source": {
+          "extent": [
+            "v. ; 24 cm."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Conservative Book Club"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1964
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "L-11 536"
+          ],
+          "parallelCreators_displayPacked": [],
+          "addedAuthorTitle": [
+            "Big man.",
+            "How to win an election.",
+            "Screwtape proposes a toast.",
+            "Convenient state."
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "L-11 536"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15316446"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "2868147"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)R130000021"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Taylor, Henry J. (Henry Junior), 1902-1984||Taylor, Henry J. (Henry Junior), 1902-1984. Big man",
+            "Shadegg, Stephen C.||Shadegg, Stephen C. How to win an election",
+            "Lewis, C. S. (Clive Staples), 1898-1963||Lewis, C. S. (Clive Staples), 1898-1963. Screwtape proposes a toast",
+            "Wills, Garry, 1934-||Wills, Garry, 1934- Convenient state"
+          ],
+          "updatedAt": 1779421647562,
+          "publicationStatement": [
+            "New Rochelle, N.Y. : Conservative Book Club, c1964-"
+          ],
+          "identifier": [
+            "urn:shelfmark:L-11 536",
+            "urn:bnum:15316446",
+            "urn:oclc:2868147",
+            "urn:identifier:(WaOLN)R130000021"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "gte": "1964",
+                "lte": "9999"
+              },
+              "raw": "770407m19649999nyu           000 0beng dcamIi ",
+              "tag": "m"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [
+            "mal"
+          ],
+          "physicalDescription": [
+            "v. ; 24 cm."
+          ],
+          "tableOfContents": [
+            "v. 1 The big man, by H.J. Taylor. - How to win an election, by S.C. Shadegg. - Screwtape proposes a toast, by C.S. Lewis. - The convenient state,   by G. Wills."
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "title": [
+            "Omnibus."
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Taylor, Henry J. (Henry Junior), 1902-1984",
+            "Shadegg, Stephen C.",
+            "Lewis, C. S. (Clive Staples), 1898-1963",
+            "Wills, Garry, 1934-"
+          ],
+          "idOclc": [
+            "2868147"
+          ],
+          "popularity": 1,
+          "dateEndYear": [
+            9999
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "titleDisplay": [
+            "Omnibus."
+          ],
+          "uri": "b15316446",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New Rochelle, N.Y."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          19.72424,
+          "b15316446"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b15316446",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "enumerationChronology_sort": "         5-",
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:L-11 536",
+                      "urn:barcode:33433002566952"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "L-11 536",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433002566952",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433002566952"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "physicalLocation": [
+                      "L-11 536"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "L-11 536"
+                    ],
+                    "shelfMark_sort": "aL-11 000536",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i12377117",
+                    "volumeRange": [
+                      {
+                        "gte": 5,
+                        "lte": 5
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         5-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b14565371",
+        "_score": 19.656548,
+        "_source": {
+          "extent": [
+            "3 v. : music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Ling Physical Education Association"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            198
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*MGS (Scandinavian) 00-3559"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            198
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*MGS (Scandinavian) 00-3559"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "14565371"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "8946872"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPY00-C7"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)Y210000097"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)8946872"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779410668176,
+          "publicationStatement": [
+            "London : Ling Physical Education Association, [19--]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*MGS (Scandinavian) 00-3559",
+            "urn:bnum:14565371",
+            "urn:oclc:8946872",
+            "urn:oclc:NYPY00-C7",
+            "urn:identifier:(WaOLN)Y210000097",
+            "urn:identifier:(OCoLC)8946872"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "lt": "1990",
+                "gte": "1900"
+              },
+              "raw": "000421m19uu1989enkdfc   r     n    eng dncm a ",
+              "tag": "m"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Folk dance music -- Scandinavia.",
+            "Folk dancing -- Scandinavia.",
+            "Piano music, Arranged."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "c",
+          "collectionIds": [
+            "pad"
+          ],
+          "physicalDescription": [
+            "3 v. : music ; 26 cm."
+          ],
+          "tableOfContents": [
+            "First series: Shoemaker ; Cochin China ; Ace of diamonds ; Mountain march ; Clap dance ; Little man in a fix ; French reel ; Swedish schottische ; Rospiggspolska ; Varsovienne ; Toast to King Gustav ; Oxdansen.",
+            "Second series: Mangling ; The bow ; Matrosdans ; Girls' joy ; Kontramarsch ; Napoleon ; Tantoli ; Gallopink ; Kontrasejre ; Finger polka ; Hornfiffen ; Swedish masquerade."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Music for piano, with directions for the dances.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Folk dance music",
+            "Folk dance music -- Scandinavia",
+            "Folk dancing",
+            "Folk dancing -- Scandinavia",
+            "Piano music, Arranged"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1989"
+          ],
+          "title": [
+            "Scandinavian dance music."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "198"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "8946872",
+            "NYPY00-C7"
+          ],
+          "dateEndYear": [
+            1989
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "198"
+          ],
+          "titleDisplay": [
+            "Scandinavian dance music."
+          ],
+          "uri": "b14565371",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          19.656548,
+          "b14565371"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b14565371",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pad32",
+                        "label": "Performing Arts Research Collections - Dance"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pad32||Performing Arts Research Collections - Dance"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*MGS (Scandinavian) 00-3559 Library has: 1st-2nd series",
+                      "urn:barcode:33433093051658"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*MGS (Scandinavian) 00-3559 Library has: 1st-2nd series",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433093051658",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433093051658"
+                    ],
+                    "physicalLocation": [
+                      "*MGS (Scandinavian) 00-3559 Library has: 1st-2nd series"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "*MGS (Scandinavian) 00-3559 Library has: 1st-2nd series"
+                    ],
+                    "shelfMark_sort": "a*MGS (Scandinavian) 00-3559 Library has: 1st-2nd series",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17050295"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b14725291",
+        "_score": 19.124489,
+        "_source": {
+          "extent": [
+            "1 sound disc (50 min.) : digital ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Varèse Sarabande"
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1985
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LDC 23438 (F)"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1985
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 23438 (F)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "14725291"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "15721299"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "VCD 47238 Varèse Sarabande"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)M210000192"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779412771658,
+          "publicationStatement": [
+            "North Hollywood, Calif. : Varèse Sarabande, p1985."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 23438 (F)",
+            "urn:bnum:14725291",
+            "urn:oclc:15721299",
+            "urn:identifier:VCD 47238 Varèse Sarabande",
+            "urn:identifier:(WaOLN)M210000192"
+          ],
+          "creators_displayPacked": [
+            "Goldsmith, Jerry||Goldsmith, Jerry"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1986",
+                "gte": "1985"
+              },
+              "raw": "870521s1985    caumpn   i              dnjmIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Motion picture music."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "y",
+          "collectionIds": [
+            "pah"
+          ],
+          "titleAlt": [
+            "Blue Max."
+          ],
+          "physicalDescription": [
+            "1 sound disc (50 min.) : digital ; 4 3/4 in."
+          ],
+          "tableOfContents": [
+            "Main title -- The new arrival -- First blood -- The first victory -- The victim -- A toast to Bruno -- The attack, parts I & II -- A lonely hero -- A small favor -- The lovers -- Finale, part I -- Prelude, part II -- The bridge -- Stachel's confession -- Retreat, parts I & II -- Stachel in Berlin, parts I & II -- Kaeti has a plan -- Stachel's last flight -- End title."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes by Tony Thomas and Len Engel ([8] p. : ill.) inserted in container.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Motion picture music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "The Blue Max original motion picture soundtrack"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "creatorLiteral": [
+            "Goldsmith, Jerry"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "15721299"
+          ],
+          "uniformTitle": [
+            "Blue Max. Selections",
+            "Blue Max (Motion picture)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "titleDisplay": [
+            "The Blue Max [sound recording] : original motion picture soundtrack / music composed and conducted by Jerry Goldsmith."
+          ],
+          "uri": "b14725291",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "North Hollywood, Calif."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          19.124489,
+          "b14725291"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b14725291",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 23438 (F)",
+                      "urn:barcode:33433047707090"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LDC 23438 (F)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433047707090",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433047707090"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 23438 (F)"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LDC 23438 (F)"
+                    ],
+                    "shelfMark_sort": "a*LDC 23438 (F)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i14506177"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b16320555",
+        "_score": 19.124489,
+        "_source": {
+          "extent": [
+            "1 sound disc (55 min.) : analog, 33 1/3 rpm, stereo. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Angel"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            198
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LSRX 17659 (F)"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            198
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LSRX 17659 (F)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16320555"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "13748095"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "AV-34005 Angel"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A040000125"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Meilhac, Henri, 1831-1897||Meilhac, Henri, 1831-1897",
+            "Halévy, Ludovic, 1834-1908||Halévy, Ludovic, 1834-1908",
+            "Bumbry, Grace, 1937-2023||Bumbry, Grace, 1937-2023",
+            "Vickers, Jon||Vickers, Jon",
+            "Freni, Mirella, 1935-2020||Freni, Mirella, 1935-2020",
+            "Frühbeck de Burgos, Rafael||Frühbeck de Burgos, Rafael",
+            "Opéra de Paris||Opéra de Paris"
+          ],
+          "updatedAt": 1779435408414,
+          "publicationStatement": [
+            "Hollywood, Calif. : Angel, [198-?]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LSRX 17659 (F)",
+            "urn:bnum:16320555",
+            "urn:oclc:13748095",
+            "urn:identifier:AV-34005 Angel",
+            "urn:identifier:(WaOLN)A040000125"
+          ],
+          "creators_displayPacked": [
+            "Bizet, Georges, 1838-1875||Bizet, Georges, 1838-1875"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1990",
+                "gte": "1980"
+              },
+              "raw": "860619s198u    cauopn   dz         fre dcjmIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "j",
+          "collectionIds": [
+            "pah"
+          ],
+          "titleAlt": [
+            "Carmen."
+          ],
+          "physicalDescription": [
+            "1 sound disc (55 min.) : analog, 33 1/3 rpm, stereo. ; 12 in."
+          ],
+          "tableOfContents": [
+            "Prelude (3:28) -- La voilà ; L'amour est un oiseau rebelle (5:29) -- Parle-moi de ma mère! (9:10) -- Près des remparts de Seville-- Tais-toi! (4:38) -- Votre toast (4:59) -- La fleur que tu m'avais jeté (4:15) -- Mêlons! Coupons! (7:05) -- Je dis que rien ne m'épouvante (5:45) -- C'est toi! C'est moi! (9:40)."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Previously released.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes in English and texts in French with English translations ([4] p.) inserted in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in French.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "title": [
+            "Carmen highlights"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "198u"
+          ],
+          "creatorLiteral": [
+            "Bizet, Georges, 1838-1875"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Meilhac, Henri, 1831-1897",
+            "Halévy, Ludovic, 1834-1908",
+            "Bumbry, Grace, 1937-2023",
+            "Vickers, Jon",
+            "Freni, Mirella, 1935-2020",
+            "Frühbeck de Burgos, Rafael",
+            "Opéra de Paris"
+          ],
+          "idOclc": [
+            "13748095"
+          ],
+          "uniformTitle": [
+            "Carmen. Selections"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "198u"
+          ],
+          "titleDisplay": [
+            "Carmen [sound recording] : highlights / Bizet ; [libretto by Henri Meilhac & Ludovic Halévy]."
+          ],
+          "uri": "b16320555",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Hollywood, Calif."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          19.124489,
+          "b16320555"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16320555",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LSRX 17659 (F) [Texts]",
+                      "urn:barcode:33433035625338"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LSRX 17659 (F) [Texts]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433035625338",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433035625338"
+                    ],
+                    "physicalLocation": [
+                      "*LSRX 17659 (F) [Texts]"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "*LSRX 17659 (F) [Texts]"
+                    ],
+                    "shelfMark_sort": "a*LSRX 17659 (F) [Texts]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15632020"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16320555",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Bizet%2C+Georges%2C+1838-1875&CallNumber=*LSRX+17659+%28F%29+%5BDisc%5D&Date=198u&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16320555&ItemISxN=i156320198&ItemNumber=33433035626013&ItemPlace=Hollywood%2C+Calif.&ItemPublisher=Angel%2C+%5B198-%3F%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b163205553&Site=LPAMRAMI&Title=Carmen+highlights"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LSRX 17659 (F) [Disc]",
+                      "urn:barcode:33433035626013"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LSRX 17659 (F) [Disc]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433035626013",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433035626013"
+                    ],
+                    "physicalLocation": [
+                      "*LSRX 17659 (F) [Disc]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LSRX 17659 (F) [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LSRX 17659 (F) [Disc]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15632019"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b16739633",
+        "_score": 19.124489,
+        "_source": {
+          "extent": [
+            "1 sound disc (55 min.) : analog, 33 1/3 rpm, stereo. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Erato ; RCA Records [distributor]"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LSRX 15843"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1984
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LSRX 15843"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16739633"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11575926"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "HBC1-5302 Erato"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A110000037"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Migenes-Johnson, Julia||Migenes-Johnson, Julia",
+            "Domingo, Plácido, 1941-||Domingo, Plácido, 1941-, performer",
+            "Raimondi, Ruggero||Raimondi, Ruggero",
+            "Esham, Faith||Esham, Faith",
+            "Daniel, Susan||Daniel, Susan",
+            "Watson, Lillian||Watson, Lillian, performer",
+            "Bogart, John-Paul||Bogart, John-Paul, performer",
+            "Le Roux, François||Le Roux, François",
+            "Maazel, Lorin, 1930-2014||Maazel, Lorin, 1930-2014",
+            "Orchestre national de France||Orchestre national de France"
+          ],
+          "updatedAt": 1779469864834,
+          "publicationStatement": [
+            "[France] : Erato ; New York : RCA Records [distributor], c1984."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LSRX 15843",
+            "urn:bnum:16739633",
+            "urn:oclc:11575926",
+            "urn:identifier:HBC1-5302 Erato",
+            "urn:identifier:(WaOLN)A110000037"
+          ],
+          "creators_displayPacked": [
+            "Bizet, Georges, 1838-1875||Bizet, Georges, 1838-1875"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1985",
+                "gte": "1984"
+              },
+              "raw": "850114s1984    fr opn              fre dcjmKa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Operas -- Excerpts.",
+            "Motion picture music -- Excerpts."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "j",
+          "collectionIds": [
+            "pah"
+          ],
+          "titleAlt": [
+            "Carmen."
+          ],
+          "physicalDescription": [
+            "1 sound disc (55 min.) : analog, 33 1/3 rpm, stereo. ; 12 in."
+          ],
+          "tableOfContents": [
+            "Habanera : \"L'amour est un oiseau rebelle\" -- Duo : \"Parle-moi de ma mère\" -- Séguedille et duo : \"Près des remparts de Séville\" -- Chanson bohème : \"Les tringles des sistres tintaient\" -- Couplets : \"Votre toast, je peux vous le rendre\" -- \"La fleur que tu m'avais jetée\" -- Air : \"Je dis que rien ne m'épouvante\" -- Marche et chœur final : \"C'est toi?\" -- \"C'est moi!\""
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Excerpts from the original soundtrack of the film by Francesco Rosi.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Digital recording.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts",
+            "Motion picture music",
+            "Motion picture music -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Carmen (excerpts)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [
+            "Bizet, Georges, 1838-1875"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Migenes-Johnson, Julia",
+            "Domingo, Plácido, 1941-",
+            "Raimondi, Ruggero",
+            "Esham, Faith",
+            "Daniel, Susan",
+            "Watson, Lillian",
+            "Bogart, John-Paul",
+            "Le Roux, François",
+            "Maazel, Lorin, 1930-2014",
+            "Orchestre national de France"
+          ],
+          "idOclc": [
+            "11575926"
+          ],
+          "uniformTitle": [
+            "Carmen. Selections"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "titleDisplay": [
+            "Carmen [sound recording] : (excerpts) / Georges Bizet."
+          ],
+          "uri": "b16739633",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[France] : New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          19.124489,
+          "b16739633"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16739633",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Bizet%2C+Georges%2C+1838-1875&CallNumber=*LSRX+15843+%5BDisc%5D&Date=1984&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16739633&ItemISxN=i174199776&ItemNumber=33433067981898&ItemPlace=%5BFrance%5D+%3A+New+York&ItemPublisher=Erato+%3B+RCA+Records+%5Bdistributor%5D%2C+c1984.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b16739633x&Site=LPAMRAMI&Title=Carmen+%28excerpts%29"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LSRX 15843 [Disc]",
+                      "urn:barcode:33433067981898"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LSRX 15843 [Disc]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433067981898",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433067981898"
+                    ],
+                    "physicalLocation": [
+                      "*LSRX 15843 [Disc]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LSRX 15843 [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LSRX 15843 [Disc]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17419977"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b16319759",
+        "_score": 18.740334,
+        "_source": {
+          "extent": [
+            "1 sound disc : analog, 33 1/3 rpm, stereo. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Stax"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LSRX 17345 (C)"
+          ],
+          "idLccn": [
+            "95785357"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1984
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LSRX 17345 (C)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16319759"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "13676631"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "95785357"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "MPS-8526 Stax"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A280000022"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Hester, Tony||Hester, Tony"
+          ],
+          "updatedAt": 1779435395575,
+          "publicationStatement": [
+            "Berkeley, Calif. : Stax, p1984."
+          ],
+          "identifier": [
+            "urn:shelfmark:*LSRX 17345 (C)",
+            "urn:bnum:16319759",
+            "urn:oclc:13676631",
+            "urn:lccn:95785357",
+            "urn:identifier:MPS-8526 Stax",
+            "urn:identifier:(WaOLN)A280000022"
+          ],
+          "creators_displayPacked": [
+            "Dramatics (Musical group)||Dramatics (Musical group), performer"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1985",
+                "gte": "1984"
+              },
+              "raw": "860602s1984    caubln              eng dcjm a ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Rhythm and blues music."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "j",
+          "collectionIds": [
+            "pah"
+          ],
+          "physicalDescription": [
+            "1 sound disc : analog, 33 1/3 rpm, stereo. ; 12 in."
+          ],
+          "tableOfContents": [
+            "Whatcha see is whatcha get (3:32) -- Thankful for your love (4:25) -- Get up and get down (3:10) -- Fall in love lady love (3:34) -- And I panicked / Jimmy Roach (3:34) -- In the rain (5:08) -- Toast to the fool / Snyder-Davis (4:13) -- Hey you! Get off my mountain (3:28) -- Fell for you (3:12) -- The Devil is dope (3:38)."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Rhythm and blues music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "All selections by Tony Hester except as indicated.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"All selections previously released as Volt singles\"--Container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes by Jack Sbarbori on container.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Rhythm and blues music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "The best of the Dramatics"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [
+            "Dramatics (Musical group)"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Hester, Tony"
+          ],
+          "idOclc": [
+            "13676631"
+          ],
+          "popularity": 1,
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "titleDisplay": [
+            "The best of the Dramatics [sound recording]."
+          ],
+          "uri": "b16319759",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Berkeley, Calif."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          18.740334,
+          "b16319759"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16319759",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Dramatics+%28Musical+group%29&CallNumber=*LSRX+17345+%28C%29+%5BDisc%5D&Date=1984&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16319759&ItemISxN=i156311252&ItemNumber=33433035629520&ItemPlace=Berkeley%2C+Calif.&ItemPublisher=Stax%2C+p1984.&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b163197593&Site=LPAMRAMI&Title=The+best+of+the+Dramatics"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LSRX 17345 (C) [Disc]",
+                      "urn:barcode:33433035629520"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LSRX 17345 (C) [Disc]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433035629520",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433035629520"
+                    ],
+                    "physicalLocation": [
+                      "*LSRX 17345 (C) [Disc]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LSRX 17345 (C) [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LSRX 17345 (C) [Disc]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15631125"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b16871054",
+        "_score": 17.928158,
+        "_source": {
+          "extent": [
+            "3 sound cassettes : analog, stereo."
+          ],
+          "partOf": [
+            "New York Shakespeare Festival records, 1954-1992."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            198
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LTC 6497"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            198
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LTC 6497"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16871054"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "234238497"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)234238497"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Papp, Gail Merrifield||Papp, Gail Merrifield, donor",
+            "New York Shakespeare Festival Public Theater||New York Shakespeare Festival Public Theater, donor"
+          ],
+          "updatedAt": 1779472032451,
+          "publicationStatement": [
+            "[1980]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LTC 6497",
+            "urn:bnum:16871054",
+            "urn:oclc:234238497",
+            "urn:identifier:(OCoLC)234238497"
+          ],
+          "creators_displayPacked": [
+            "Kleban, Edward||Kleban, Edward"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1990",
+                "gte": "1980"
+              },
+              "raw": "080718s198u    nyuuunn           n eng dnjdIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Songs (Medium voice) with piano.",
+            "Musical theater -- New York (State) -- New York.",
+            "Music rehearsals."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "j",
+          "collectionIds": [
+            "pah"
+          ],
+          "titleAlt": [
+            "Dinner music",
+            "New York Shakespeare Festival recordings collection."
+          ],
+          "physicalDescription": [
+            "3 sound cassettes : analog, stereo."
+          ],
+          "tableOfContents": [
+            "[Cassette 1] Side 1. Last blue song -- I won't be there -- Listening to you -- [Morning] (1st draft)",
+            "[Cassette 1] Side 2. [God grant us bread] -- The last judgement.",
+            "[Cassette 2] Side 1. I like a peach -- Fruit -- French toast -- Married him (1st version)",
+            "[Cassette 3] Side 1. Unaccustomed -- Still life -- Married him (2nd version) -- Mona.",
+            "[Cassette 3] Side 2. Mona (Song and rehearsal)"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title from spine (Cassette 1)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Separated from the New York Shakespeare Festival records; for papers, see the Billy Rose Theatre Collection, *T-Mss 1993-028; for sheet music and scores, see the Music Division, JPB 04-03.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Forms part of: New York Shakespeare Festival recordings collection.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Songs (Medium voice) with piano",
+            "Musical theater",
+            "Musical theater -- New York (State)",
+            "Musical theater -- New York (State) -- New York",
+            "Music rehearsals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            3
+          ],
+          "title": [
+            "Gallery demo songs in rehearsal."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "198u"
+          ],
+          "creatorLiteral": [
+            "Kleban, Edward"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Papp, Gail Merrifield",
+            "New York Shakespeare Festival Public Theater"
+          ],
+          "idOclc": [
+            "234238497"
+          ],
+          "summary": [
+            "Cassettes contain rehearsal demo (vocals and piano) of songs and background piano music from the unproduced musical production of Gallery. Each track started out with a final version of song with vocals and piano by Ed Kleban, followed by several rehearsals of each song."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "198u"
+          ],
+          "titleDisplay": [
+            "Gallery [sound recording] : demo songs in rehearsal."
+          ],
+          "uri": "b16871054",
+          "parallelContributorLiteral": [
+            null,
+            null
+          ],
+          "recordTypeId": "j",
+          "issuance": [
+            {
+              "id": "urn:biblevel:d",
+              "label": "subunit"
+            }
+          ]
+        },
+        "sort": [
+          17.928158,
+          "b16871054"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 3,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16871054",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Kleban%2C+Edward&CallNumber=*LTC+6497+%5BCassette%5D&Date=198u&Form=30&Genre=archival+sound+recording&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16871054&ItemISxN=i177251888&ItemNumber=33433077370777&ItemPublisher=%5B1980%5D&ItemVolume=3+of+3&Location=ReCAP&ReferenceNumber=b168710547&Site=LPAMRAMI&SubLocation=rcph9&Title=Gallery+demo+songs+in+rehearsal."
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:23",
+                        "label": "archival sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:23||archival sound recording"
+                    ],
+                    "enumerationChronology": [
+                      "3 of 3"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcph9",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcph9||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LTC 6497 [Cassette]",
+                      "urn:barcode:33433077370777"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LTC 6497 [Cassette]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433077370777",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433077370777"
+                    ],
+                    "physicalLocation": [
+                      "*LTC 6497 [Cassette]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LTC 6497 [Cassette]"
+                    ],
+                    "shelfMark_sort": "a*LTC 6497 [Cassette]",
+                    "status": [
+                      {
+                        "id": "status:v",
+                        "label": "Preservation"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:v||Preservation"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17725188"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16871054",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Kleban%2C+Edward&CallNumber=*LTC+6497+%5BCassette%5D&Date=198u&Form=30&Genre=archival+sound+recording&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16871054&ItemISxN=i177251876&ItemNumber=33433077362139&ItemPublisher=%5B1980%5D&ItemVolume=2+of+3&Location=ReCAP&ReferenceNumber=b168710547&Site=LPAMRAMI&SubLocation=rcph9&Title=Gallery+demo+songs+in+rehearsal."
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:23",
+                        "label": "archival sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:23||archival sound recording"
+                    ],
+                    "enumerationChronology": [
+                      "2 of 3"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcph9",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcph9||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LTC 6497 [Cassette]",
+                      "urn:barcode:33433077362139"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LTC 6497 [Cassette]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433077362139",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433077362139"
+                    ],
+                    "physicalLocation": [
+                      "*LTC 6497 [Cassette]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LTC 6497 [Cassette]"
+                    ],
+                    "shelfMark_sort": "a*LTC 6497 [Cassette]",
+                    "status": [
+                      {
+                        "id": "status:v",
+                        "label": "Preservation"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:v||Preservation"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17725187"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16871054",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Kleban%2C+Edward&CallNumber=*LTC+6497+%5BCassette%5D&Date=198u&Form=30&Genre=archival+sound+recording&ItemInfo1=Supervised+use&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16871054&ItemISxN=i177251864&ItemNumber=33433077362147&ItemPublisher=%5B1980%5D&ItemVolume=1+of+3&Location=ReCAP&ReferenceNumber=b168710547&Site=LPAMRAMI&SubLocation=rcph9&Title=Gallery+demo+songs+in+rehearsal."
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:23",
+                        "label": "archival sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:23||archival sound recording"
+                    ],
+                    "enumerationChronology": [
+                      "1 of 3"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcph9",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcph9||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LTC 6497 [Cassette]",
+                      "urn:barcode:33433077362147"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LTC 6497 [Cassette]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433077362147",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433077362147"
+                    ],
+                    "physicalLocation": [
+                      "*LTC 6497 [Cassette]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LTC 6497 [Cassette]"
+                    ],
+                    "shelfMark_sort": "a*LTC 6497 [Cassette]",
+                    "status": [
+                      {
+                        "id": "status:v",
+                        "label": "Preservation"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:v||Preservation"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17725186"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b10756597",
+        "_score": 17.764614,
+        "_source": {
+          "extent": [
+            "1 score (   v.) : ill. (some col.) ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Columbia Pictures Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "JNN 82-2"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1980
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNN 82-2"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10756597"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG82-C2179"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0763482"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779320518940,
+          "publicationStatement": [
+            "[S.l.] : Columbia Pictures Publications, [1980-"
+          ],
+          "identifier": [
+            "urn:shelfmark:JNN 82-2",
+            "urn:bnum:10756597",
+            "urn:oclc:NYPG82-C2179",
+            "urn:identifier:(WaOLN)nyp0763482"
+          ],
+          "creators_displayPacked": [
+            "Forbert, Steve||Forbert, Steve"
+          ],
+          "dates": [
+            {
+              "range": {
+                "gte": "1980",
+                "lte": "9999"
+              },
+              "raw": "820929m19809999xxurcc              eng dccm a ",
+              "tag": "m"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Rock music -- United States."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "c",
+          "collectionIds": [
+            "pam"
+          ],
+          "titleAlt": [
+            "Songs."
+          ],
+          "physicalDescription": [
+            "1 score (   v.) : ill. (some col.) ; 31 cm."
+          ],
+          "tableOfContents": [
+            "The oil song -- Tonight I feel sa far away from home -- Goin' down to Laurel -- Steve Forbet's midsummer night's toast -- Thinkin' -- What kinda guy? -- It isn't gonna be that way -- Big city cat -- Grand Central Station, March 18, 1977 -- Settle down -- You cannot win if you do not play -- The sweet love that ya give (sure goes a long, long way) -- Romeo's tune -- I'm in love with you -- Say goodbye to little Jo -- Wait -- Make it all so real -- Baby -- Complications -- January 23-30, 1978 -- Sadly sorta like a soap opera."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Rock music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Words and music by Forbert.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Rock music",
+            "Rock music -- United States"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "title": [
+            "Steve Forbert songbook : piano, vocal, chords."
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "creatorLiteral": [
+            "Forbert, Steve"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "NYPG82-C2179"
+          ],
+          "uniformTitle": [
+            "Songs. Selections; arranged"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "titleDisplay": [
+            "Steve Forbert songbook : piano, vocal, chords."
+          ],
+          "uri": "b10756597",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "c",
+          "placeOfPublication": [
+            "[S.l.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          17.764614,
+          "b10756597"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b10756597",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "enumerationChronology_sort": "         1-",
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pam32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pam32||Performing Arts Research Collections - Music"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:JNN 82-2",
+                      "urn:barcode:33433068925019"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JNN 82-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433068925019",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433068925019"
+                    ],
+                    "physicalLocation": [
+                      "JNN 82-2"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "JNN 82-2"
+                    ],
+                    "shelfMark_sort": "aJNN 82-000002",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i13905447",
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ]
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b16745779",
+        "_score": 17.229954,
+        "_source": {
+          "extent": [
+            "1 sound disc : analog, 33 1/3 rpm ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Court Opera Classics"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LRX 8448"
+          ],
+          "parallelCreators_displayPacked": [],
+          "addedAuthorTitle": [
+            "Don Giovanni.",
+            "Nachtlager in Granada.",
+            "Fliegende Holländer.",
+            "Tannhäuser.",
+            "Trovatore.",
+            "Aïda.",
+            "Carmen.",
+            "Ring des Nibelungen.",
+            "Parsifal."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LRX 8448"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16745779"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "10481461"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "CO 421 Court Opera Classics"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A280000002"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Lohfing, Max, 1870-1953||Lohfing, Max, 1870-1953",
+            "Denera, Erna, 1881-1938||Denera, Erna, 1881-1938",
+            "Shore, Dinah, 1917-1994||Shore, Dinah, 1917-1994",
+            "Krasa, Rudolf, 1859-1936||Krasa, Rudolf, 1859-1936",
+            "Mozart, Wolfgang Amadeus, 1756-1791||Mozart, Wolfgang Amadeus, 1756-1791. Don Giovanni. Già la mensa è preparata. German",
+            "Kreutzer, Conradin, 1780-1849||Kreutzer, Conradin, 1780-1849. Nachtlager in Granada. Schütz bin ich in des Regenten Sold",
+            "Wagner, Richard, 1813-1883||Wagner, Richard, 1813-1883. Fliegende Holländer. Wie aus der Ferne längst vergang'ner Zeiten",
+            "Wagner, Richard, 1813-1883||Wagner, Richard, 1813-1883. Tannhäuser. Als du in kühnem Sange",
+            "Wagner, Richard, 1813-1883||Wagner, Richard, 1813-1883. Tannhäuser. Blick' ich umher in diesem edlen Kreise",
+            "Wagner, Richard, 1813-1883||Wagner, Richard, 1813-1883. Tannhäuser. O du mein holder Abendstern",
+            "Verdi, Giuseppe, 1813-1901||Verdi, Giuseppe, 1813-1901. Trovatore. Balen del suo sorriso. German",
+            "Verdi, Giuseppe, 1813-1901||Verdi, Giuseppe, 1813-1901. Trovatore. Per me ora fatale. German",
+            "Verdi, Giuseppe, 1813-1901||Verdi, Giuseppe, 1813-1901. Aïda. Rivedrai le foreste imbalsamate. German",
+            "Bizet, Georges, 1838-1875||Bizet, Georges, 1838-1875. Carmen. Chanson du toréador. German",
+            "Wagner, Richard, 1813-1883||Wagner, Richard, 1813-1883. Ring des Nibelungen. Götterdämmerung. Brünhild', die hehrste Frau",
+            "Wagner, Richard, 1813-1883||Wagner, Richard, 1813-1883. Parsifal. Mein Vater"
+          ],
+          "updatedAt": 1779469999755,
+          "publicationStatement": [
+            "[Austria] : Court Opera Classics, [198-?]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LRX 8448",
+            "urn:bnum:16745779",
+            "urn:oclc:10481461",
+            "urn:identifier:CO 421 Court Opera Classics",
+            "urn:identifier:(WaOLN)A280000002"
+          ],
+          "creators_displayPacked": [
+            "Bronsgeest, Cornelis||Bronsgeest, Cornelis"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1981",
+                "gte": "1980"
+              },
+              "raw": "840302q19801984au opn   fi         ger dcjmIa ",
+              "tag": "q"
+            },
+            {
+              "range": {
+                "lt": "1985",
+                "gte": "1984"
+              },
+              "raw": "840302q19801984au opn   fi         ger dcjmIa ",
+              "tag": "q"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "j",
+          "collectionIds": [
+            "pah"
+          ],
+          "physicalDescription": [
+            "1 sound disc : analog, 33 1/3 rpm ; 12 in."
+          ],
+          "tableOfContents": [
+            "Don Juan. Ha, das Mahl ist schon bereitet! / Mozart (with Max Lohfing, bass) -- Nachtlager in Granade. Ein Schütz bin ich / Kreutzer -- Fliegende Holländer. Wie aus der Ferne längst vergang'ner Zeiten / Wagner (with Erna Denera, soprano) -- Tannhäuser. Als du in kühnem Sange uns bestrittest ; Blick' ich umher in diesem edlen Kreise ; Wie Todesahnung Dämm'rung deckt die Lande / Wagner -- Der Troubadour. Ihres Auges himmlisch Strahlen ; O dürfte ich es glauben / Verdi -- Aida. Zu dir fürht mich ein ernster Grund, Aida / Verdi (with Frances Rose) -- Carmen. Euren Toast kann ich wohl erwidern / Bizet -- Götterdämmerung. Brünhild, die hehrste Frau / Wagner -- Parsifal. Wehe! Wehe mir der Qual / Wagner (with Rudolf Krasa)."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Opera arias and scenes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Biographical and program notes by Leo Riemens in German on container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded 1907-1913; originally released on Parlophon, Odeon or Gramophone labels.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in German.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "title": [
+            "Cornelis Bronsgeest 1878-1957."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "creatorLiteral": [
+            "Bronsgeest, Cornelis"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Lohfing, Max, 1870-1953",
+            "Denera, Erna, 1881-1938",
+            "Shore, Dinah, 1917-1994",
+            "Krasa, Rudolf, 1859-1936",
+            "Mozart, Wolfgang Amadeus, 1756-1791",
+            "Kreutzer, Conradin, 1780-1849",
+            "Wagner, Richard, 1813-1883",
+            "Verdi, Giuseppe, 1813-1901",
+            "Bizet, Georges, 1838-1875"
+          ],
+          "idOclc": [
+            "10481461"
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "titleDisplay": [
+            "Cornelis Bronsgeest [sound recording] : 1878-1957."
+          ],
+          "uri": "b16745779",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[Austria]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          17.229954,
+          "b16745779"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16745779",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Bronsgeest%2C+Cornelis&CallNumber=*LRX+8448+%5BDisc%5D&Date=1980&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16745779&ItemISxN=i174269018&ItemNumber=33433068004625&ItemPlace=%5BAustria%5D&ItemPublisher=Court+Opera+Classics%2C+%5B198-%3F%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b167457792&Site=LPAMRAMI&Title=Cornelis+Bronsgeest+1878-1957."
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LRX 8448 [Disc]",
+                      "urn:barcode:33433068004625"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LRX 8448 [Disc]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433068004625",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433068004625"
+                    ],
+                    "physicalLocation": [
+                      "*LRX 8448 [Disc]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LRX 8448 [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LRX 8448 [Disc]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i17426901"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b16159529",
+        "_score": 16.990204,
+        "_source": {
+          "extent": [
+            "<4> sound discs : analog, 33 1/3 rpm ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Lebendige Vergangenheit"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LZR 5122 (C)"
+          ],
+          "idLccn": [
+            "77762223"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1970
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LZR 5122 (C)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16159529"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "12913709"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77762223"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "LV 108 Lebendige Vergangenheit"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "LV 110 Lebendige Vergangenheit"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "LV 187 Lebendige Vergangenheit"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "LV 1330 LebendigeVergangenheit"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A230000008"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Hutt, Robert, 1878-1942||Hutt, Robert, 1878-1942"
+          ],
+          "updatedAt": 1779434005895,
+          "publicationStatement": [
+            "Austria : Lebendige Vergangenheit, [between 1970 and <1986>]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LZR 5122 (C)",
+            "urn:bnum:16159529",
+            "urn:oclc:12913709",
+            "urn:lccn:77762223",
+            "urn:identifier:LV 108 Lebendige Vergangenheit",
+            "urn:identifier:LV 110 Lebendige Vergangenheit",
+            "urn:identifier:LV 187 Lebendige Vergangenheit",
+            "urn:identifier:LV 1330 LebendigeVergangenheit",
+            "urn:identifier:(WaOLN)A230000008"
+          ],
+          "creators_displayPacked": [
+            "Schlusnus, Heinrich, 1888-1952||Schlusnus, Heinrich, 1888-1952, performer"
+          ],
+          "dates": [
+            {
+              "range": {
+                "gte": "1970",
+                "lte": "9999"
+              },
+              "raw": "840510m19709999au opn              ger  cjm1a ",
+              "tag": "m"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "M1505"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "j",
+          "collectionIds": [
+            "pah"
+          ],
+          "physicalDescription": [
+            "<4> sound discs : analog, 33 1/3 rpm ; 12 in."
+          ],
+          "tableOfContents": [
+            "Disc 3. Tannhäuser. Blick' ich umher in diesem edlen Kreise / Wagner -- Wilhelm Tell. Ha, wohin? Sprich, was soll dein Eilen? / Rossini -- La traviata. Hat dein heimatliches Land keinen Reiz für deinen Sinn ; Die Macht des Schicksals. In dieser heil'gen Stunde (Robert Hutt) / Verdi -- Die Perlenfischer. Dort in des Tempels Grund / Bizet (Robert Hutt) -- Die Afrikanerin. Dir, Königin, bin ich ergeben ; Wie hat mein Herz geschlagen / Meyerbeer -- Die Walküre. Leb' wohl, du kühnes, herrliches Kind ; Loge, hör'! lausche hierher! / Wagner -- Carmen. Euren Toast kann ich wohl erwidern / Bizet -- Othello. Ich glaube an einen Gott ; Saht ihr nicht manchmal in Desdemonens Händen (Robert Hutt) / Verdi -- La bohème. Ach, Geliebte! Nie kehrst du in meinen Arm / Puccini (Robert Hutt)."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Lebendige Vergangenheit: LV 108, LV 110, LV 187, LV 1330.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Opera excerpts.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes by Clemens Höslinger in German on container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded 1920-1938.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung principally in German.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "title": [
+            "Heinrich Schlusnus"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "creatorLiteral": [
+            "Schlusnus, Heinrich, 1888-1952"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Hutt, Robert, 1878-1942"
+          ],
+          "idOclc": [
+            "12913709"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "titleDisplay": [
+            "Heinrich Schlusnus [sound recording]."
+          ],
+          "uri": "b16159529",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Austria"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          16.990204,
+          "b16159529"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b16159529",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&Author=Schlusnus%2C+Heinrich%2C+1888-1952&CallNumber=*LZR+5122+%28C%29+%5BDisc%5D&Date=1970&Form=30&Genre=musical+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db16159529&ItemISxN=i155655607&ItemNumber=33433035869852&ItemPlace=Austria&ItemPublisher=Lebendige+Vergangenheit%2C+%5Bbetween+1970+and+%3C1986%3E%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b161595297&Site=LPAMRAMI&Title=Heinrich+Schlusnus&Transaction.CustomFields.MapsLocationNote=Program+notes+on+container."
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LZR 5122 (C) [Disc]",
+                      "urn:barcode:33433035869852"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LZR 5122 (C) [Disc]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433035869852",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433035869852"
+                    ],
+                    "physicalLocation": [
+                      "*LZR 5122 (C) [Disc]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LZR 5122 (C) [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LZR 5122 (C) [Disc]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i15565560"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b21916755",
+        "_score": 16.229954,
+        "_source": {
+          "extent": [
+            "1 online resource (1 sound file)"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Deutsche Grammophon"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            1984
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "DEF058230702",
+            "DEF058230703",
+            "DEF058230706",
+            "DEF058230709",
+            "DEF058230711",
+            "DEF058230745",
+            "DEF058230746",
+            "DEF058230757",
+            "DEF058230721",
+            "DEF058230765",
+            "DEF058230723",
+            "DEF058230701",
+            "DEF058230705",
+            "DEF058230724",
+            "DEF058230712"
+          ],
+          "parallelCreators_displayPacked": [],
+          "addedAuthorTitle": [
+            "Carmen."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "21916755"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "983830749"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230702"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230703"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230706"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230709"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230711"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230745"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230746"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230757"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230721"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230765"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230723"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230701"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230705"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230724"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "DEF058230712"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "00028941332226 Deutsche Grammophon"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)983830749"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Meilhac, Henri, 1831-1897||Meilhac, Henri, 1831-1897, librettist",
+            "Halévy, Ludovic, 1834-1908||Halévy, Ludovic, 1834-1908, librettist",
+            "Ricciarelli, Katia||Ricciarelli, Katia, singer",
+            "Baltsa, Agnes||Baltsa, Agnes, singer",
+            "Carreras, José||Carreras, José, singer",
+            "Dam, José van||Dam, José van, singer",
+            "Karajan, Herbert von||Karajan, Herbert von, conductor",
+            "Mérimée, Prosper, 1803-1870||Libretto based on (work): Mérimée, Prosper, 1803-1870. Carmen",
+            "Opéra de Paris. Chœur||Opéra de Paris. Chœur, singer",
+            "Schöneberger Sängerknaben||Schöneberger Sängerknaben, singer",
+            "Berliner Philharmoniker||Berliner Philharmoniker, instrumentalist"
+          ],
+          "updatedAt": 1779513889739,
+          "publicationStatement": [
+            "Hamburg : Deutsche Grammophon, [1984]"
+          ],
+          "identifier": [
+            "urn:bnum:21916755",
+            "urn:oclc:983830749",
+            "urn:lccn:DEF058230702",
+            "urn:lccn:DEF058230703",
+            "urn:lccn:DEF058230706",
+            "urn:lccn:DEF058230709",
+            "urn:lccn:DEF058230711",
+            "urn:lccn:DEF058230745",
+            "urn:lccn:DEF058230746",
+            "urn:lccn:DEF058230757",
+            "urn:lccn:DEF058230721",
+            "urn:lccn:DEF058230765",
+            "urn:lccn:DEF058230723",
+            "urn:lccn:DEF058230701",
+            "urn:lccn:DEF058230705",
+            "urn:lccn:DEF058230724",
+            "urn:lccn:DEF058230712",
+            "urn:identifier:00028941332226 Deutsche Grammophon",
+            "urn:identifier:(OCoLC)983830749"
+          ],
+          "creators_displayPacked": [
+            "Bizet, Georges, 1838-1875||Bizet, Georges, 1838-1875, composer"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1985",
+                "gte": "1984"
+              },
+              "raw": "170425s1984    gw opnn o         n fre dnjmKi ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Operas -- Excerpts."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "w",
+          "collectionIds": [],
+          "titleAlt": [
+            "Carmen."
+          ],
+          "physicalDescription": [
+            "1 online resource (1 sound file)"
+          ],
+          "tableOfContents": [
+            "Prélude, acte I (3:37) -- Sur la place (6:25) -- Avec la garde montante (2:28) -- L'amour est un oiseau rebelle (4:32) -- Dialogue: Monsieur le brigadier ; Parle-moi de ma mère (6:29) -- Près des remparts de Séville (4:49) -- Les tringles des sistres tintaient (4:59) -- Dialogue: Vous avez quelque chose à nous dire (1:21) -- Vivat! vivat le Toréro! (1:39) -- Votre toast, je peux vous le rendre (5:27) -- La fleur que tu m'avais jetée (4:22) -- En vain, pour éviter les réponses amères/Parlez encore, parlez, mes belles (3:08) -- A dos cuartos! (2:24) -- Musique de transition (:40) -- C'est toi!/C'est moi! (10:27)."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Opera excerpts.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Libretto by Henri Meilhac and Ludovic Halévy, based on the novel by Propser Mérimée.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Sung in French.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Operas",
+            "Operas -- Excerpts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "title": [
+            "Carmen : Querschnitt = highlights"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [
+            "Bizet, Georges, 1838-1875"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "contributorLiteral": [
+            "Meilhac, Henri, 1831-1897",
+            "Halévy, Ludovic, 1834-1908",
+            "Ricciarelli, Katia",
+            "Baltsa, Agnes",
+            "Carreras, José",
+            "Dam, José van",
+            "Karajan, Herbert von",
+            "Mérimée, Prosper, 1803-1870",
+            "Opéra de Paris. Chœur",
+            "Schöneberger Sängerknaben",
+            "Berliner Philharmoniker"
+          ],
+          "idOclc": [
+            "983830749"
+          ],
+          "uniformTitle": [
+            "Carmen. Selections"
+          ],
+          "genreForm": [
+            "Streaming audio."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "titleDisplay": [
+            "Carmen : Querschnitt = highlights / Bizet."
+          ],
+          "uri": "b21916755",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "electronicResources": [
+            {
+              "label": "Access Naxos Music Library",
+              "url": "https://nypl.naxosmusiclibrary.com/catalogue/item.asp?cid=00028941332226"
+            }
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Hamburg"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          16.229954,
+          "b21916755"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b15896309",
+        "_score": 14.699237,
+        "_source": {
+          "extent": [
+            "1 sound disc : 33 1/3 rpm, microgroove ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Decca"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            19
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LZR 20455"
+          ],
+          "idLccn": [
+            "r  57000950"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            19
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LZR 20455"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "15896309"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "3256752"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "r  57000950"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "DL 9043 Decca"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)A190000075"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Moss, Arnold, 1910-1989||Moss, Arnold, 1910-1989, performer",
+            "Johnson, Raymond Edward||Johnson, Raymond Edward, performer"
+          ],
+          "updatedAt": 1779430242690,
+          "publicationStatement": [
+            "New York : Decca, [19--]"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LZR 20455",
+            "urn:bnum:15896309",
+            "urn:oclc:3256752",
+            "urn:lccn:r  57000950",
+            "urn:identifier:DL 9043 Decca",
+            "urn:identifier:(WaOLN)A190000075"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "lt": "2000",
+                "gte": "1900"
+              },
+              "raw": "770912s19uu    nyunnn         p    eng  cimIa ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Love poetry, English.",
+            "Love poetry, American."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "i",
+          "collectionIds": [
+            "pah"
+          ],
+          "titleAlt": [
+            "Lyrics of love"
+          ],
+          "physicalDescription": [
+            "1 sound disc : 33 1/3 rpm, microgroove ; 12 in."
+          ],
+          "tableOfContents": [
+            "A supplication / Thomas Wyatt -- The true beauty / Thomas Carew -- There be none of beauty's daughters / Byron -- Song to Celia / Ben Jonson -- Jenny kissed me / Hunt -- The night has a thousand eyes / Bourdillon -- The winds out of the west / A.E. Housman -- White in the moon / A.E. Housman -- How sweet I roamed / William Blake -- Who ever loved / Christopher Marlowe -- Love me little, love me long / Anon. -- My heart is like a singing bird / Christina Rossetti -- Break, break, break / Alfred Tennyson -- Remember me when I am gone away / Christina Rossetti -- All for love / Byron -- The passionate shepherd to his love / Marlowe -- How do I love thee / E.B. Browining -- When we two parted / Byron -- The time I've lost in wooing / Moore -- Who is Sylvia / Shakespeare -- Ruth / Thomas Hood -- To Helen / Edgar Allan Poe -- She dwelt among untrodden ways / William Wordsworth -- Send me back my heart / Sir John Suckling -- She walks in beauty / Byron -- Song to Celia / Ben Jonson -- Counsel to girls / Robert Herrick -- She was a phantom of delight / William Wordsworth -- My love is like a red red rose / Robert Burns -- Believe me if all those endearing young charms / Moore -- O, when I was in love with you / E.A. Housman -- Farewell to Nancy / Robert Burns -- Let the toast pass / Richard Brinsley Sheridan -- Ask and have / Samuel Lover -- The manly heart / George Wither -- When I was one and twenty / A.E. Housman -- Why so pale and wan / Sir John Suckling -- Constancy / Sir John Suckling -- The children's hour / Henry Wadsworth Longfellow."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Program notes, in part by Louis Untermeyer, on container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Arnold Moss, R.E. Johnson, readers.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Love poetry, English",
+            "Love poetry, American"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "The Heart speaks : lyrics of love"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "19uu"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Moss, Arnold, 1910-1989",
+            "Johnson, Raymond Edward"
+          ],
+          "idOclc": [
+            "3256752"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "19uu"
+          ],
+          "titleDisplay": [
+            "The Heart speaks : lyrics of love [sound recording]."
+          ],
+          "uri": "b15896309",
+          "parallelContributorLiteral": [
+            null,
+            null
+          ],
+          "recordTypeId": "i",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "series": [
+            "Parnassus, a treasury of the spoken word"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Parnassus, a treasury of the spoken word||Parnassus, a treasury of the spoken word"
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          14.699237,
+          "b15896309"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b15896309",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://nypl-aeon-test.aeon.atlas-sys.com/aeon/Aeon.dll?Action=10&CallNumber=*LZR+20455+%5BDisc%5D&Date=19uu&Form=30&Genre=spoken+sound+recording&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db15896309&ItemISxN=i146783529&ItemNumber=33433035439284&ItemPlace=New+York&ItemPublisher=Decca%2C+%5B19--%5D&Location=Performing+Arts+Music+and+Recorded+Sound+Division&ReferenceNumber=b15896309x&Site=LPAMRAMI&Title=The+Heart+speaks+%3A+lyrics+of+love"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:13",
+                        "label": "spoken sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:13||spoken sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Spoken word recording"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah22",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah22||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LZR 20455 [Disc]",
+                      "urn:barcode:33433035439284"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LZR 20455 [Disc]",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433035439284",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433035439284"
+                    ],
+                    "physicalLocation": [
+                      "*LZR 20455 [Disc]"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LZR 20455 [Disc]"
+                    ],
+                    "shelfMark_sort": "a*LZR 20455 [Disc]",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i14678352"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b11149912",
+        "_score": 14.506463,
+        "_source": {
+          "extent": [
+            "1 sound disc : digital, stereo. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Bis"
+          ],
+          "language": [
+            {
+              "id": "lang:fin",
+              "label": "Finnish"
+            }
+          ],
+          "buildingLocationIds": [
+            "pa"
+          ],
+          "createdYear": [
+            1985
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "*LDC 249 (F)"
+          ],
+          "parallelCreators_displayPacked": [],
+          "addedAuthorTitle": [
+            "Vuoripaimen.",
+            "Kevätteiltä.",
+            "Länsilinnan lauluja.",
+            "Lauluja hyljätyltä seudulta.",
+            "Syyspäiviä."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LDC 249 (F)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11149912"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG87-R126"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "CD-279 Bis"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1157415"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Piipponen, Matti||Piipponen, Matti, performer",
+            "Hynninen, Jorma, 1941-||Hynninen, Jorma, 1941-, performer",
+            "Haverinen, Margareta||Haverinen, Margareta, performer",
+            "Gothóni, Ralf, 1946-||Gothóni, Ralf, 1946-, performer",
+            "Nummi, Seppo, 1932-1981||Nummi, Seppo, 1932-1981. Vuoripaimen",
+            "Nummi, Seppo, 1932-1981||Nummi, Seppo, 1932-1981. Kevätteiltä",
+            "Nummi, Seppo, 1932-1981||Nummi, Seppo, 1932-1981. Länsilinnan lauluja",
+            "Nummi, Seppo, 1932-1981||Nummi, Seppo, 1932-1981. Lauluja hyljätyltä seudulta",
+            "Nummi, Seppo, 1932-1981||Nummi, Seppo, 1932-1981. Syyspäiviä"
+          ],
+          "updatedAt": 1779327129121,
+          "publicationStatement": [
+            "Djursholm, Sweden : Bis, c1985"
+          ],
+          "identifier": [
+            "urn:shelfmark:*LDC 249 (F)",
+            "urn:bnum:11149912",
+            "urn:oclc:NYPG87-R126",
+            "urn:identifier:CD-279 Bis",
+            "urn:identifier:(WaOLN)nyp1157415"
+          ],
+          "creators_displayPacked": [
+            "Nummi, Seppo, 1932-1981||Nummi, Seppo, 1932-1981"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1986",
+                "gte": "1985"
+              },
+              "raw": "870604p19851983sw sg    di         fin dcjm a ",
+              "tag": "p"
+            },
+            {
+              "range": {
+                "lt": "1984",
+                "gte": "1983"
+              },
+              "raw": "870604p19851983sw sg    di         fin dcjm a ",
+              "tag": "p"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Songs (High voice) with piano.",
+            "Songs (Medium voice) with piano.",
+            "Song cycles."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "y",
+          "collectionIds": [
+            "pah"
+          ],
+          "titleAlt": [
+            "Songs.",
+            "Vuoripaimen.",
+            "Mountain shepherd.",
+            "Kevätteiltä.",
+            "From spring roads.",
+            "Länsilinnan lauluja.",
+            "Songs of the western palace.",
+            "Lauluja hyljätyltä seudulta.",
+            "Songs from a deserted place.",
+            "Kiinalainen laulukirja.",
+            "Chinese song book.",
+            "Syyspäiviä.",
+            "Autumn days."
+          ],
+          "physicalDescription": [
+            "1 sound disc : digital, stereo. ; 4 3/4 in."
+          ],
+          "tableOfContents": [
+            "Vuoripaimen = Mountain shepherd : 1951. Ajatuksia = Thoughts (4:03) ; Rakastunut = In love (1:29) ; Mutta kun olen runoniekka = But as I am a poet (2:32) ; Tuoksua puutarhoista = The scent of gardens (1:49) ; Ikävä, ikävä on mieli = Sad, sad is my mind : [rev.] 1980 (2:17) ; Mietteliäät vainiot = The pensive corn fields (2:56) (total time 15:23) -- Kevätteiltä : Kiinalainen laulukirja II = From spring roads : Chinese song book II. Lähtömalja = Parting toast (2:33) ; Sydänyöllä = In the heart of the night (2:09) ; Kevätteiltä = From spring roads (1:05) ; Korsikeinu = The swing of straw (1:57) ; Viinituvan valkamassa = In the haven of the wine lodge (3:58) ; Vuosipäivä = Anniversary (2:05) ; Vuorella = In the mountain (1:48) (total time 16:04) -- Länsilinnan lauluja : Kiinalainen laulukirja III = Songs of the western palace : Chinese song book III. Ikuinen runo = Eternal poem (3:57) ; Kevätyö = Spring night (1:21) ; Lemmenhurma = Love's enchantment (2:49) ; Hovinainen = Lady of the court (3:47) ; Hibiscus-kukat = The hibiscus flowers (3:02) ; Paimen ja kutojaneito = The shepherd and the weaving maid (3:51) (total time 19:08) --",
+            "Lauluja hyljätyltä seudulta : Kiinalainen laulukirja I = Songs from a deserted place : Chinese song book I. Venheessä = In a boat (1:44) ; Hyljätty palatsi = The abandoned palace (1:43) ; Salaperäinen huilu = The secret flute (2:48) ; Ikilumiset vuoret = Mountains of perpetual snow (2:35) ; Hyljätty seutu = Deserted place (1:40) (total time 10:44) -- Syyspäiviä = Autumn days : 1979. Syksyn juhla = Autumn feast (2:00) ; Metsässä = In the forest (3:43) ; Syyspäivä = Autumn day (5:17) (total time 11:24)."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Sung in Finnish.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Text of the 1st work by Lassi Nummi, of the 2nd-4th translated from various Chinese poets and traditional Chinese poetry, and of the 5th work by Aale Tynni and Lassi Nummi.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Dist. by Qualiton Imports Ltd., N.Y.\"--Label on container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Compact disc.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Program notes in English, Swedish, German, and French translated from the Finnish of Lassi Nummi, notes on the performers in English, Swedish, German, and French, and Finnish texts with English translations ([32] p. : ill.) in container.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Recorded in Studio Bis, Djursholm, Sweden, Nov. 14, 1983 and May 18-19 and June 28, 1984.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Songs (High voice) with piano",
+            "Songs (Medium voice) with piano",
+            "Song cycles"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1983"
+          ],
+          "title": [
+            "5 song cycles"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "creatorLiteral": [
+            "Nummi, Seppo, 1932-1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Piipponen, Matti",
+            "Hynninen, Jorma, 1941-",
+            "Haverinen, Margareta",
+            "Gothóni, Ralf, 1946-"
+          ],
+          "idOclc": [
+            "NYPG87-R126"
+          ],
+          "uniformTitle": [
+            "Songs. Selections"
+          ],
+          "dateEndYear": [
+            1983
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "titleDisplay": [
+            "5 song cycles [sound recording] /  Seppo Nummi."
+          ],
+          "uri": "b11149912",
+          "parallelContributorLiteral": [
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Djursholm, Sweden"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "4 3/4 in."
+          ]
+        },
+        "sort": [
+          14.506463,
+          "b11149912"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "on-site",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "b11149912",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:12",
+                        "label": "musical sound recording"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:12||musical sound recording"
+                    ],
+                    "formatLiteral": [
+                      "Music CD"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:pah32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:pah32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:*LDC 249 (F)",
+                      "urn:barcode:33433047566470"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LDC 249 (F)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "33433047566470",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433047566470"
+                    ],
+                    "physicalLocation": [
+                      "*LDC 249 (F)"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LDC 249 (F)"
+                    ],
+                    "shelfMark_sort": "a*LDC 249 (F)",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "i13991747"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "cb3033197",
+        "_score": 13.829319,
+        "_source": {
+          "extent": [
+            "volumes : illustrations (part color) portraits ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "serialPublicationDates": [
+            "1st-      1887?-"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1887
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1887
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "3033197"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm10936985"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-4138001"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm10936985"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "3033197"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779538068724,
+          "publicationStatement": [
+            "New York"
+          ],
+          "identifier": [
+            "urn:bnum:3033197",
+            "urn:oclc:ocm10936985",
+            "urn:oclc:SCSB-4138001",
+            "urn:identifier:(OCoLC)ocm10936985",
+            "urn:identifier:3033197"
+          ],
+          "creators_displayPacked": [
+            "New York Southern Society||New York Southern Society"
+          ],
+          "dates": [
+            {
+              "range": {
+                "gte": "1887",
+                "lte": "9999"
+              },
+              "raw": "840711u1887uuuunyuar         0   a0eng d",
+              "tag": "u"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "volumes : illustrations (part color) portraits ; 19-31 cm"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Some nos. issued with variant title: Annual dinner.",
+              "type": "bf:Note"
+            }
+          ],
+          "numItemDatesParsed": [
+            15
+          ],
+          "numItemsTotal": [
+            15
+          ],
+          "dateEndString": [
+            "uuuu"
+          ],
+          "title": [
+            "Annual banquet."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1887"
+          ],
+          "creatorLiteral": [
+            "New York Southern Society"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocm10936985",
+            "SCSB-4138001"
+          ],
+          "dateEndYear": [
+            null
+          ],
+          "summary": [
+            "Consists of menu, toasts, officers, songs, etc."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1887"
+          ],
+          "titleDisplay": [
+            "Annual banquet."
+          ],
+          "uri": "cb3033197",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "19-31 cm"
+          ]
+        },
+        "sort": [
+          13.829319,
+          "cb3033197"
+        ],
+        "matched_queries": [
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 15,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb3033197",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1924",
+                        "lte": "1926"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "(1924-1926)"
+                    ],
+                    "enumerationChronology_sort": "          -1924",
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:367N So8",
+                      "urn:barcode:CU09123130"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "367N So8",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "CU09123130",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU09123130"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "367N So8"
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "367N So8"
+                    ],
+                    "shelfMark_sort": "a367N So000008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci4598347"
+                  },
+                  "sort": [
+                    "          -1924"
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb3033197",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1922",
+                        "lte": "1924"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "(1922-1924)"
+                    ],
+                    "enumerationChronology_sort": "          -1922",
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:367N So8",
+                      "urn:barcode:CU09123148"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "367N So8",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "CU09123148",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU09123148"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "367N So8"
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "367N So8"
+                    ],
+                    "shelfMark_sort": "a367N So000008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci4598349"
+                  },
+                  "sort": [
+                    "          -1922"
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb3033197",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1921",
+                        "lte": "1922"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "(1921-1922)"
+                    ],
+                    "enumerationChronology_sort": "          -1921",
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:367N So8",
+                      "urn:barcode:CU09123121"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "367N So8",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "CU09123121",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU09123121"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "367N So8"
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "367N So8"
+                    ],
+                    "shelfMark_sort": "a367N So000008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci4598343"
+                  },
+                  "sort": [
+                    "          -1921"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "b14525941",
+        "_score": 12.366635,
+        "_source": {
+          "extent": [
+            "4"
+          ],
+          "partOf": [
+            "c2pc Frank Silvera Writers Workshop. Frank Silvera Writers Workshop records. (CStRLIN)NYPW89-A93."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [],
+          "createdYear": [
+            1974
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "Sc MG 64 ",
+            "Sc MG 64"
+          ],
+          "parallelCreators_displayPacked": [],
+          "addedAuthorTitle": [
+            "Replenish.",
+            "Strength.",
+            "Diminish: sulphur's ire.",
+            "When the vase breaks."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc MG 64 "
+            },
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc MG 64"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "14525941"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPW98-A472"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)W280000004"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Armstrong, Althea Rogetta||Armstrong, Althea Rogetta. Replenish",
+            "Armstrong, Althea Rogetta||Armstrong, Althea Rogetta. Strength",
+            "Armstrong, Althea Rogetta||Armstrong, Althea Rogetta. Diminish: sulphur's ire",
+            "Armstrong, Althea Rogetta||Armstrong, Althea Rogetta. When the vase breaks",
+            "Frank Silvera Writers Workshop||Frank Silvera Writers Workshop"
+          ],
+          "updatedAt": 1779410165165,
+          "identifier": [
+            "urn:shelfmark:Sc MG 64 ",
+            "urn:shelfmark:Sc MG 64",
+            "urn:bnum:14525941",
+            "urn:oclc:NYPW98-A472",
+            "urn:identifier:(WaOLN)W280000004"
+          ],
+          "creators_displayPacked": [
+            "Armstrong, Althea Rogetta||Armstrong, Althea Rogetta"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1988",
+                "gte": "1974"
+              },
+              "raw": "981014i19741987nyu                 eng dcpdzaa",
+              "tag": "i"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Armstrong, Althea Rogetta.",
+            "Frank Silvera Writers Workshop.",
+            "African American dramatists.",
+            "African American authors.",
+            "American drama -- African American authors.",
+            "Authors -- United States.",
+            "American drama -- 20th century.",
+            "Dramatists, American -- 20th century."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "p",
+          "collectionIds": [
+            "scd"
+          ],
+          "physicalDescription": [
+            "4"
+          ],
+          "note": [
+            {
+              "noteType": "Terms of Use",
+              "label": "Photocopying requires prior permission from Frank Silvera Writers Workshop.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Playwright, composer, producer, director, choreographer and professor. Althea Rogetta Armstrong attended Wayne State University, Detroit, Michigan (B.A. in Mass Communications and Theater, 1973), and Howard University, Washington, DC (M.A. in Communication Theory, 1976). Armstrong authored a dozen plays and musicals, with music and choreography, which were staged at numerous universities throughout the United States and in radio, television and film productions. Her honors and awards include Wayne State University Black Theater & Film Guild Award for the musical \"Strength,\" Winner of Weekly Vocal Competition, Toast Supper Club, PUSH Award for Excellence, Outstanding Young Women of America, 1974.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Forms a part of: Frank Silvera Writers Workshop records. See collection record for more information.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Armstrong, Althea Rogetta",
+            "Frank Silvera Writers Workshop",
+            "African American dramatists",
+            "African American authors",
+            "American drama",
+            "American drama -- African American authors",
+            "Authors",
+            "Authors -- United States",
+            "American drama -- 20th century",
+            "Dramatists, American",
+            "Dramatists, American -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "dateEndString": [
+            "1987"
+          ],
+          "title": [
+            "Althea Rogetta Armstrong plays"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "creatorLiteral": [
+            "Armstrong, Althea Rogetta"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Frank Silvera Writers Workshop"
+          ],
+          "donor": [
+            "Schomburg NEH Humanities Resources for African and African Diasporan Studies Access Project."
+          ],
+          "idOclc": [
+            "NYPW98-A472"
+          ],
+          "dateEndYear": [
+            1987
+          ],
+          "summary": [
+            "Collection includes photocopies of four unpublished play scripts. Titles are: \"Replenish,: [1974]; \"Strength,\" 1980; \"When the vase breaks\" 1987; \"Diminish: sulphur's ire,\" n.d."
+          ],
+          "genreForm": [
+            "Scripts.",
+            "Plays."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mix",
+              "label": "Mixed material"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "titleDisplay": [
+            "Althea Rogetta Armstrong plays, 1974-1987."
+          ],
+          "uri": "b14525941",
+          "parallelContributorLiteral": [
+            null,
+            null
+          ],
+          "recordTypeId": "p",
+          "issuance": [
+            {
+              "id": "urn:biblevel:d",
+              "label": "subunit"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Finding aid",
+              "url": "http://archives.nypl.org/scm/20721 "
+            }
+          ]
+        },
+        "sort": [
+          12.366635,
+          "b14525941"
+        ],
+        "matched_queries": [
+          "term nyplSource",
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 0,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "cb11012105",
+        "_score": 8.968448,
+        "_source": {
+          "extent": [
+            "1 audio disc : analog, 33 1/3 rpm, stereo ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "publisherLiteral": [
+            "Beat Records Co."
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1984
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "11012105"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocn894917168"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "894917168"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-5772470"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "BL 4022 Beat Records"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocn894917168"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)894917168"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)11012105"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "11012105"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Alessandro Alessandroni Orchestra||Alessandro Alessandroni Orchestra, instrumentalist"
+          ],
+          "updatedAt": 1779324988900,
+          "publicationStatement": [
+            "Roma : Beat Records Co., [1984], ℗1984."
+          ],
+          "identifier": [
+            "urn:bnum:11012105",
+            "urn:oclc:ocn894917168",
+            "urn:oclc:894917168",
+            "urn:oclc:SCSB-5772470",
+            "urn:identifier:BL 4022 Beat Records",
+            "urn:identifier:(OCoLC)ocn894917168",
+            "urn:identifier:(OCoLC)894917168",
+            "urn:identifier:(NNC)11012105",
+            "urn:identifier:11012105"
+          ],
+          "creators_displayPacked": [
+            "Alessandroni, Alessandro||Alessandroni, Alessandro, composer, conductor"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "1985",
+                "gte": "1984"
+              },
+              "raw": "141110t19841984it ppn            n zxx d",
+              "tag": "t"
+            },
+            {
+              "range": {
+                "lt": "1985",
+                "gte": "1984"
+              },
+              "raw": "141110t19841984it ppn            n zxx d",
+              "tag": "t"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:s",
+              "label": "audio"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Popular instrumental music -- Italy."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "j",
+          "collectionIds": [],
+          "titleAlt": [
+            "Enchanted coast.",
+            "Woman\\u0027s perfume.",
+            "Toast for two.",
+            "Down the market.",
+            "Taormina sand.",
+            "Hopeful trip.",
+            "Romantic nature.",
+            "Portrait of love.",
+            "Romantic story.",
+            "Little tale.",
+            "Brightfull path.",
+            "Back in Venice."
+          ],
+          "physicalDescription": [
+            "1 audio disc : analog, 33 1/3 rpm, stereo ; 12 in."
+          ],
+          "tableOfContents": [
+            "Romantic nature (2:34) -- Portrait of love (3:20) -- A romantic story (3:15) -- Little tale (3:26) -- Brightfull path (3:20) -- Back in Venice (2:42) -- Enchanted coast (2:51) -- Woman\\u0027s perfume (2:45) -- Toast for two (2:48) -- Down the market (2:45) -- Taormina sand (2:25) -- Hopeful trip (2:37)."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Popular instrumental music.",
+              "type": "bf:Note"
+            }
+          ],
+          "seriesUniformTitle_displayPacked": [
+            "Serie Orbiter.||Serie Orbiter."
+          ],
+          "subjectLiteral_exploded": [
+            "Popular instrumental music",
+            "Popular instrumental music -- Italy"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "title": [
+            "A way to remember"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "creatorLiteral": [
+            "Alessandroni, Alessandro"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Alessandro Alessandroni Orchestra"
+          ],
+          "idOclc": [
+            "ocn894917168",
+            "894917168",
+            "SCSB-5772470"
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "seriesUniformTitle": [
+            "Serie Orbiter."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:sd",
+              "label": "audio disc"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "titleDisplay": [
+            "A way to remember / music by Alessandro Alessandroni."
+          ],
+          "uri": "cb11012105",
+          "parallelContributorLiteral": [
+            null
+          ],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "Roma"
+          ],
+          "series": [
+            "Serie Orbiter"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "series_displayPacked": [
+            "Serie Orbiter||Serie Orbiter"
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          8.968448,
+          "cb11012105"
+        ],
+        "matched_queries": [
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb11012105",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:SNK14669",
+                      "urn:barcode:MRS0146692"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "SNK14669",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "MRS0146692",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "MRS0146692"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "SNK14669"
+                    ],
+                    "recapCustomerCode": [
+                      "MR"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "SNK14669"
+                    ],
+                    "shelfMark_sort": "aSNK014669",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci8609844"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "cb10812928",
+        "_score": 7.653764,
+        "_source": {
+          "extent": [
+            "1 audio disc : analog, 33 1/3 rpm, stereo ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "publisherLiteral": [
+            "Stang Records : All Platinum Enterprises"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            19
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            19
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [
+            null
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "10812928"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocn644271470"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "644271470"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-5746767"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "ST-1007 Stang Records"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocn644271470"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)644271470"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)10812928"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "10812928"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [],
+          "updatedAt": 1779321428102,
+          "publicationStatement": [
+            "[Englewood, N.J.] : Stang Records : All Platinum Enterprises, between 1900 and 1999."
+          ],
+          "identifier": [
+            "urn:bnum:10812928",
+            "urn:oclc:ocn644271470",
+            "urn:oclc:644271470",
+            "urn:oclc:SCSB-5746767",
+            "urn:identifier:ST-1007 Stang Records",
+            "urn:identifier:(OCoLC)ocn644271470",
+            "urn:identifier:(OCoLC)644271470",
+            "urn:identifier:(NNC)10812928",
+            "urn:identifier:10812928"
+          ],
+          "creators_displayPacked": [
+            "Thyssen, Roland||Thyssen, Roland"
+          ],
+          "dates": [
+            {
+              "range": {
+                "lt": "2000",
+                "gte": "1900"
+              },
+              "raw": "100628s19uu    njujzn            n zxx d",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:s",
+              "label": "audio"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Jazz."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "parallelSubjectLiteral": [],
+          "formatId": "j",
+          "collectionIds": [],
+          "titleAlt": [
+            "Brazilian parade.",
+            "Man of love.",
+            "Crazy ruin.",
+            "Dream.",
+            "Enter into paris.",
+            "Foolish horn.",
+            "Uncertain starting.",
+            "Little boy.",
+            "It\\u0027s too much.",
+            "If it were to happen again.",
+            "Toast for johnny.",
+            "Because i love you."
+          ],
+          "physicalDescription": [
+            "1 audio disc : analog, 33 1/3 rpm, stereo ; 12 in."
+          ],
+          "tableOfContents": [
+            "Side 1. Brazilian parade / Thyssen, Darlier (2:35) ; Man of love / Dassin, Lemesle (2:27) ; Crazy ruin / Thyssen, Darlier (2:40) ; Dream / Schumann (2:45) ; Enter into paris / Vidalie, Bessieres (2:32) ; Foolish horn / Thyssen, Darlier (2:32) -- Side 2. Uncertain starting / Thyssen, Bells (2:32) ; The little boy / Dabadie, Datin (2:47) ; It\\u0027s too much / Varner, Barcy (2:25) ; If it were to happen again / Thyssen, Davignac, Darlier (3:01) ; Toast for johnny / Thyssen, Darlier (2:27) ; Because i love you / Davignac, Thyssen (3:28)."
+          ],
+          "subjectLiteral_exploded": [
+            "Jazz"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "The best of Roland Thyssen."
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "19uu"
+          ],
+          "creatorLiteral": [
+            "Thyssen, Roland"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "idOclc": [
+            "ocn644271470",
+            "644271470",
+            "SCSB-5746767"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:aud",
+              "label": "Audio"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:sd",
+              "label": "audio disc"
+            }
+          ],
+          "dateString": [
+            "19uu"
+          ],
+          "titleDisplay": [
+            "The best of Roland Thyssen."
+          ],
+          "uri": "cb10812928",
+          "parallelContributorLiteral": [],
+          "recordTypeId": "j",
+          "placeOfPublication": [
+            "[Englewood, N.J.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "12 in."
+          ]
+        },
+        "sort": [
+          7.653764,
+          "cb10812928"
+        ],
+        "matched_queries": [
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb10812928",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Musical recording"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:SNK17991",
+                      "urn:barcode:MRS0179914"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "SNK17991",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "MRS0179914",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "MRS0179914"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "SNK17991"
+                    ],
+                    "recapCustomerCode": [
+                      "MR"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "SNK17991"
+                    ],
+                    "shelfMark_sort": "aSNK017991",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci8499364"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "cb299666",
+        "_score": 4.842765,
+        "_source": {
+          "extent": [
+            "201 pages : illustrations ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "publisherLiteral": [
+            "G.M. Smith"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1985
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "85010833"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1985
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "299666"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0879052082"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780879052089"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "087905204X"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780879052041"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0879052112"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780879052119"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm12107195"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "12107195"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-2362365"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "85010833"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm12107195"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1003845379"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)12107195"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "299666"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Cannon, Hal, 1948-||Cannon, Hal, 1948-",
+            "Knudson, J. Scott||Knudson, J. Scott, book designer"
+          ],
+          "updatedAt": 1779537561862,
+          "publicationStatement": [
+            "Salt Lake City : G.M. Smith, 1985."
+          ],
+          "identifier": [
+            "urn:bnum:299666",
+            "urn:isbn:0879052082",
+            "urn:isbn:9780879052089",
+            "urn:isbn:087905204X",
+            "urn:isbn:9780879052041",
+            "urn:isbn:0879052112",
+            "urn:isbn:9780879052119",
+            "urn:oclc:ocm12107195",
+            "urn:oclc:12107195",
+            "urn:oclc:SCSB-2362365",
+            "urn:lccn:85010833",
+            "urn:identifier:(OCoLC)ocm12107195",
+            "urn:identifier:(OCoLC)1003845379",
+            "urn:identifier:(OCoLC)12107195",
+            "urn:identifier:299666"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "lt": "1986",
+                "gte": "1985"
+              },
+              "raw": "851125s1985    utua     b    000 p eng  ",
+              "tag": "s"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Folk poetry, American.",
+            "Cowboys -- Poetry."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "PS477.5.C67 C68 1985"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "201 pages : illustrations ; 18 cm"
+          ],
+          "tableOfContents": [
+            "Cowboy's soliloquy / Allen McCanless -- Sierry Petes / Gail Gardner -- Duded wrangler / Gail Gardner -- Zebra dun / Anonymous -- Gol-darned wheel / Anonymous -- Rain on the range / S. Omar Barker -- Bear ropin' buckaroo / S. Omar Barker -- Jack Potter's courtin' / S. Omar Barker -- Cowboy's Christmas Ball / Larry Chittendon -- Alkali Pete hits town / T.J. McCoy -- Silver Jack / Anonymous -- Blizzard / Eugene Ware -- Windy Bill / Anonymous -- D-2 horse wrangler / D.J. O'Malley -- Cowboy's dance song / James Barton Adams -- That little blue roan / Bruce Kiskaddon -- When they've finished shipping cattle in the Fall / Bruce Kiskaddon -- Cowboy's dream / Bruce Kiskaddon -- Old night hawk / Bruce Kiskaddon -- Boomer Johnson / Henry Herbert Knibbs -- Murph and McClop / Anonymous -- Silver Bells and Golden Spurs / Anonymous -- Hell in Texas / Anonymous -- Strawberry Roan / Curley Fletcher -- Flyin' outlaw / Curley Fletcher -- Cowboy's prayer / Curley Fletcher -- Cowboy's prayer / Badger Clark -- \"Bueno,\" which in Spanish means good / Nyle A. Henderson -- How many cows? / Nyle A. Henderson -- Ol' Edgar Martin / Carlos Ashley -- To be a top hand / Georgie sicking -- Old Tuff / Georgie Sicking -- For Jeff / Jon Bowerman -- Tribute to Freckles and Tornado / Jon Bowerman -- Grey's River Roundup / Howard Norskog -- Book / Waddie Mitchell -- Throw-back / Waddie Mitchell -- One Red Rose / Ernie Fanning -- Vanishing Valley / Ernie Fanning -- Saturday Night in Woody / Jesse Smith -- Saddle tramp / Buck Wilkerson -- Kid solos / Bob Schild -- Two of a kind / Bob Schild -- Matching green ribbon / Jim Hofer -- Time to stay, a time to go / Baxter Black -- Big high and lonesome / Baxter Black -- Poets gathering, 1985 / Charles A. Kortes -- Greasin' the miles / Nick Johnson -- Dudes / Nick Johnson -- Bellerin' and bawlin' / Linda Ash -- Great Wanagan Creek flood / Bill Lowman -- So long / Ross Knox -- Easy chairs and saddle sores / Ross Knox -- Dying times / Ross Knox -- Old horse / Don Ian Smith -- Open range / Melvin L. Whipple -- Voices in the night / Melvin L. Whipple -- Chookaloski Mare / Lucky Whipple -- Buckin' horse ballet / Lucky Whipple -- Buckskin Flats / Gorden Eastman -- No imposter / Duane Reece -- Cows and logs / Harold Otto -- Range cow in winter / Vern Mortensen -- Young fellers / R.O. Munn -- Gathering cattle in the Deertracks Pasture / Drummond Hadley -- Old Cowman / Dick Gibford -- Cowboy's toast / Dick Gibford -- Last Buckaroo / Dick Gibford -- Glow / Bill Simpson -- Like it or not / Bill Simpson -- Cowboy's favorite / Barney Nelson -- Fill up those glasses, Bartender / Jim Bollers -- Early morning roundup / Owen Barton -- My Ol' Stetson / Owen Barton -- Going to the Shawnee Rodeo / Don Bell -- Reincarnation / Wallace McRae -- Lease hound / Wallace McRae -- Spring / Vess Quinlan."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"A Peregrine Smith book\"--Title page verso.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Rare Book copy: In original dust jacket. NNC",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (pages 191-199).",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Folk poetry, American",
+            "Cowboys",
+            "Cowboys -- Poetry"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "title": [
+            "Cowboy poetry : a gathering"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Cannon, Hal, 1948-",
+            "Knudson, J. Scott"
+          ],
+          "idOclc": [
+            "ocm12107195",
+            "12107195",
+            "SCSB-2362365"
+          ],
+          "summary": [
+            "This collection of poems was chosen from among 10,000 gathered from cowboy reciters, ranch poets and from a library of over 200 published works of cowboy verse. One third of the poems are classics that have proven their vitality by having lived in the hearts and minds of cowboys and ranchers for decades. The remaining two-thirds are new, created within the last few years."
+          ],
+          "genreForm": [
+            "Cowboy poetry.",
+            "Poetry."
+          ],
+          "idIsbn": [
+            "0879052082",
+            "9780879052089",
+            "087905204X",
+            "9780879052041",
+            "0879052112",
+            "9780879052119"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "titleDisplay": [
+            "Cowboy poetry : a gathering / edited and with an introduction by Hal Cannon."
+          ],
+          "uri": "cb299666",
+          "parallelContributorLiteral": [
+            null,
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "Salt Lake City"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm"
+          ],
+          "idIsbn_clean": [
+            "0879052082",
+            "9780879052089",
+            "087905204X",
+            "9780879052041",
+            "0879052112",
+            "9780879052119"
+          ]
+        },
+        "sort": [
+          4.842765,
+          "cb299666"
+        ],
+        "matched_queries": [
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 1,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb299666",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:PS477.5.C67 C68 1985",
+                      "urn:barcode:CU71452699"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PS477.5.C67 C68 1985",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "CU71452699",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU71452699"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "PS477.5.C67 C68 1985"
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "PS477.5.C67 C68 1985"
+                    ],
+                    "shelfMark_sort": "aPS477.5.C67 C68 001985",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci4249477"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-qa-2026-05-12",
+        "_id": "cb10611860",
+        "_score": 3.1538382,
+        "_source": {
+          "extent": [
+            "volumes ;"
+          ],
+          "nyplSource": [
+            "recap-cul"
+          ],
+          "editionStatement": [
+            "[1st ed.]."
+          ],
+          "publisherLiteral": [
+            "Knopf"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "buildingLocationIds": [
+            "rc"
+          ],
+          "createdYear": [
+            1959
+          ],
+          "parallelSeriesAddedEntry": [],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [],
+          "idLccn": [
+            "59011691"
+          ],
+          "parallelCreators_displayPacked": [],
+          "dateStartYear": [
+            1959
+          ],
+          "parallelContributors_displayPacked": [],
+          "parallelCreatorLiteral": [],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "10611860"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "ocm00388127"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "388127"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-5724502"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "59011691"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)ocm00388127"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)490294"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)388127"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(NNC)10611860"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "10611860"
+            }
+          ],
+          "seriesAddedEntry": [],
+          "contributors_displayPacked": [
+            "Thruelsen, Richard||Thruelsen, Richard, editor",
+            "Kobler, John||Kobler, John, editor"
+          ],
+          "updatedAt": 1779318026979,
+          "publicationStatement": [
+            "New York : Knopf, 1959-"
+          ],
+          "identifier": [
+            "urn:bnum:10611860",
+            "urn:oclc:ocm00388127",
+            "urn:oclc:388127",
+            "urn:oclc:SCSB-5724502",
+            "urn:lccn:59011691",
+            "urn:identifier:(OCoLC)ocm00388127",
+            "urn:identifier:(OCoLC)490294",
+            "urn:identifier:(OCoLC)388127",
+            "urn:identifier:(NNC)10611860",
+            "urn:identifier:10611860"
+          ],
+          "creators_displayPacked": [],
+          "dates": [
+            {
+              "range": {
+                "gte": "1959",
+                "lte": "9999"
+              },
+              "raw": "720420m19599999nyu           000 0 eng  ",
+              "tag": "m"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "seriesAddedEntry_displayPacked": [],
+          "subjectLiteral": [
+            "Civilization, Modern -- 20th century."
+          ],
+          "parallelSeriesAddedEntry_displayPacked": [],
+          "lccClassification": [
+            "CB425 .S357"
+          ],
+          "parallelSubjectLiteral": [],
+          "formatId": "a",
+          "collectionIds": [],
+          "physicalDescription": [
+            "volumes ; 22 cm"
+          ],
+          "tableOfContents": [
+            "1st series. An evolutionist looks at modern man / Loren Eiseley -- The misbehavioral sciences / Jacques Barzun -- The riddle of life / William S. Beck -- The lost dimension in religion / Paul Tillich -- The mystery of matter / J. Robert Oppenheimer -- The lessons of the past / Edith Hamilton -- Drugs that shape men's minds / Aldous Huxley -- The decline of heroes / Arthur M. Schlesinger, Jr. -- The poet's vision / Edith Sitwell -- The end of empire / D. W. Brogan -- What makes basic research basic? / Hans Selye -- Art and life / Herbert Read -- When time began / Fred Hoyle -- How war began / Lewis Mumford -- The pleasures of music / Aaron Copland -- The varieties of human love / Martin Cyril D'Arcy -- Einstein's great idea / James R. Newman -- How words change our lives / S. I. Hayakawa -- The case for abstract art / Clement Greenberg -- The curse of conformity / Walter Gropius -- The expanding mental universe / Bertrand Russell. 2nd series. The challenge of being free / Henry M. Wriston -- The connecting imagination / Stephen Spender -- What you should know about physics / Sir George Thomson -- The anguish of modern art / William Snaith -- The meaning of mathematics / Morris Kline -- Screwtape proposes a toast / C. S. Lewis -- Why Marx failed here / Clinton Rossiter -- The origin of the elements / Williams Alfred Fowler -- The awesome decision / David L. Bazelon -- The sense of truth / Alexander Eliot -- Life's mysterious clocks / Frank A. Brown, Jr. -- Men and capital / John Kenneth Galbraith -- Science and sex ethics / George W. Corner -- Listening to the universe / A. C. B. Lovell -- The final answer / Francois Mauriac -- The economic revolution / Barbara Ward -- Natural history of a star / Jesse L. Greenstein -- The U.S. presidency / Gerald W. Johnson -- How life began / Earl A. Evans, Jr. -- The rediscovery of meaning / Owen Barfield -- The tragic vision / Stanley Hyman -- The small world / J. D. Williams -- The two-way imagination / Nancy Hale",
+            "Your brain and your behavior / R. W. Gerard -- The two cities of law / Charles L. Black, Jr. -- Cause, chance and creation / Philip Morrison -- What is existentialism? / William Barrett -- Words that divide the world / Stefan T. Possony -- The making of a poem / C. Day Lewis -- In praise of waste / Garrett Hardin -- Can democracy survive? / C. Northcote Parkinson -- The false images of science / Gerald Holton -- Battle cry for book lovers / Robertson Davies -- The universe revalued / D. E. Harding -- The messages of life / James Bonner -- The act of language / John Ciardi -- New horizons in philosophy / Morton White -- The elusive neutron / Donald J. Hughes -- The dilemma of youth / John Wain -- The conflict of cultures / C. P. Snow."
+          ],
+          "subjectLiteral_exploded": [
+            "Civilization, Modern",
+            "Civilization, Modern -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "title": [
+            "Adventures of the mind"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1959"
+          ],
+          "creatorLiteral": [],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Thruelsen, Richard",
+            "Kobler, John"
+          ],
+          "idOclc": [
+            "ocm00388127",
+            "388127",
+            "SCSB-5724502"
+          ],
+          "uniformTitle": [
+            "Saturday evening post."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1959"
+          ],
+          "titleDisplay": [
+            "Adventures of the mind / [1st-   series] Edited by Richard Thruelsen and John Kobler. Introd. by Mark Van Doren."
+          ],
+          "uri": "cb10611860",
+          "parallelContributorLiteral": [
+            null,
+            null
+          ],
+          "recordTypeId": "a",
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm"
+          ]
+        },
+        "sort": [
+          3.1538382,
+          "cb10611860"
+        ],
+        "matched_queries": [
+          "bib multi_match"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": {
+                "value": 2,
+                "relation": "eq"
+              },
+              "max_score": null,
+              "hits": [
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb10611860",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "enumerationChronology": [
+                      "ser.2"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:901 Sa84",
+                      "urn:barcode:CU13298070"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "901 Sa84",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "CU13298070",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU13298070"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "901 Sa84"
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "901 Sa84"
+                    ],
+                    "shelfMark_sort": "a901 Sa000084",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci8402648"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_index": "resources-qa-2026-05-12",
+                  "_id": "cb10611860",
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "enumerationChronology": [
+                      "ser.1"
+                    ],
+                    "formatLiteral": [
+                      "Book/text"
+                    ],
+                    "identifier": [
+                      "urn:shelfmark:901 Sa84",
+                      "urn:barcode:CU13298062"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "901 Sa84",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "value": "CU13298062",
+                        "type": "bf:Barcode"
+                      }
+                    ],
+                    "idBarcode": [
+                      "CU13298062"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0002",
+                        "label": "Columbia University Libraries"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0002||Columbia University Libraries"
+                    ],
+                    "physicalLocation": [
+                      "901 Sa84"
+                    ],
+                    "recapCustomerCode": [
+                      "CU"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "shelfMark": [
+                      "901 Sa84"
+                    ],
+                    "shelfMark_sort": "a901 Sa000084",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "uri": "ci8402647"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-eeac30646e717d633f600c60a20a9031.json
+++ b/test/fixtures/query-eeac30646e717d633f600c60a20a9031.json
@@ -1,0 +1,18 @@
+{
+  "took": 358,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 0,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": []
+  }
+}

--- a/test/fixtures/scsb-by-barcode-1238efd9a8d0a841d3eadd442a893e20.json
+++ b/test/fixtures/scsb-by-barcode-1238efd9a8d0a841d3eadd442a893e20.json
@@ -1,0 +1,207 @@
+[
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Not Available",
+    "itemBarcode": "MR61509485"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433036075665"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "33433066644109"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "33433066644091"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433110534520"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433110534512"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433086370503"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "32044042656827"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433036090011"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433036090029"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433036090037"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433137385237"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433119383762"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433079269134"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "33433084518764"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433087266205"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "33433084518756"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433064016748"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "33433002566952"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433093051658"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433047707090"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433035625338"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433035626013"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433067981898"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433035629520"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433077370777"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433077362139"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433077362147"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433068925019"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433068004625"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433035869852"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433035439284"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433047566470"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "CU09123130"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "CU09123148"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "CU09123121"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "MRS0146692"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "MRS0179914"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "CU71452699"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "CU13298070"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "CU13298062"
+  }
+]

--- a/test/fixtures/scsb-by-barcode-68099189504c4191eba4302f5c16e875.json
+++ b/test/fixtures/scsb-by-barcode-68099189504c4191eba4302f5c16e875.json
@@ -1,0 +1,242 @@
+[
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433118568447"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "32101095377683"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "32101095377683"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "33333113836635"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Not Available",
+    "itemBarcode": "33433090460647"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33333225144951"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433122276318"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Not Available",
+    "itemBarcode": "32044077499465"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Not Available",
+    "itemBarcode": "32101072287822"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Not Available",
+    "itemBarcode": "32101072287822"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433089426146"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433041530118"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433040606604"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "CU27972887"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Not Available",
+    "itemBarcode": "MR61509485"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433036075665"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433074287149"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433129000943"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "32101069223301"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "32101069223301"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "33333120986738"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "32044089630495"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433089279883"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433087759761"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "33433066644109"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "33433066644091"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433114669116"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433135837288"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "CU24576484"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "AR02401576"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433076591738"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433073344230"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "33433083720965"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Not Available",
+    "itemBarcode": "HXSKRU"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "CU71435093"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "HNGRR7"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "HXL53Z"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "32044105914865"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "32044108950577"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "32101085641676"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "32101069496063"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "32101085641676"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433059013205"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433069269284"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433089303840"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433083328249"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "itemBarcode": "33433120132745"
+  },
+  {
+    "errorMessage": null,
+    "itemAvailabilityStatus": "Available",
+    "itemBarcode": "32101069496063"
+  }
+]


### PR DESCRIPTION
- update all filtering on texty var fields to use keyword lowercase stripped
- rely on existing filter and search config for cql mappings

Another next step might be to find a way to programatically include parallel fields in these config files. It could be something like maintaining a list of fields somewhere in config.js that have parallels , and then building a util that checks that array and includes them in search and filter fields if they exist. 

This PR is contingent on this PR going out (or at least the changes from the index schema being applied to a new index and included in this repo's config).