### PR TITLE
Scc 5381

### DIFF
--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -281,6 +281,8 @@ class ResourceSerializer extends JsonLdItemSerializer {
     }
 
     // DFE depends on this being set to an empty array when null:
+    // Also, a small number of records have arrays of urls, which don't display
+    // properly, so we split them into multiple statements.
     stmts.electronicResources = (stmts.electronicResources || []).map(stmt => {
       if (typeof stmt.url === 'string') return [stmt]
       return stmt.url.map(url => Object.assign({}, stmt, { url }))

--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -281,7 +281,11 @@ class ResourceSerializer extends JsonLdItemSerializer {
     }
 
     // DFE depends on this being set to an empty array when null:
-    stmts.electronicResources = stmts.electronicResources || []
+    stmts.electronicResources = (stmts.electronicResources || []).map(stmt => {
+      if (typeof stmt.url === 'string') return [stmt]
+      return stmt.url.map(url => Object.assign({}, stmt, { url }))
+    }).flat()
+
     return stmts
   }
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -95,7 +95,6 @@ module.exports = function (app, _private = null) {
       }
       const hitsAndItemAggregations = resp.hits.hits[0]._source
       hitsAndItemAggregations.itemAggregations = resp.aggregations
-      // console.log('Going to serialize: ', JSON.stringify(hitsAndItemAggregations, null, 2))
       return ResourceSerializer.serialize(hitsAndItemAggregations, Object.assign(opts, { root: true }))
     }
   }

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -95,6 +95,7 @@ module.exports = function (app, _private = null) {
       }
       const hitsAndItemAggregations = resp.hits.hits[0]._source
       hitsAndItemAggregations.itemAggregations = resp.aggregations
+      // console.log('Going to serialize: ', JSON.stringify(hitsAndItemAggregations, null, 2))
       return ResourceSerializer.serialize(hitsAndItemAggregations, Object.assign(opts, { root: true }))
     }
   }

--- a/test/resource_serializer.test.js
+++ b/test/resource_serializer.test.js
@@ -82,4 +82,36 @@ describe('Resource Serializer', () => {
       ])
     })
   })
+  describe('electronicResources', () => {
+    it('splits electronicResources with an array of URLs into separate objects', async () => {
+      const esDoc = {
+        uri: 'b123',
+        electronicResources: [
+          {
+            prefLabel: 'Single URL',
+            url: 'http://example.com/1'
+          },
+          {
+            prefLabel: 'Multiple URLs',
+            url: ['http://example.com/2', 'http://example.com/3']
+          }
+        ]
+      }
+      const serialized = await ResourceSerializer.serialize(esDoc)
+      expect(serialized.electronicResources).to.deep.equal([
+        {
+          prefLabel: 'Single URL',
+          url: 'http://example.com/1'
+        },
+        {
+          prefLabel: 'Multiple URLs',
+          url: 'http://example.com/2'
+        },
+        {
+          prefLabel: 'Multiple URLs',
+          url: 'http://example.com/3'
+        }
+      ])
+    })
+  })
 })


### PR DESCRIPTION
- We have some records where `electronicResources` includes statements with multiple urls in the url field, which are not displaying properly. This PR splits those statement into separate statements, one per url, and adds a test for that situation