### PR TITLE
Add try/catch around cql call

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -915,7 +915,7 @@ const buildElasticQuery = function (params, cqlQuery = null) {
   const request = ApiRequest.fromParams(params)
   if (params.search_scope === 'cql') {
     try {
-       const query = (cqlQuery || new CqlQuery(params.q)).buildEsQuery(request)
+      const query = (cqlQuery || new CqlQuery(params.q)).buildEsQuery(request)
       return query
     } catch (e) {
       throw new InvalidQuerySyntaxError(e.message)

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -914,8 +914,12 @@ const buildElasticBody = function (params, cqlQuery = null) {
 const buildElasticQuery = function (params, cqlQuery = null) {
   const request = ApiRequest.fromParams(params)
   if (params.search_scope === 'cql') {
-    const query = (cqlQuery || new CqlQuery(params.q)).buildEsQuery(request)
-    return query
+    try {
+       const query = (cqlQuery || new CqlQuery(params.q)).buildEsQuery(request)
+      return query
+    } catch (e) {
+      throw new InvalidQuerySyntaxError(e.message)
+    }
   }
 
   const builder = ElasticQueryBuilder.forApiRequest(request)


### PR DESCRIPTION
Addresses an error found in today's alarms: when a patron searches for an invalid CQL query, the RC searches both /resources and /resources/aggregations. We are correctly responding with a 422 for the first path, but the second path responds with a 500 error that is invisible to the patron but clutters our logs.
This PR adds a try/catch block around the parsing so that we can respond with a 422 in this case and not log an error.
Future work in RC may investigate whether it is possible to avoid this call altogether.