### PR TITLE
Update customer-code discrepancy check

### DIFF
--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -273,8 +273,16 @@ class AvailabilityResolver {
           logger.debug('Not updating item with most recent customer code because none returned')
           return
         }
+        // Some customer codes are indexed with namespace prefixes (e.g. hd:)
+        // for disambiguation. SCSB does not do the same, so when checking for
+        // a matching code, remove the namespace prefix:
+        let customerCodeSansPrefix = item.recapCustomerCode[0]
+        if (customerCodeSansPrefix.includes(':')) {
+          customerCodeSansPrefix = customerCodeSansPrefix.split(':')[1]
+        }
+
         if (!item.recapCustomerCode) item.recapCustomerCode = [mostRecentCustomerCode]
-        else if (mostRecentCustomerCode !== item.recapCustomerCode[0]) {
+        else if (mostRecentCustomerCode !== customerCodeSansPrefix) {
           logger.error('Mismatched customer code', { barcode })
           item.recapCustomerCode[0] = mostRecentCustomerCode
         }

--- a/test/availability_resolver.test.js
+++ b/test/availability_resolver.test.js
@@ -205,7 +205,8 @@ describe('Response with updated availability', function () {
       })
 
       it('updates recapCustomerCode when item\'s code does not match SCSB', () => {
-        return availabilityResolver.responseWithUpdatedAvailability()
+        availabilityResolver = new AvailabilityResolver(recapScsbQueryMismatch())
+        return availabilityResolver.responseWithUpdatedAvailability({ queryRecapCustomerCode: true })
           .then((response) => {
             const items = response.hits.hits[0]._source.items
             // A ReCAP item with customer code XX
@@ -217,9 +218,24 @@ describe('Response with updated availability', function () {
       })
 
       it('does nothing when current recapCustomerCode and SCSB code are a match', () => {
-        availabilityResolver = new AvailabilityResolver(recapScsbQueryMatch())
+        availabilityResolver = new AvailabilityResolver(recapScsbQueryMatch({ queryRecapCustomerCode: true }))
         const loggerSpy = sinon.spy(logger, 'error')
         return availabilityResolver.responseWithUpdatedAvailability()
+          .then(() => {
+            expect(loggerSpy.notCalled).to.equal(true)
+            logger.error.restore()
+          })
+      })
+
+      it('discounts namespace prefixes on customer codes when comparing codes to those in SCSB', () => {
+        // Amend fixture to emulate it having been indexed with a prefixed
+        // customer code:
+        const esResponse = JSON.parse(JSON.stringify(recapScsbQueryMatch()))
+        esResponse.hits.hits[0]._source.items[0].recapCustomerCode = ['someprefix:NC']
+
+        availabilityResolver = new AvailabilityResolver(esResponse)
+        const loggerSpy = sinon.spy(logger, 'error')
+        return availabilityResolver.responseWithUpdatedAvailability({ queryRecapCustomerCode: true })
           .then(() => {
             expect(loggerSpy.notCalled).to.equal(true)
             logger.error.restore()


### PR DESCRIPTION
Updates the customer-code discrepancy check, which alerts us to differences between a record's indexed ReCAP customer code and the one returned from SCSB. Now that we're sometimes indexing customer codes with a namespace prefix for disambiguation, given that the SCSB api continues to return not-namespaced values, we should discount the namespace prefix when making the comparison.

Also fixes a few tests discovered to be not testing what they purported to test.