### PR TITLE
Scc 5399

### DIFF
--- a/lib/elasticsearch/cql_query_builder.js
+++ b/lib/elasticsearch/cql_query_builder.js
@@ -259,12 +259,18 @@ function mappedQueryForControlledVocabulary ({ fields, relation, terms, term, sc
   // If relation is any/all, termsToMap should be terms, otherwise it should be [term]
   const termsToMap = ['any', 'all'].includes(relation) ? terms : [term]
   const controlledVocabFields = vocabularies[scope]
+  console.dir(controlledVocabFields, { depth: null })
   const normalizer = str => str.toLowerCase().replace(/[^a-zA-Z0-9 ]/g, '')
-  const fieldMatcher = relation === '=='
-    ? (queryTerm) => field => field.value === queryTerm
+  let fieldMatcher = relation === '=='
+    ? (queryTerm) => field => field.value === queryTerm || field.label === queryTerm
     : (queryTerm) =>
         field => [field.value, field.label].some(property => normalizer(property).includes(normalizer(queryTerm)))
 
+  if (scope === 'language' && relation === '==') {
+    // for language, we want to allow for missing `lang:` prefix, even in case of ==
+    fieldMatcher = (queryTerm) => field =>
+      field.value === queryTerm || field.value === `lang:${queryTerm}` || field.label === queryTerm || field.label === `lang:${queryTerm}`
+  }
   const mappedQueries = termsToMap.map((queryTerm) => {
     const matchingValues = controlledVocabFields
       .filter(fieldMatcher(queryTerm))

--- a/lib/elasticsearch/cql_query_builder.js
+++ b/lib/elasticsearch/cql_query_builder.js
@@ -259,7 +259,6 @@ function mappedQueryForControlledVocabulary ({ fields, relation, terms, term, sc
   // If relation is any/all, termsToMap should be terms, otherwise it should be [term]
   const termsToMap = ['any', 'all'].includes(relation) ? terms : [term]
   const controlledVocabFields = vocabularies[scope]
-  console.dir(controlledVocabFields, { depth: null })
   const normalizer = str => str.toLowerCase().replace(/[^a-zA-Z0-9 ]/g, '')
   let fieldMatcher = relation === '=='
     ? (queryTerm) => field => field.value === queryTerm || field.label === queryTerm

--- a/test/cql_es_queries.js
+++ b/test/cql_es_queries.js
@@ -1567,6 +1567,41 @@ const divisionExact = {
   }
 }
 
+const englishExactLanguageQuery = {
+  bool: {
+    must: [
+      {
+        bool: {
+          should: [
+            {
+              bool: {
+                must: [
+                  {
+                    bool: {
+                      should: [
+                        {
+                          bool: {
+                            should: [
+                              { term: { 'language.id': 'lang:eng' } },
+                              {
+                                term: { 'language.label': 'lang:eng' }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
 const wildcardQueryNoShelfMark = {
   bool: {
     must: [
@@ -1585,12 +1620,12 @@ const wildcardQueryNoShelfMark = {
                         'titleAlt.folded',
                         'uniformTitle.folded',
                         'titleDisplay.folded',
-                        'seriesStatement.folded',
+                        'series.folded',
                         'contentsTitle.folded',
                         'donor.folded',
                         'parallelTitle.folded',
                         'parallelTitleDisplay.folded',
-                        'parallelSeriesStatement.folded',
+                        'parallelSeries.folded',
                         'parallelTitleAlt.folded',
                         'parallelCreatorLiteral.folded',
                         'parallelUniformTitle',
@@ -1635,7 +1670,7 @@ const wildcardQueryWithShelfMark = {
                         'contributorLiteral.folded',
                         'note.label.foldedStemmed',
                         'publisherLiteral.folded',
-                        'seriesStatement.folded',
+                        'series.folded',
                         'titleAlt.folded',
                         'titleDisplay.folded',
                         'contentsTitle.folded',
@@ -1645,7 +1680,7 @@ const wildcardQueryWithShelfMark = {
                         'parallelTitle.folded',
                         'parallelTitleDisplay.folded',
                         'parallelTitleAlt.folded',
-                        'parallelSeriesStatement.folded',
+                        'parallelSeries.folded',
                         'parallelCreatorLiteral.folded',
                         'parallelPublisher',
                         'parallelPublisherLiteral',
@@ -1715,6 +1750,7 @@ module.exports = {
   divisionAll,
   divisionAny,
   divisionExact,
+  englishExactLanguageQuery,
   wildcardQueryNoShelfMark,
   wildcardQueryWithShelfMark
 }

--- a/test/cql_query_builder.test.js
+++ b/test/cql_query_builder.test.js
@@ -32,6 +32,7 @@ const {
   divisionAll,
   divisionAny,
   divisionExact,
+  englishExactLanguageQuery,
   wildcardQueryNoShelfMark,
   wildcardQueryWithShelfMark
 } = require('./cql_es_queries')
@@ -321,6 +322,29 @@ describe('CQL Query Builder', function () {
       expect(result).to.deep.equal(
         divisionExact
       )
+    })
+
+    it('Maps controlled vocab fields correctly for == when label is used instead of value', () => {
+      const result = new CqlQuery('division == "Milstein Division"').buildEsQuery()
+      console.dir(result, { depth: null })
+      expect(result).to.deep.equal(
+        divisionExact
+      )
+    })
+
+    it('generates correct controlled vocab query for == with language scope based on label', () => {
+      const result = new CqlQuery('language == "English"').buildEsQuery()
+      expect(result).to.deep.equal(englishExactLanguageQuery)
+    })
+
+    it('generates correct controlled vocab query for == with language scope based on value', () => {
+      const result = new CqlQuery('language == "lang:eng"').buildEsQuery()
+      expect(result).to.deep.equal(englishExactLanguageQuery)
+    })
+
+    it('generates correct controlled vocab query for == with language scope based on value without lang: prefix', () => {
+      const result = new CqlQuery('language == "eng"').buildEsQuery()
+      expect(result).to.deep.equal(englishExactLanguageQuery)
     })
   })
 })


### PR DESCRIPTION
A small change: for language queries, even for exact matching we don't want to require the `lang:` prefix.

Also adds some more tests for `==`